### PR TITLE
Configure PDF viewing with pdf-tools

### DIFF
--- a/elisp/writing.el
+++ b/elisp/writing.el
@@ -91,5 +91,11 @@
 (when (facep 'jotain-fonts-serif)
   (set-face-attribute 'jotain-fonts-serif nil :family "Source Serif Pro"))
 
+
+;; PDF viewing
+(use-package pdf-tools
+  :ensure t
+  :mode ("\\.pdf\\'" . pdf-view-mode))
+
 (provide 'writing)
 ;;; writing.el ends here


### PR DESCRIPTION
Added a basic configuration for viewing PDFs in Emacs by introducing the `pdf-tools` package. Configured `pdf-view-mode` as the default mode for `.pdf` files in `elisp/writing.el`.

---
*PR created automatically by Jules for task [12496123350879094514](https://jules.google.com/task/12496123350879094514) started by @Jylhis*