### PR TITLE
Configure world clock

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -197,5 +197,16 @@
                      (float-time (time-subtract after-init-time before-init-time))
                      gcs-done)))
 
+
+;; World clock configuration
+(use-package time
+  :ensure nil
+  :custom
+  (world-clock-list
+   '(("Europe/Zurich" "Zurich")
+     ("Europe/Helsinki" "Helsinki")
+     ("Asia/Bangkok" "Bangkok")
+     ("Asia/Shanghai" "Shanghai"))))
+
 (provide 'core)
 ;;; core.el ends here

--- a/elisp/utils.el
+++ b/elisp/utils.el
@@ -104,16 +104,5 @@ If there are not exactly 2 windows, display an error message."
           (if this-win-2nd (other-window 1))))
     (user-error "Can only toggle split with exactly 2 windows")))
 
-
-;; World clock configuration
-(use-package time
-  :ensure nil
-  :custom
-  (world-clock-list
-   '(("Europe/Zurich" "Zurich")
-     ("Europe/Helsinki" "Helsinki")
-     ("Asia/Bangkok" "Bangkok")
-     ("Asia/Shanghai" "Shanghai"))))
-
 (provide 'utils)
 ;;; utils.el ends here

--- a/elisp/utils.el
+++ b/elisp/utils.el
@@ -104,5 +104,16 @@ If there are not exactly 2 windows, display an error message."
           (if this-win-2nd (other-window 1))))
     (user-error "Can only toggle split with exactly 2 windows")))
 
+
+;; World clock configuration
+(use-package time
+  :ensure nil
+  :custom
+  (world-clock-list
+   '(("Europe/Zurich" "Zurich")
+     ("Europe/Helsinki" "Helsinki")
+     ("Asia/Bangkok" "Bangkok")
+     ("Asia/Shanghai" "Shanghai"))))
+
 (provide 'utils)
 ;;; utils.el ends here


### PR DESCRIPTION
Configured `world-clock-list` for Emacs' built-in `time` library to show the time for Zurich, Helsinki, Bangkok, and Shanghai.

---
*PR created automatically by Jules for task [16321490266102710665](https://jules.google.com/task/16321490266102710665) started by @Jylhis*