### PR TITLE
feat: auto-create missing directories

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -52,6 +52,8 @@
   :ensure nil
   :hook
   (after-save . executable-make-buffer-file-executable-if-script-p)
+  :config
+  (add-to-list 'find-file-not-found-functions #'my/auto-create-missing-dirs)
   :custom
   ;; Disable autosave and backups
   (auto-save-default nil "Disable separate autosave files")

--- a/elisp/utils.el
+++ b/elisp/utils.el
@@ -110,6 +110,6 @@ If there are not exactly 2 windows, display an error message."
 ;;;###autoload
 (defun my/auto-create-missing-dirs ()
   "Automatically create missing directories when finding a file."
-  (let ((target-dir (file-name-directory buffer-file-name)))
-    (unless (file-exists-p target-dir)
+  (let ((target-dir (if buffer-file-name (file-name-directory buffer-file-name))))
+    (when (and target-dir (not (file-exists-p target-dir)))
       (make-directory target-dir t))))

--- a/elisp/utils.el
+++ b/elisp/utils.el
@@ -106,3 +106,10 @@ If there are not exactly 2 windows, display an error message."
 
 (provide 'utils)
 ;;; utils.el ends here
+
+;;;###autoload
+(defun my/auto-create-missing-dirs ()
+  "Automatically create missing directories when finding a file."
+  (let ((target-dir (file-name-directory buffer-file-name)))
+    (unless (file-exists-p target-dir)
+      (make-directory target-dir t))))

--- a/tests/test-utils.el
+++ b/tests/test-utils.el
@@ -150,3 +150,10 @@
           (my/auto-create-missing-dirs)
           (should (file-directory-p nested-dir)))
       (delete-directory temp-dir t))))
+
+(ert-deftest test-utils/auto-create-missing-dirs-nil-buffer-file-name ()
+  "Test that my/auto-create-missing-dirs does not crash when buffer-file-name is nil."
+  :tags '(unit utils)
+  (let ((buffer-file-name nil))
+    (my/auto-create-missing-dirs)
+    (should t)))

--- a/tests/test-utils.el
+++ b/tests/test-utils.el
@@ -137,3 +137,16 @@
 
 (provide 'test-utils)
 ;;; test-utils.el ends here
+
+(ert-deftest test-utils/auto-create-missing-dirs ()
+  "Test that my/auto-create-missing-dirs creates missing directories."
+  :tags '(unit utils filesystem)
+  (let* ((temp-dir (make-temp-file "emacs-test-auto-create-" t))
+         (nested-dir (expand-file-name "a/b/c" temp-dir))
+         (test-file (expand-file-name "test.txt" nested-dir)))
+    (unwind-protect
+        (let ((buffer-file-name test-file))
+          (should-not (file-exists-p nested-dir))
+          (my/auto-create-missing-dirs)
+          (should (file-directory-p nested-dir)))
+      (delete-directory temp-dir t))))


### PR DESCRIPTION
This PR adds functionality to automatically create missing directories when saving or opening files, following the [Emacs Redux article](https://emacsredux.com/blog/2022/06/12/auto-create-missing-directories/).

- Adds `my/auto-create-missing-dirs` to `elisp/utils.el`.
- Hooks the function to `find-file-not-found-functions` in `elisp/core.el`.
- Includes automated unit tests in `tests/test-utils.el`.

---
*PR created automatically by Jules for task [9670312125435853639](https://jules.google.com/task/9670312125435853639) started by @Jylhis*