### PR TITLE
Update default fill-column to 100 and add visual indicator

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,7 +2,7 @@
 ;;; For more information see (info "(emacs) Directory Variables")
 
 ((nil
-  (fill-column . 80))
+  (fill-column . 100))
  (emacs-lisp-mode
   (sentence-end-double-space . t)
   (projection-commands-build-project . "just build")

--- a/elisp/core.el
+++ b/elisp/core.el
@@ -9,6 +9,7 @@
   :init
   :custom
   (text-mode-ispell-word-completion nil "Emacs 30 and newer: Disable Ispell completion function.")
+  (fill-column 100 "Modern standard for line length")
   (use-short-answers t "life is too short to type yes or no")
   (create-lockfiles nil)
   (delete-by-moving-to-trash t "Delete by moving to trash in interactive mode")
@@ -88,6 +89,10 @@
   :config
   (line-number-mode 1)   ; Show line number in modeline
   (column-number-mode 1)) ; Show column number
+
+(use-package display-fill-column-indicator
+  :ensure nil
+  :hook (prog-mode . display-fill-column-indicator-mode))
 
 (use-package subword
   :ensure nil


### PR DESCRIPTION
This PR updates the default `fill-column` setting to 100 characters to better align with modern screen sizes and standards.

### Changes:
- **`.dir-locals.el`**: Updates `fill-column` from 80 to 100 for all modes locally.
- **`elisp/core.el`**: Globally adds `fill-column 100` to Emacs' custom variables.
- **`elisp/core.el`**: Automatically enables `display-fill-column-indicator-mode` via `prog-mode-hook` to give clear visual feedback of the limit while writing code, matching modern IDE behavior.

---
*PR created automatically by Jules for task [17383592116470017988](https://jules.google.com/task/17383592116470017988) started by @Jylhis*