### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - uses: DeterminateSystems/determinate-nix-action@main

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - uses: DeterminateSystems/determinate-nix-action@main

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -12,7 +12,7 @@ jobs:
   nix-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - run: nix flake check

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: "actions/checkout@v5"
+      - uses: "actions/checkout@v6"
         with:
           persist-credentials: false
       - uses: DeterminateSystems/determinate-nix-action@main

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: DeterminateSystems/determinate-nix-action@main


### PR DESCRIPTION
Updated actions/checkout from v4/v5 to v6 (latest: v6.0.0, Nov 20, 2024) across all workflow files:
- claude-code-review.yml
- claude.yml
- emacs.yml
- flakehub-publish-rolling.yml
- weekly-maintenance.yml

Other actions are already using optimal versions:
- DeterminateSystems actions use @main (appropriate for dev workflows)
- anthropics/claude-code-action@v1 tracks latest v1.x.x (v1.0.21)