### PR TITLE
feat: add jinja2-mode support for .j2 and .jinja2 files

### DIFF
--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -311,6 +311,11 @@
 (use-package yaml-mode
   :defer t
   )
+
+(use-package jinja2-mode
+  :ensure t
+  :mode (("\\.j2\\'" . jinja2-mode)
+         ("\\.jinja2?\\'" . jinja2-mode)))
 (use-package csv-mode
   :ensure t
   :mode "\\.csv\\'"

--- a/tests/test-programming.el
+++ b/tests/test-programming.el
@@ -348,5 +348,17 @@
   (should (member 'editorconfig-mode
                   (bound-and-true-p prog-mode-hook))))
 
+
+;;; Jinja2 Configuration
+
+(ert-deftest test-programming/jinja2-mode-registered ()
+  "Test that jinja2-mode is registered for .j2 and .jinja2 files."
+  :tags '(unit)
+  (should (assoc "\\.j2\\'" auto-mode-alist))
+  (should (assoc "\\.jinja2?\\'" auto-mode-alist))
+  (when (locate-library "jinja2-mode")
+     (require 'jinja2-mode)
+     (should (fboundp 'jinja2-mode))))
+
 (provide 'test-programming)
 ;;; test-programming.el ends here

--- a/tests/test-programming.el
+++ b/tests/test-programming.el
@@ -357,8 +357,8 @@
   (should (assoc "\\.j2\\'" auto-mode-alist))
   (should (assoc "\\.jinja2?\\'" auto-mode-alist))
   (when (locate-library "jinja2-mode")
-     (require 'jinja2-mode)
-     (should (fboundp 'jinja2-mode))))
+    (require 'jinja2-mode)
+    (should (fboundp 'jinja2-mode))))
 
 (provide 'test-programming)
 ;;; test-programming.el ends here


### PR DESCRIPTION
This PR adds `jinja2-mode` configuration to `elisp/programming.el`.

It ensures that files with extensions `.j2`, `.jinja2`, and compound extensions like `.md.j2` are correctly opened in `jinja2-mode`.

A regression test has been added to `tests/test-programming.el` to verify the `auto-mode-alist` registration.

---
*PR created automatically by Jules for task [12357160796092152778](https://jules.google.com/task/12357160796092152778) started by @Jylhis*