### PR TITLE
🎨 Palette: Auto-scroll compilation output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Auto-scroll Compilation Output to First Error
+**Learning:** Users running long builds or tests in Emacs often lose track of the process state because the compilation buffer doesn't scroll by default. This forces them to manually jump to the compilation window to check progress or find errors, disrupting their workflow.
+**Action:** Set `compilation-scroll-output` to `'first-error`. This automatically scrolls the compilation buffer to follow output but stops at the first error, giving users immediate feedback on build progress without missing the point of failure.

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -9,6 +9,11 @@
   :hook
   (prog-mode . display-line-numbers-mode))
 
+(use-package compile
+  :ensure nil
+  :custom
+  (compilation-scroll-output 'first-error))
+
 (use-package treesit
   :ensure nil
   :custom

--- a/tests/test-programming.el
+++ b/tests/test-programming.el
@@ -101,6 +101,14 @@
   (should (fboundp 'jsonrpc--log-event))
   (should (eq (symbol-function 'jsonrpc--log-event) #'ignore)))
 
+;;; Compilation Configuration
+
+(ert-deftest test-programming/compile-auto-scroll-configured ()
+  "Test that compilation output auto-scrolling is configured."
+  :tags '(fast unit)
+  (require 'compile)
+  (should (eq compilation-scroll-output 'first-error)))
+
 ;;; Xref Configuration
 
 (ert-deftest test-programming/xref-uses-ripgrep ()


### PR DESCRIPTION
💡 What: Added configuration to `elisp/programming.el` to set `compilation-scroll-output` to `'first-error`.
🎯 Why: Running builds or tests shouldn't require users to manually switch to the compilation buffer to scroll for ongoing output, nor should they miss where a failure first occurred. Setting it to `'first-error` perfectly balances monitoring progress with catching the exact point of failure.
📸 Before/After: Not a visual UI change; rather, it's a workflow/interaction improvement.
♿ Accessibility: Reduces manual keyboard/mouse overhead by keeping relevant output in focus automatically.

---
*PR created automatically by Jules for task [15503551682880711853](https://jules.google.com/task/15503551682880711853) started by @Jylhis*