### PR TITLE
fix: suppress invalid nil foreground warning for font-lock-doc-markup-face

### DIFF
--- a/elisp/ui.el
+++ b/elisp/ui.el
@@ -15,7 +15,7 @@ Replaces :foreground nil with :foreground 'unspecified."
   (if (eq face 'font-lock-doc-markup-face)
       (let ((new-args (copy-sequence args)))
         (let ((tail new-args))
-          (while tail
+          (while (and tail (cdr tail))
             (when (and (eq (car tail) :foreground)
                        (null (cadr tail)))
               (setcar (cdr tail) 'unspecified))

--- a/elisp/ui.el
+++ b/elisp/ui.el
@@ -9,6 +9,22 @@
   "Customization group for UI."
   :group 'emacs)
 
+(defun j10s/fix-font-lock-doc-markup-face (fn face frame &rest args)
+  "Workaround for invalid nil foreground in `font-lock-doc-markup-face'.
+Replaces :foreground nil with :foreground 'unspecified."
+  (if (eq face 'font-lock-doc-markup-face)
+      (let ((new-args (copy-sequence args)))
+        (let ((tail new-args))
+          (while tail
+            (when (and (eq (car tail) :foreground)
+                       (null (cadr tail)))
+              (setcar (cdr tail) 'unspecified))
+            (setq tail (cddr tail))))
+        (apply fn face frame new-args))
+    (apply fn face frame args)))
+
+(advice-add 'set-face-attribute :around #'j10s/fix-font-lock-doc-markup-face)
+
 (defcustom j10s-theme-light 'modus-operandi-tinted
   "Theme to use when system is in light mode or detection fails."
   :type 'symbol


### PR DESCRIPTION
Suppress invalid face attribute warning for font-lock-doc-markup-face

This commit adds an advice to `set-face-attribute` in `elisp/ui.el` to intercept and correct invalid face attribute settings for `font-lock-doc-markup-face`. specifically, it replaces `:foreground nil` with `:foreground 'unspecified` to prevent the "nil value is invalid" warning that occurs during startup or theme loading.

This workaround addresses an issue likely caused by an upstream package or theme configuration without requiring direct modification of external dependencies.

---
*PR created automatically by Jules for task [18439893474733284469](https://jules.google.com/task/18439893474733284469) started by @Jylhis*