### PR TITLE
Fix modus-themes loading failure by updating config for v4 compatibility

### DIFF
--- a/elisp/ui.el
+++ b/elisp/ui.el
@@ -35,7 +35,7 @@
 (defun j10s/toggle-theme ()
   "Toggle between light and dark themes."
   (interactive)
-(if (memq j10s-theme-light custom-enabled-themes)
+  (if (eq (car custom-enabled-themes) j10s-theme-light)
       (progn
         (disable-theme j10s-theme-light)
         (load-theme j10s-theme-dark t))

--- a/elisp/ui.el
+++ b/elisp/ui.el
@@ -35,7 +35,7 @@
 (defun j10s/toggle-theme ()
   "Toggle between light and dark themes."
   (interactive)
-  (if (eq (car custom-enabled-themes) j10s-theme-light)
+(if (memq j10s-theme-light custom-enabled-themes)
       (progn
         (disable-theme j10s-theme-light)
         (load-theme j10s-theme-dark t))

--- a/elisp/ui.el
+++ b/elisp/ui.el
@@ -32,17 +32,20 @@
   (tool-bar-mode -1)
   (scroll-bar-mode -1))
 
+(defun j10s/toggle-theme ()
+  "Toggle between light and dark themes."
+  (interactive)
+  (if (eq (car custom-enabled-themes) j10s-theme-light)
+      (progn
+        (disable-theme j10s-theme-light)
+        (load-theme j10s-theme-dark t))
+    (progn
+      (disable-theme j10s-theme-dark)
+      (load-theme j10s-theme-light t))))
+
 (use-package modus-themes
   :ensure t
-  :custom
-  (modus-themes-italic-constructs t)
-  (modus-themes-bold-constructs nil)
-  (modus-themes-mixed-fonts t)
-  (modus-themes-variable-pitch-ui nil)
-  :bind ("C-c t" . modus-themes-toggle)
-  :config
-  (setq modus-themes-to-toggle `(,j10s-theme-light ,j10s-theme-dark))
-  )
+  :bind ("C-c t" . j10s/toggle-theme))
 
 (use-package auto-dark
   :ensure t


### PR DESCRIPTION
This PR updates the `modus-themes` configuration in `elisp/ui.el` to be compatible with version 4.0+.

Breaking changes in `modus-themes` v4 caused errors during load and when using the toggle command. The deprecated variables and functions have been removed, and a replacement toggle function `j10s/toggle-theme` has been implemented to restore the theme toggling functionality using `load-theme` and `disable-theme`.

The `C-c t` keybinding is preserved but now calls the new `j10s/toggle-theme` command.

---
*PR created automatically by Jules for task [10058570728955618433](https://jules.google.com/task/10058570728955618433) started by @Jylhis*