### PR TITLE
refactor: disable dialog boxes for yes-or-no prompts

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -11,7 +11,7 @@
   (text-mode-ispell-word-completion nil "Emacs 30 and newer: Disable Ispell completion function.")
   (fill-column 100 "Modern standard for line length")
   (use-short-answers t "life is too short to type yes or no")
-  (use-dialog-box nil "Disable dialog boxes for a consistent experience")
+  (use-dialog-box nil "Disable dialog boxes to complement use-short-answers")
   (create-lockfiles nil)
   (delete-by-moving-to-trash t "Delete by moving to trash in interactive mode")
   (sentence-end-double-space nil "Disable the obsolete practice of end-of-line spacing from the typewriter era.")

--- a/elisp/core.el
+++ b/elisp/core.el
@@ -11,6 +11,7 @@
   (text-mode-ispell-word-completion nil "Emacs 30 and newer: Disable Ispell completion function.")
   (fill-column 100 "Modern standard for line length")
   (use-short-answers t "life is too short to type yes or no")
+  (use-dialog-box nil "Disable dialog boxes for a consistent experience")
   (create-lockfiles nil)
   (delete-by-moving-to-trash t "Delete by moving to trash in interactive mode")
   (sentence-end-double-space nil "Disable the obsolete practice of end-of-line spacing from the typewriter era.")


### PR DESCRIPTION
Following modern Emacs practices, `use-dialog-box` is set to `nil` in
`elisp/core.el` to complement `use-short-answers` for a consistent,
frictionless yes-or-no prompting experience.

---
*PR created automatically by Jules for task [13888485076748848367](https://jules.google.com/task/13888485076748848367) started by @Jylhis*