### PR TITLE
⚡ Optimize org agenda files update

### DIFF
--- a/elisp/utils.el
+++ b/elisp/utils.el
@@ -5,6 +5,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'ansi-color)
 
 ;;;###autoload
@@ -46,11 +47,11 @@ Otherwise, use `my/org-agenda-directories'."
   (let* ((directories (or directories my/org-agenda-directories))
          (org-files '()))
     ;; Collect org files from all directories that exist
-    (dolist (dir directories)
-      (let ((expanded-dir (expand-file-name dir)))
-        (when (file-exists-p expanded-dir)
-          (setq org-files (append org-files
-                                  (my/find-org-files-recursively expanded-dir))))))
+    (setq org-files (cl-mapcan (lambda (dir)
+                                 (let ((expanded-dir (expand-file-name dir)))
+                                   (when (file-exists-p expanded-dir)
+                                     (my/find-org-files-recursively expanded-dir))))
+                               directories))
     ;; Remove duplicates (in case of symlinks or overlapping paths)
     (setq org-files (delete-dups org-files))
     (when org-files

--- a/elisp/utils.el
+++ b/elisp/utils.el
@@ -6,6 +6,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'seq)
 (require 'ansi-color)
 
 ;;;###autoload
@@ -45,15 +46,14 @@ Each directory will be searched recursively for .org files."
 If DIRECTORIES is provided, search those directories.
 Otherwise, use `my/org-agenda-directories'."
   (let* ((directories (or directories my/org-agenda-directories))
-         (org-files (delete-dups
-                     (cl-mapcan (lambda (dir)
-                                  (my/find-org-files-recursively (expand-file-name dir)))
-                                directories))))
+         (expanded-dirs (mapcar #'expand-file-name directories))
+         (valid-dirs (seq-filter #'file-directory-p expanded-dirs))
+         (org-files (delete-dups (cl-mapcan #'my/find-org-files-recursively valid-dirs))))
     (when org-files
       (setq org-agenda-files org-files))
     (message "Updated org-agenda-files: %d files found across %d directories"
              (length org-files)
-             (length (seq-filter (lambda (d) (file-exists-p (expand-file-name d))) directories)))))
+             (length valid-dirs))))
 
 (defun my/setup-org-agenda-files ()
   "Set up dynamic org agenda files updating."

--- a/elisp/utils.el
+++ b/elisp/utils.el
@@ -45,15 +45,10 @@ Each directory will be searched recursively for .org files."
 If DIRECTORIES is provided, search those directories.
 Otherwise, use `my/org-agenda-directories'."
   (let* ((directories (or directories my/org-agenda-directories))
-         (org-files '()))
-    ;; Collect org files from all directories that exist
-    (setq org-files (cl-mapcan (lambda (dir)
-                                 (let ((expanded-dir (expand-file-name dir)))
-                                   (when (file-exists-p expanded-dir)
-                                     (my/find-org-files-recursively expanded-dir))))
-                               directories))
-    ;; Remove duplicates (in case of symlinks or overlapping paths)
-    (setq org-files (delete-dups org-files))
+         (org-files (delete-dups
+                     (cl-mapcan (lambda (dir)
+                                  (my/find-org-files-recursively (expand-file-name dir)))
+                                directories))))
     (when org-files
       (setq org-agenda-files org-files))
     (message "Updated org-agenda-files: %d files found across %d directories"


### PR DESCRIPTION
*   💡 **What:** Replaced $O(N^2)$ `dolist` + `append` loop with $O(N)$ `cl-mapcan` in `my/update-org-agenda-files`. Added `(require 'cl-lib)`.
*   🎯 **Why:** The previous implementation reconstructed the list of files repeatedly, leading to quadratic complexity as the number of directories/files grew.
*   📊 **Measured Improvement:** Theoretical complexity improved from $O(N^2)$ to $O(N)$. Local benchmarking was not possible due to environment limitations, but `cl-mapcan` is the standard performant replacement for `append` loops in Emacs Lisp.

---
*PR created automatically by Jules for task [11943908436667214366](https://jules.google.com/task/11943908436667214366) started by @Jylhis*