### PR TITLE
Fix clean unloading of Emacs themes

### DIFF
--- a/elisp/ui.el
+++ b/elisp/ui.el
@@ -27,7 +27,7 @@
   "Disable all active themes before loading a new one, unless NO-ENABLE is non-nil.
 This prevents theme blending/stacking artifacts."
   (unless no-enable
-    (mapc #'disable-theme custom-enabled-themes)))
+    (mapc #'disable-theme (copy-sequence custom-enabled-themes))))
 
 (advice-add 'load-theme :before #'jotain-ui--disable-all-themes)
 

--- a/tests/test-ui.el
+++ b/tests/test-ui.el
@@ -34,13 +34,17 @@
   "Test that advice disables all themes when NO-ENABLE is nil."
   :tags '(unit ui fast)
   (let ((disabled-themes nil)
-        (custom-enabled-themes '(theme-a theme-b)))
+        (custom-enabled-themes (list 'theme-a 'theme-b 'theme-c)))
     (cl-letf (((symbol-function 'disable-theme)
-               (lambda (theme) (push theme disabled-themes))))
+               (lambda (theme)
+                 (push theme disabled-themes)
+                 (setq custom-enabled-themes (delq theme custom-enabled-themes)))))
       (jotain-ui--disable-all-themes 'some-theme nil nil)
       (should (member 'theme-a disabled-themes))
       (should (member 'theme-b disabled-themes))
-      (should (= (length disabled-themes) 2)))))
+      (should (member 'theme-c disabled-themes))
+      (should (= (length disabled-themes) 3))
+      (should (null custom-enabled-themes)))))
 
 (ert-deftest test-ui-preload-themes-defined ()
   "Test that jotain-ui--preload-themes is defined."


### PR DESCRIPTION
When iterating over `custom-enabled-themes` using `mapc` to pass them to
`disable-theme`, the underlying list is modified. Iterating over the list
concurrently as `disable-theme` deletes items from it results in missed 
elements because cdr moves past the removed element's former position,
skipping the adjacent elements.

By passing a copied sequence of `custom-enabled-themes` to `mapc`, all
themes are successfully disabled before the new theme is loaded,
eliminating blending/stacking artifacts as pointed out by Bozhidar 
Batsov in his Emacs Redux blog.

---
*PR created automatically by Jules for task [9288239017385680846](https://jules.google.com/task/9288239017385680846) started by @Jylhis*