### PR TITLE
🎨 Palette: Auto-focus help windows

### DIFF
--- a/elisp/help.el
+++ b/elisp/help.el
@@ -5,6 +5,11 @@
 
 ;;; Code:
 
+(use-package help
+  :ensure nil
+  :custom
+  (help-window-select t "Automatically shift focus to the help window upon opening"))
+
 (use-package help-at-pt
   :ensure nil
   :custom


### PR DESCRIPTION
💡 **What**: Added `help-window-select t` to `elisp/help.el`.
🎯 **Why**: When a user opens a help buffer (e.g., via `C-h f`), the help window pops up but doesn't receive focus by default. This forces users to manually switch to the help window if they want to scroll or close it. Auto-focusing it eliminates this friction, making help documentation exploration much smoother.
♿ **Accessibility/UX**: This reduces the required physical interactions (keystrokes) and cognitive load associated with window management when accessing standard help docs.

---
*PR created automatically by Jules for task [12771006227547012555](https://jules.google.com/task/12771006227547012555) started by @Jylhis*