### PR TITLE
feat(ui): implement clean theme loading to prevent blending

### DIFF
--- a/elisp/ui.el
+++ b/elisp/ui.el
@@ -19,6 +19,14 @@
   :type 'symbol
   :group 'jotain-ui)
 
+(defun jotain-ui--disable-all-themes (theme &optional _no-confirm no-enable)
+  "Disable all active themes before loading a new one, unless NO-ENABLE is non-nil.
+This prevents theme blending/stacking artifacts."
+  (unless no-enable
+    (mapc #'disable-theme custom-enabled-themes)))
+
+(advice-add 'load-theme :before #'jotain-ui--disable-all-themes)
+
 (use-package doom-themes
   :ensure t
   :demand t)


### PR DESCRIPTION
This PR addresses the "Frankenstein" theme blending issue where faces from previous themes bleed through when switching themes. It implements a clean theme loading mechanism by advising `load-theme` to disable all currently active themes before loading a new one, unless `no-enable` is set.

Changes:
- Added `jotain-ui--disable-all-themes` function to `elisp/ui.el`.
- Advised `load-theme` with this function to ensure a clean slate on theme switch.

Fixes JYL-64.

---
*PR created automatically by Jules for task [9273575957758686762](https://jules.google.com/task/9273575957758686762) started by @Jylhis*