### PR TITLE
⚡ Bolt: Optimize buffer list traversal in dashboard

### DIFF
--- a/elisp/dashboard.el
+++ b/elisp/dashboard.el
@@ -9,9 +9,10 @@
   "Return enlight dashboard unless file-visiting buffers already exist.
 When Emacs is launched with file arguments, those buffers are
 visited before this function runs, so we skip the dashboard."
-  (if (seq-some #'buffer-file-name (buffer-list))
-      (seq-find #'buffer-file-name (buffer-list))
-    (enlight)))
+  ;; Optimization: Use `or` with `seq-find` to avoid traversing the buffer list
+  ;; twice (previously `seq-some` followed by `seq-find`).
+  (or (seq-find #'buffer-file-name (buffer-list))
+      (enlight)))
 
 (use-package enlight
   :ensure t


### PR DESCRIPTION
💡 **What:** Replaced the redundant `seq-some` + `seq-find` call chain in `jotain-dashboard-initial-buffer` with a single `or` and `seq-find`.
🎯 **Why:** The `buffer-list` was being traversed twice—first to check if a file-visiting buffer existed (O(N)), and a second time to actually return it (O(N)).
📊 **Impact:** Reduces list traversal operations by 50% during startup when Emacs is launched with file arguments.
🔬 **Measurement:** You can verify the behavior hasn't changed by running `emacs -Q -l <path-to-dashboard.el>` with and without opening a file buffer. This preserves existing behavior precisely while using a cleaner Lisp idiom.

---
*PR created automatically by Jules for task [17251397316730411186](https://jules.google.com/task/17251397316730411186) started by @Jylhis*