### PR TITLE
Install and configure Gited package

### DIFF
--- a/elisp/git.el
+++ b/elisp/git.el
@@ -21,6 +21,13 @@
   :config
   (magit-todos-mode 1))
 
+(use-package gited
+  :ensure
+  :after magit
+  :bind (:map dired-mode-map
+              ("C-x C-g" . gited-list-branches))
+  :custom
+  (gited-expert t "Skip confirmation for operations"))
 
 (use-package diff-hl
   :ensure


### PR DESCRIPTION
Install and configure the Gited package, which provides a dired-like interface for managing Git branches, remote branches, and tags.

Changes:
- Add use-package declaration for gited in elisp/git.el
- Bind gited-list-branches to C-x C-g in dired-mode
- Enable expert mode to skip confirmations for operations
- Load after magit for consistency with other git tools

Gited will be automatically detected by the dependency extraction system and added to the emacsPackages list during build.