### PR TITLE
⚡ Optimize font enumeration in platform-show-info

### DIFF
--- a/elisp/platforms.el
+++ b/elisp/platforms.el
@@ -177,7 +177,9 @@
             (princ (format "Current font: %s\n" font))
           (princ "Font: (default)\n")))
       (when (display-graphic-p)
-        (princ (format "Available fonts: %d\n" (length (font-family-list)))))
+        (if (bound-and-true-p j10s-fonts--available-cache)
+            (princ (format "Available fonts: %d\n" (length j10s-fonts--available-cache)))
+          (princ "Available fonts: (uncached)\n")))
       (princ "\n=== Environment ===\n")
       (when platform-android-p
         (princ (format "EXTERNAL_STORAGE: %s\n" (or (getenv "EXTERNAL_STORAGE") "not set")))


### PR DESCRIPTION
Optimizes `platform-show-info` by removing the blocking synchronous call to `(font-family-list)`. Instead, it uses a cached value from `j10s-fonts--available-cache` if available, or skips the calculation to prevent UI freezes.

---
*PR created automatically by Jules for task [15688554454106532100](https://jules.google.com/task/15688554454106532100) started by @Jylhis*