### PR TITLE
🎨 Palette: Auto-select help windows for immediate reading

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Auto-select help windows in Emacs
+**Learning:** In Emacs, help windows (e.g., from `C-h f`) appear but do not receive focus by default, forcing users to manually switch to them to scroll or dismiss. This breaks flow.
+**Action:** Adding `(help-window-select t)` to the built-in `help` package configuration fixes this, making the help window immediately active so it can be scrolled and quickly closed with `q`.

--- a/elisp/help.el
+++ b/elisp/help.el
@@ -5,6 +5,11 @@
 
 ;;; Code:
 
+(use-package help
+  :ensure nil
+  :custom
+  (help-window-select t "Automatically select the help window for immediate reading and dismissing."))
+
 (use-package help-at-pt
   :ensure nil
   :custom


### PR DESCRIPTION
**💡 What:** Automatically select and focus the help window when it is opened (e.g., via `C-h f` or `C-h v`).

**🎯 Why:** By default in Emacs, opening a help buffer splits the window but keeps focus in the original buffer. The user must manually switch to the help window to scroll through the documentation or close it with `q`. Setting `help-window-select` to `t` automatically shifts focus to the newly opened help window, which significantly improves the interaction flow and saves keystrokes.

**♿ Accessibility:** Improves keyboard navigation by immediately putting focus where the user's intent is directed, reducing the cognitive load and manual window-switching steps required to read documentation.

Also documented this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [3972525927785950544](https://jules.google.com/task/3972525927785950544) started by @Jylhis*