### PR TITLE
feat: add claude-code-ide Emacs integration

### DIFF
--- a/elisp/ai.el
+++ b/elisp/ai.el
@@ -1,0 +1,16 @@
+;;; ai.el --- AI tools and assistants configuration -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; AI coding assistants and LLM integrations.
+
+;;; Code:
+
+(use-package claude-code-ide
+  :ensure t
+  :defer t
+  :bind ("C-c C-'" . claude-code-ide-menu)
+  :config
+  (claude-code-ide-emacs-tools-setup))
+
+(provide 'ai)
+;;; ai.el ends here

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -386,9 +386,12 @@
         tooltip-recent-seconds 1
         tooltip-hide-delay 10))
 
-;; Future enhancement options (commented out - packages not in nixpkgs):
-;; For even better diagnostic display, consider these packages via straight.el or melpa:
-;; - flymake-diagnostic-at-point: Shows diagnostics in minibuffer/tooltip
+(use-package claude-code-ide
+  :ensure t
+  :defer t
+  :bind ("C-c C-'" . claude-code-ide-menu)
+  :config
+  (claude-code-ide-emacs-tools-setup))
 
 (provide 'programming)
 ;;; programming.el ends here

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -386,12 +386,5 @@
         tooltip-recent-seconds 1
         tooltip-hide-delay 10))
 
-(use-package claude-code-ide
-  :ensure t
-  :defer t
-  :bind ("C-c C-'" . claude-code-ide-menu)
-  :config
-  (claude-code-ide-emacs-tools-setup))
-
 (provide 'programming)
 ;;; programming.el ends here

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             emacs-overlay.overlays.default
             self.overlays.default
           ];
+          config.allowUnfree = true;
         };
 
         packages = {

--- a/init.el
+++ b/init.el
@@ -32,6 +32,7 @@
 (require 'dashboard)   ; Startup dashboard
 (require 'completion)  ; Modern completion framework
 (require 'programming) ; Programming and development tools
+(require 'ai)          ; AI coding assistants
 (require 'per-project) ; Thing to help with project specific setups
 (require 'writing)     ; Org-mode and documentation
 (require 'git)         ; Git and version control

--- a/nix/lib/runtime-deps.nix
+++ b/nix/lib/runtime-deps.nix
@@ -204,6 +204,10 @@ let
       # Used by: elisp/programming.el (markdown-mode)
       (optionalPackage "multimarkdown")
 
+      # Claude Code CLI
+      # Used by: elisp/programming.el (claude-code-ide)
+      pkgs.claude-code
+
       # Additional tools (uncomment as needed):
       # pkgs.sqlite  # Used by org-roam, forge
       # pkgs.graphviz  # Used by org-mode diagrams

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -19,5 +19,19 @@ final: prev: {
       # first alphabetically. Native compilation will JIT-compile at runtime.
       buildPhase = ":";
     };
+
+    # Claude Code IDE integration (not yet in nixpkgs)
+    # https://github.com/manzaltu/claude-code-ide.el
+    claude-code-ide = efinal.trivialBuild {
+      pname = "claude-code-ide";
+      version = "0.2.6";
+      src = final.fetchFromGitHub {
+        owner = "manzaltu";
+        repo = "claude-code-ide.el";
+        rev = "5f12e60c6d2d1802c8c1b7944bbdf935d5db1364";
+        sha256 = "148xcrqff6khpwf8nnadcyvz8h6mk45xz1498k0wbzy80yzd2axn";
+      };
+      packageRequires = with efinal; [ websocket transient web-server ];
+    };
   });
 }


### PR DESCRIPTION
- Add claude-code-ide use-package config in programming.el with C-c C-' keybinding
- Package claude-code-ide via trivialBuild overlay (v0.2.6, manzaltu/claude-code-ide.el)
- Add claude-code CLI to runtime deps
- Allow unfree packages in nixpkgs config

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>