### PR TITLE
chore(core): replace expand-region with expreg

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -167,9 +167,9 @@
   :bind ("C-x u" . vundo)
   :config (setq vundo-glyph-alist vundo-unicode-symbols))
 
-(use-package expand-region
+(use-package expreg
   :ensure t
-  :bind ("C-=" . er/expand-region))
+  :bind ("C-=" . expreg-expand))
 
 (use-package multiple-cursors
   :ensure t


### PR DESCRIPTION
Replace the `expand-region` package with `expreg` in `elisp/core.el` as requested. Update the `use-package` declaration and bind `C-=` to `expreg-expand` instead of `er/expand-region` following the package's documentation.

---
*PR created automatically by Jules for task [9018446076703225679](https://jules.google.com/task/9018446076703225679) started by @Jylhis*