### PR TITLE
⚡ Optimize Flymake diagnostic display to reduce timer churn

### DIFF
--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -64,10 +64,17 @@
 
   ;; Show diagnostics using an idle timer (efficient)
   (defvar j10s/flymake-idle-timer nil "Timer for showing flymake diagnostics.")
-  (when (timerp j10s/flymake-idle-timer)
-    (cancel-timer j10s/flymake-idle-timer))
-  (setq j10s/flymake-idle-timer
-        (run-with-idle-timer 0.5 t #'j10s/flymake-show-diagnostic-at-point))
+
+  (defun j10s/flymake-ensure-idle-timer ()
+    "Start the Flymake idle diagnostic timer if not already running."
+    (unless (timerp j10s/flymake-idle-timer)
+      (setq j10s/flymake-idle-timer
+            (run-with-idle-timer 0.5 t
+                                 (lambda ()
+                                   (when (bound-and-true-p flymake-mode)
+                                     (j10s/flymake-show-diagnostic-at-point)))))))
+
+  (add-hook 'flymake-mode-hook #'j10s/flymake-ensure-idle-timer)
 
   ;; Configure elisp-flymake-byte-compile to trust local configuration files
   (with-eval-after-load 'elisp-mode

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -68,14 +68,18 @@
   (defun j10s/flymake-manage-idle-timer ()
     "Start or stop the Flymake idle timer based on active buffers."
     (if flymake-mode
+        ;; Flymake is being enabled: start the timer if not already running.
         (unless (timerp j10s/flymake-idle-timer)
           (setq j10s/flymake-idle-timer
-                (run-with-idle-timer 0.5 t #'j10s/flymake-show-diagnostic-at-point)))
+                (run-with-idle-timer 0.5 t
+                                     (lambda ()
+                                       (with-current-buffer (window-buffer (selected-window))
+                                         (j10s/flymake-show-diagnostic-at-point))))))
+      ;; Flymake is being disabled: stop the timer only if no other buffer
+      ;; has flymake-mode enabled.
       (when (timerp j10s/flymake-idle-timer)
-        (unless (catch 'found
-                  (dolist (buf (buffer-list))
-                    (with-current-buffer buf
-                      (when flymake-mode (throw 'found t)))))
+        (unless (seq-some (lambda (buf) (with-current-buffer buf flymake-mode))
+                          (buffer-list))
           (cancel-timer j10s/flymake-idle-timer)
           (setq j10s/flymake-idle-timer nil)))))
 

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -67,11 +67,20 @@
 
   (defun j10s/flymake-ensure-idle-timer ()
     "Start the Flymake idle diagnostic timer if not already running."
-    (unless (timerp j10s/flymake-idle-timer)
-      (setq j10s/flymake-idle-timer
-            (run-with-idle-timer 0.5 t #'j10s/flymake-show-diagnostic-at-point))))
+    (when flymake-mode
+      (unless (timerp j10s/flymake-idle-timer)
+        (setq j10s/flymake-idle-timer
+              (run-with-idle-timer 0.5 t #'j10s/flymake-show-diagnostic-at-point)))))
 
   (add-hook 'flymake-mode-hook #'j10s/flymake-ensure-idle-timer)
+
+  (defun j10s/flymake-cleanup-timer ()
+    "Cancel the Flymake idle timer."
+    (when (timerp j10s/flymake-idle-timer)
+      (cancel-timer j10s/flymake-idle-timer)
+      (setq j10s/flymake-idle-timer nil)))
+
+  (add-hook 'kill-emacs-hook #'j10s/flymake-cleanup-timer)
 
   ;; Configure elisp-flymake-byte-compile to trust local configuration files
   (with-eval-after-load 'elisp-mode

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -69,10 +69,7 @@
     "Start the Flymake idle diagnostic timer if not already running."
     (unless (timerp j10s/flymake-idle-timer)
       (setq j10s/flymake-idle-timer
-            (run-with-idle-timer 0.5 t
-                                 (lambda ()
-                                   (when (bound-and-true-p flymake-mode)
-                                     (j10s/flymake-show-diagnostic-at-point)))))))
+            (run-with-idle-timer 0.5 t #'j10s/flymake-show-diagnostic-at-point))))
 
   (add-hook 'flymake-mode-hook #'j10s/flymake-ensure-idle-timer)
 

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -62,21 +62,12 @@
                                          (_ 'default)))
                      (flymake-diagnostic-text diagnostic)))))))
 
-  ;; Show diagnostic after a short delay
-  (defvar-local j10s/flymake-diagnostic-timer nil)
-  (defun j10s/flymake-show-diagnostic-delayed ()
-    "Show diagnostic after a delay."
-    (when flymake-mode
-      (when j10s/flymake-diagnostic-timer
-        (cancel-timer j10s/flymake-diagnostic-timer))
-      (setq j10s/flymake-diagnostic-timer
-            (run-with-timer 0.5 nil #'j10s/flymake-show-diagnostic-at-point))))
-
-  (add-hook 'flymake-mode-hook
-            (lambda ()
-              (if flymake-mode
-                  (add-hook 'post-command-hook #'j10s/flymake-show-diagnostic-delayed nil t)
-                (remove-hook 'post-command-hook #'j10s/flymake-show-diagnostic-delayed t))))
+  ;; Show diagnostics using an idle timer (efficient)
+  (defvar j10s/flymake-idle-timer nil "Timer for showing flymake diagnostics.")
+  (when (timerp j10s/flymake-idle-timer)
+    (cancel-timer j10s/flymake-idle-timer))
+  (setq j10s/flymake-idle-timer
+        (run-with-idle-timer 0.5 t #'j10s/flymake-show-diagnostic-at-point))
 
   ;; Configure elisp-flymake-byte-compile to trust local configuration files
   (with-eval-after-load 'elisp-mode

--- a/tests/test-programming.el
+++ b/tests/test-programming.el
@@ -56,6 +56,7 @@
   (should (fboundp 'j10s/flymake-show-diagnostic-at-point))
   (should (boundp 'j10s/flymake-idle-timer))
   (should (fboundp 'j10s/flymake-ensure-idle-timer))
+  (should (fboundp 'j10s/flymake-cleanup-timer))
   (should (fboundp 'j10s/trust-local-elisp-files)))
 
 (ert-deftest test-programming/flymake-elisp-trust-config ()

--- a/tests/test-programming.el
+++ b/tests/test-programming.el
@@ -55,7 +55,7 @@
   (require 'flymake)
   (should (fboundp 'j10s/flymake-show-diagnostic-at-point))
   (should (boundp 'j10s/flymake-idle-timer))
-  (should (fboundp 'j10s/flymake-ensure-idle-timer))
+  (should (fboundp 'j10s/flymake-manage-idle-timer))
   (should (fboundp 'j10s/flymake-cleanup-timer))
   (should (fboundp 'j10s/trust-local-elisp-files)))
 

--- a/tests/test-programming.el
+++ b/tests/test-programming.el
@@ -54,7 +54,7 @@
   :tags '(unit)
   (require 'flymake)
   (should (fboundp 'j10s/flymake-show-diagnostic-at-point))
-  (should (fboundp 'j10s/flymake-show-diagnostic-delayed))
+  (should (boundp 'j10s/flymake-idle-timer))
   (should (fboundp 'j10s/trust-local-elisp-files)))
 
 (ert-deftest test-programming/flymake-elisp-trust-config ()

--- a/tests/test-programming.el
+++ b/tests/test-programming.el
@@ -55,6 +55,7 @@
   (require 'flymake)
   (should (fboundp 'j10s/flymake-show-diagnostic-at-point))
   (should (boundp 'j10s/flymake-idle-timer))
+  (should (fboundp 'j10s/flymake-ensure-idle-timer))
   (should (fboundp 'j10s/trust-local-elisp-files)))
 
 (ert-deftest test-programming/flymake-elisp-trust-config ()


### PR DESCRIPTION
💡 **What:**
Replaced the `post-command-hook` implementation for showing Flymake diagnostics with a `run-with-idle-timer`.

🎯 **Why:**
The previous implementation attached a function to `post-command-hook` that cancelled the previous timer and created a new one on *every* command (keystroke, cursor move). This caused excessive object allocation and timer churn.

📊 **Measured Improvement:**
While the execution environment precluded running the benchmark directly, the optimization reduces the overhead of `post-command-hook` for this feature to zero.

Benchmark code used for verification logic:
```emacs-lisp
;; Benchmark for Flymake Timer Churn
(require 'ert)
(require 'timer)

;; Mock flymake machinery
(defvar flymake-mode nil)
(defvar flymake-mode-hook nil)
(defvar flymake-diagnostics nil)
(defun flymake-diagnostics (point) nil)
(defun flymake-diagnostic-type (diag) :error)
(defun flymake-diagnostic-text (diag) "Error")

;; Original Implementation
(defun j10s/flymake-show-diagnostic-at-point ()
  "Display flymake diagnostic at point in echo area."
  (when flymake-mode
    ;; Simulate some work
    (ignore)))

(defvar-local j10s/flymake-diagnostic-timer nil)
(defun j10s/flymake-show-diagnostic-delayed ()
  "Show diagnostic after a delay."
  (when flymake-mode
    (when j10s/flymake-diagnostic-timer
      (cancel-timer j10s/flymake-diagnostic-timer))
    (setq j10s/flymake-diagnostic-timer
          (run-with-timer 0.5 nil #'j10s/flymake-show-diagnostic-at-point))))

;; Setup Buffer
(setq flymake-mode t)
(add-hook 'post-command-hook #'j10s/flymake-show-diagnostic-delayed nil t)

(message "Running baseline benchmark...")
(let ((start-time (float-time)))
  (dotimes (_ 100000)
    (run-hooks 'post-command-hook))
  (message "Baseline (100000 iterations): %.4f seconds" (- (float-time) start-time)))

;; Optimized Implementation Setup (Simulated)
;; In optimized version, post-command-hook is empty regarding this feature.
(remove-hook 'post-command-hook #'j10s/flymake-show-diagnostic-delayed t)

;; Define the idle timer (just to show we can)
(defvar j10s/flymake-idle-timer nil)
(setq j10s/flymake-idle-timer (run-with-idle-timer 0.5 t #'j10s/flymake-show-diagnostic-at-point))

(message "Running optimized benchmark...")
(let ((start-time (float-time)))
  (dotimes (_ 100000)
    (run-hooks 'post-command-hook))
  (message "Optimized (100000 iterations): %.4f seconds" (- (float-time) start-time)))

;; Clean up
(when j10s/flymake-idle-timer (cancel-timer j10s/flymake-idle-timer))
```

---
*PR created automatically by Jules for task [10411389576318947472](https://jules.google.com/task/10411389576318947472) started by @Jylhis*