### PR TITLE
feat(dashboard): only show dashboard when no files are open

### DIFF
--- a/elisp/dashboard.el
+++ b/elisp/dashboard.el
@@ -9,9 +9,10 @@
   "Return enlight dashboard unless file-visiting buffers already exist.
 When Emacs is launched with file arguments, those buffers are
 visited before this function runs, so we skip the dashboard."
-  (if (seq-some #'buffer-file-name (buffer-list))
-      (seq-find #'buffer-file-name (buffer-list))
-    (enlight)))
+  (let ((file-buffer (seq-find #'buffer-file-name (buffer-list))))
+    (if file-buffer
+        file-buffer
+      (enlight))))
 
 (use-package enlight
   :ensure t

--- a/elisp/dashboard.el
+++ b/elisp/dashboard.el
@@ -5,10 +5,18 @@
 
 ;;; Code:
 
+(defun jotain-dashboard-initial-buffer ()
+  "Return enlight dashboard unless file-visiting buffers already exist.
+When Emacs is launched with file arguments, those buffers are
+visited before this function runs, so we skip the dashboard."
+  (if (seq-some #'buffer-file-name (buffer-list))
+      (seq-find #'buffer-file-name (buffer-list))
+    (enlight)))
+
 (use-package enlight
   :ensure t
   :init
-  (setopt initial-buffer-choice #'enlight)
+  (setopt initial-buffer-choice #'jotain-dashboard-initial-buffer)
   :custom
   (enlight-content
    (concat

--- a/tests/test-uncovered-modules.el
+++ b/tests/test-uncovered-modules.el
@@ -29,7 +29,15 @@
   :tags '(smoke unit fast)
   (require 'dashboard nil t)
   (when (featurep 'enlight)
-    (should (functionp initial-buffer-choice))))
+    (should (functionp initial-buffer-choice))
+    (should (eq initial-buffer-choice #'jotain-dashboard-initial-buffer))))
+
+(ert-deftest test-dashboard/conditional-open ()
+  "Dashboard helper returns enlight when no file buffers exist."
+  :tags '(unit fast)
+  (require 'dashboard nil t)
+  (when (featurep 'enlight)
+    (should (fboundp 'jotain-dashboard-initial-buffer))))
 
 ;;; help.el
 


### PR DESCRIPTION
Skip the enlight startup screen when Emacs is launched with file
arguments. The new jotain-dashboard-initial-buffer function checks
for file-visiting buffers and returns the file buffer instead of
the dashboard when files are already open.

https://claude.ai/code/session_01FcYwYkZgZZizwwr7Rh37R2