### PR TITLE
Add Nix setup automation for Claude Code remote environments

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup-nix.sh",
+            "timeout": 600,
+            "statusMessage": "Installing Nix and configuring environment..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/setup-nix.sh
+++ b/scripts/setup-nix.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SessionStart hook: install Nix and configure the dev environment
+# for Claude Code on the web. Only runs in remote environments.
+set -euo pipefail
+
+# ── Guard: only run in Claude Code remote (web) environments ───────────
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+log() { echo "[setup-nix] $*"; }
+
+# ── Install Nix if missing ─────────────────────────────────────────────
+if ! command -v nix &>/dev/null; then
+  log "Installing Nix via Determinate Systems installer..."
+  curl --proto '=https' --tlsv1.2 -sSf -L \
+    https://install.determinate.systems/nix | sh -s -- install --no-confirm
+
+  # Source the Nix daemon profile so this script can use nix immediately
+  if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    # shellcheck disable=SC1091
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  fi
+else
+  log "Nix already installed, skipping installation."
+fi
+
+# Verify nix is available
+if ! command -v nix &>/dev/null; then
+  log "ERROR: Nix not found after installation attempt."
+  exit 2
+fi
+
+log "Nix version: $(nix --version)"
+
+# ── Ensure flakes are enabled ──────────────────────────────────────────
+mkdir -p ~/.config/nix
+if ! grep -q 'experimental-features' ~/.config/nix/nix.conf 2>/dev/null; then
+  echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+  log "Enabled flakes in ~/.config/nix/nix.conf"
+fi
+
+# ── Persist Nix environment for subsequent Bash commands ───────────────
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  log "Persisting Nix environment to CLAUDE_ENV_FILE..."
+
+  # Source Nix profile to capture all env changes
+  ENV_BEFORE=$(export -p | sort)
+
+  if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    # shellcheck disable=SC1091
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  fi
+
+  ENV_AFTER=$(export -p | sort)
+  comm -13 <(echo "$ENV_BEFORE") <(echo "$ENV_AFTER") >> "$CLAUDE_ENV_FILE"
+
+  # Ensure PATH includes nix
+  echo 'export PATH="/nix/var/nix/profiles/default/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
+fi
+
+# ── Quick flake evaluation check ──────────────────────────────────────
+if [ -f "${CLAUDE_PROJECT_DIR:-$PWD}/flake.nix" ]; then
+  log "Verifying flake evaluation..."
+  if nix flake metadata "${CLAUDE_PROJECT_DIR:-$PWD}" &>/dev/null; then
+    log "Flake evaluation OK."
+  else
+    log "WARNING: Flake evaluation failed. Check network access (Full internet required for Nix binary cache)."
+  fi
+fi
+
+log "Nix setup complete."
+exit 0


### PR DESCRIPTION
## Summary
This PR adds automated Nix installation and configuration for Claude Code web environments through a SessionStart hook. This enables projects using Nix flakes to have their development environment automatically set up when opening in Claude Code on the web.

## Key Changes
- **scripts/setup-nix.sh**: New setup script that:
  - Installs Nix using the Determinate Systems installer if not already present
  - Enables experimental features (nix-command and flakes) in the Nix configuration
  - Sources the Nix daemon profile to make Nix available immediately
  - Persists Nix environment variables to `CLAUDE_ENV_FILE` for subsequent shell commands
  - Verifies flake evaluation if a `flake.nix` exists in the project
  - Only runs in remote Claude Code environments (guarded by `CLAUDE_CODE_REMOTE` check)

- **.claude/settings.json**: New configuration file that:
  - Registers the setup script as a SessionStart hook
  - Sets a 10-minute timeout for the installation process
  - Provides user feedback during the setup process

## Notable Implementation Details
- The script uses strict mode (`set -euo pipefail`) for reliability
- Nix daemon profile is sourced both during installation and when persisting environment variables to ensure immediate availability
- Environment variable diffing (`comm -13`) captures only new variables added by Nix
- Flake evaluation check is non-blocking (warnings only) to handle network constraints
- The setup is conditional on the `CLAUDE_CODE_REMOTE` environment variable to avoid running in local environments

https://claude.ai/code/session_01HLgASsVf7noNdW4AaAcp6W