### PR TITLE
fix(nix): disable stylix emacs target if stylix is imported

### DIFF
--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, options, ... }:
 
 let
   cfg = config.programs.jotain;
@@ -108,6 +108,11 @@ in
     # fonts.fontconfig is Linux-only in home-manager; nix-darwin doesn't have it
     (lib.mkIf (cfg.includeRuntimeDeps && pkgs.stdenv.isLinux) {
       fonts.fontconfig.enable = true;
+    })
+
+    # Disable stylix's emacs target if stylix module is imported
+    (lib.optionalAttrs (options ? stylix) {
+      stylix.targets.emacs.enable = false;
     })
   ]);
 }


### PR DESCRIPTION
This change updates the home manager module to conditionally disable Stylix's Emacs target (`stylix.targets.emacs.enable`) if the `stylix` option is present in the configuration. This prevents conflicts and allows Stylix to be used without forcing its Emacs configuration.

The implementation uses `lib.optionalAttrs (options ? stylix)` to safely check for the option existence before setting it, ensuring evaluation safety even when Stylix is not imported.

Verified by successfully evaluating the module with `nix build .#checks.x86_64-linux.test-module-enabled`.

---
*PR created automatically by Jules for task [13021795524368917874](https://jules.google.com/task/13021795524368917874) started by @Jylhis*