### PR TITLE
Add Enlight dashboard configuration

### DIFF
--- a/elisp/dashboard.el
+++ b/elisp/dashboard.el
@@ -5,6 +5,8 @@
 
 ;;; Code:
 
+(require 'xdg)
+
 (use-package enlight
   :ensure t
   :custom
@@ -14,10 +16,10 @@
     (propertize "MENU" 'face 'highlight)
     "\n"
     (enlight-menu
-     '(("Org Mode"
+     `(("Org Mode"
         ("Org-Agenda (current day)" (org-agenda nil "a") "a"))
        ("Downloads"
-        ("Downloads folder" (dired "~/Downloads") "a"))
+        ("Downloads folder" (dired ,(or (xdg-user-dir "DOWNLOAD") "~/Downloads")) "d"))
        ("Other"
         ("Projects" project-switch-project "p")))))))
 

--- a/elisp/dashboard.el
+++ b/elisp/dashboard.el
@@ -5,21 +5,29 @@
 
 ;;; Code:
 
+(defun my-dashboard/open-downloads ()
+  "Open the user's downloads directory in dired."
+  (interactive)
+  (let ((downloads-dir
+         (if (and (eq system-type 'gnu/linux) (require 'xdg nil t))
+             (or (xdg-user-dir "DOWNLOAD") "~/Downloads")
+           "~/Downloads")))
+    (dired downloads-dir)))
+
 (use-package enlight
   :ensure t
   :custom
   (initial-buffer-choice #'enlight)
   :config
-  (require 'xdg)
   (setq enlight-content
         (concat
          (propertize "MENU" 'face 'highlight)
          "\n"
          (enlight-menu
-          `(("Org Mode"
+          '(("Org Mode"
              ("Org-Agenda (current day)" (org-agenda nil "a") "a"))
             ("Downloads"
-             ("Downloads folder" (dired ,(or (xdg-user-dir "DOWNLOAD") "~/Downloads")) "d"))
+             ("Downloads folder" my-dashboard/open-downloads "d"))
             ("Other"
              ("Projects" project-switch-project "p")))))))
 

--- a/elisp/dashboard.el
+++ b/elisp/dashboard.el
@@ -5,23 +5,23 @@
 
 ;;; Code:
 
-(require 'xdg)
-
 (use-package enlight
   :ensure t
   :custom
   (initial-buffer-choice #'enlight)
-  (enlight-content
-   (concat
-    (propertize "MENU" 'face 'highlight)
-    "\n"
-    (enlight-menu
-     `(("Org Mode"
-        ("Org-Agenda (current day)" (org-agenda nil "a") "a"))
-       ("Downloads"
-        ("Downloads folder" (dired ,(or (xdg-user-dir "DOWNLOAD") "~/Downloads")) "d"))
-       ("Other"
-        ("Projects" project-switch-project "p")))))))
+  :config
+  (require 'xdg)
+  (setq enlight-content
+        (concat
+         (propertize "MENU" 'face 'highlight)
+         "\n"
+         (enlight-menu
+          `(("Org Mode"
+             ("Org-Agenda (current day)" (org-agenda nil "a") "a"))
+            ("Downloads"
+             ("Downloads folder" (dired ,(or (xdg-user-dir "DOWNLOAD") "~/Downloads")) "d"))
+            ("Other"
+             ("Projects" project-switch-project "p")))))))
 
 (provide 'dashboard)
 ;;; dashboard.el ends here

--- a/elisp/dashboard.el
+++ b/elisp/dashboard.el
@@ -1,0 +1,25 @@
+;;; dashboard.el --- Startup dashboard configuration -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Startup screen configuration using Enlight.
+
+;;; Code:
+
+(use-package enlight
+  :ensure t
+  :custom
+  (initial-buffer-choice #'enlight)
+  (enlight-content
+   (concat
+    (propertize "MENU" 'face 'highlight)
+    "\n"
+    (enlight-menu
+     '(("Org Mode"
+        ("Org-Agenda (current day)" (org-agenda nil "a") "a"))
+       ("Downloads"
+        ("Downloads folder" (dired "~/Downloads") "a"))
+       ("Other"
+        ("Projects" project-switch-project "p")))))))
+
+(provide 'dashboard)
+;;; dashboard.el ends here

--- a/init.el
+++ b/init.el
@@ -40,6 +40,7 @@
 (require 'help)        ; Enhanced help system
 (require 'ai)          ; AI integrations
 (require 'systems)     ; System administration tools
+(require 'dashboard)   ; Startup dashboard
 
 ;; Load platform-specific configurations
 (require 'platforms)   ; General platform adaptations

--- a/init.el
+++ b/init.el
@@ -32,6 +32,7 @@
 (require 'core)        ; Core Emacs settings and built-ins
 (require 'fonts)       ; Font configuration and management
 (require 'ui)          ; UI and appearance
+(require 'dashboard)   ; Startup dashboard
 (require 'completion)  ; Modern completion framework
 (require 'programming) ; Programming and development tools
 (require 'per-project) ; Thing to help with project specific setups
@@ -40,7 +41,6 @@
 (require 'help)        ; Enhanced help system
 (require 'ai)          ; AI integrations
 (require 'systems)     ; System administration tools
-(require 'dashboard)   ; Startup dashboard
 
 ;; Load platform-specific configurations
 (require 'platforms)   ; General platform adaptations


### PR DESCRIPTION
Added a new module elisp/dashboard.el to configure the Enlight startup screen.
Updated init.el to load the new module.
The dashboard includes a simple menu with Org Agenda, Downloads, and Projects.

---
*PR created automatically by Jules for task [18157014834037200648](https://jules.google.com/task/18157014834037200648) started by @Jylhis*