### PR TITLE
Add csv-mode configuration

### DIFF
--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -311,6 +311,12 @@
 (use-package yaml-mode
   :defer t
   )
+(use-package csv-mode
+  :ensure t
+  :mode "\\.csv\\'"
+  :hook (csv-mode . csv-align-mode)
+  :custom
+  (csv-separators '("," ";" "|" " " "\t")))
 (use-package modern-cpp-font-lock
   :ensure t
   :hook (c++-mode . modern-c++-font-lock-mode))

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -316,7 +316,7 @@
   :mode "\\.csv\\'"
   :hook (csv-mode . csv-align-mode)
   :custom
-  (csv-separators '("," ";" "|" " " "\t")))
+  (csv-separators '("," ";" "|" "\t")))
 (use-package modern-cpp-font-lock
   :ensure t
   :hook (c++-mode . modern-c++-font-lock-mode))

--- a/tests/test-programming.el
+++ b/tests/test-programming.el
@@ -198,6 +198,15 @@
   (when (locate-library "just-mode")
     (should (locate-library "just-mode"))))
 
+(ert-deftest test-programming/csv-mode-registered ()
+  "Test that csv-mode is registered for .csv files."
+  :tags '(unit)
+  (should (assoc "\\.csv\\'" auto-mode-alist))
+  (when (locate-library "csv-mode")
+    (require 'csv-mode)
+    (should (boundp 'csv-separators))
+    (should (member "," csv-separators))))
+
 ;;; C/C++ Configuration
 
 (ert-deftest test-programming/cc-mode-configured ()


### PR DESCRIPTION
Added `csv-mode` configuration to `elisp/programming.el` with proper hooks and custom settings. Added unit tests to `tests/test-programming.el` to verify the configuration.

---
*PR created automatically by Jules for task [4748064121245356886](https://jules.google.com/task/4748064121245356886) started by @Jylhis*