### PR TITLE
Migrate diminish to Emacs 31 mode-line-collapse-minor-modes

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -96,7 +96,6 @@
 
 (use-package subword
   :ensure nil
-  :diminish
   :hook ((prog-mode . subword-mode)
          (minibuffer-setup . subword-mode)))
 
@@ -153,7 +152,6 @@
 ;;; Essential packages
 (use-package super-save
   :ensure t
-  :diminish
   :custom
   (super-save-auto-save-when-idle t)
   (super-save-remote-files nil)
@@ -179,7 +177,6 @@
 
 (use-package drag-stuff
   :ensure t
-  :diminish
   :autoload drag-stuff-define-keys
   :hook ((text-mode prog-mode) . drag-stuff-mode)
   :config

--- a/elisp/help.el
+++ b/elisp/help.el
@@ -12,7 +12,6 @@
 
 (use-package helpful
   :ensure t
-  :diminish
   :bind
   (("C-h f" . #'helpful-callable)
    ("C-h v" . #'helpful-variable)

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -27,7 +27,6 @@
   (global-treesit-auto-mode))
 
 (use-package treesit-fold
-  :diminish
   :ensure t
   :hook (after-init . global-treesit-fold-indicators-mode)
   :init (setq treesit-fold-indicators-priority -1))
@@ -223,7 +222,6 @@
 
 (use-package dtrt-indent
   :defer t
-  :diminish
   :hook (prog-mode . dtrt-indent-mode)
   )
 
@@ -405,7 +403,6 @@
 (use-package editorconfig
   :ensure nil  ; Built-in since Emacs 30
   :defer t
-  :diminish
   :hook (prog-mode . editorconfig-mode))
 
 ;; Enhanced error display using built-in features

--- a/elisp/ui.el
+++ b/elisp/ui.el
@@ -58,7 +58,6 @@ auto-dark is the sole decider of which theme becomes active."
 (use-package auto-dark
   :ensure t
   :demand t
-  :diminish
   :bind ("C-c t" . auto-dark-toggle-appearance)
   :after nord-theme doom-themes
   :custom
@@ -70,11 +69,11 @@ auto-dark is the sole decider of which theme becomes active."
               (when (display-graphic-p frame)
                 (with-selected-frame frame (auto-dark-mode 1))))))
 
-(use-package diminish)
+
+(setq mode-line-collapse-minor-modes '(subword-mode super-save-mode drag-stuff-mode helpful-mode treesit-fold-indicators-mode dtrt-indent-mode editorconfig-mode auto-dark-mode which-key-mode))
 
 (use-package which-key
   :ensure nil  ; Built-in since Emacs 30
-  :diminish
   :hook (after-init . which-key-mode))
 
 (use-package hl-line


### PR DESCRIPTION
Since Emacs 31 introduces a built-in way to collapse minor modes on the modeline (`mode-line-collapse-minor-modes`), we no longer need the third-party diminish package.

---
*PR created automatically by Jules for task [8054611563003212280](https://jules.google.com/task/8054611563003212280) started by @Jylhis*