### PR TITLE
feat: configure fancy-fill-paragraph

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -90,6 +90,11 @@
   (line-number-mode 1)   ; Show line number in modeline
   (column-number-mode 1)) ; Show column number
 
+(use-package fancy-fill-paragraph
+  :ensure t
+  :bind
+  ([remap fill-paragraph] . fancy-fill-paragraph))
+
 (use-package display-fill-column-indicator
   :ensure nil
   :hook (prog-mode . display-fill-column-indicator-mode))


### PR DESCRIPTION
Added `fancy-fill-paragraph` to `elisp/core.el` to replace the default `fill-paragraph` functionality.
This provides a context-aware paragraph fill logic for better formatting without relying on manual fill modifications.
Tested the package addition. All `ert` tests passed.

---
*PR created automatically by Jules for task [6931897075840204839](https://jules.google.com/task/6931897075840204839) started by @Jylhis*