### PR TITLE
⚡ Optimize redundant directory listing in test-use-package-ensure.el

### DIFF
--- a/tests/test-use-package-ensure.el
+++ b/tests/test-use-package-ensure.el
@@ -117,11 +117,12 @@ External packages should use :ensure t for explicit documentation."
   :tags '(fast unit)
   ;; This is informational - we verify external packages have :ensure t
   ;; by checking a sample of known external packages
-  (let ((elisp-dir (expand-file-name "elisp" user-emacs-directory))
-        (sample-externals '("magit" "vertico" "consult" "corfu" "orderless")))
+  (let* ((elisp-dir (expand-file-name "elisp" user-emacs-directory))
+         (sample-externals '("magit" "vertico" "consult" "corfu" "orderless"))
+         (el-files (directory-files elisp-dir t "\\.el$")))
     (dolist (pkg sample-externals)
       (let ((found nil))
-        (dolist (file (directory-files elisp-dir t "\\.el$"))
+        (dolist (file el-files)
           (with-temp-buffer
             (insert-file-contents file)
             (goto-char (point-min))


### PR DESCRIPTION
💡 **What:** Optimized `test-use-package-ensure/external-packages-documented` in `tests/test-use-package-ensure.el` by moving the `directory-files` call outside of the `dolist` loop. Used `let*` for idiomatic Emacs Lisp binding.
🎯 **Why:** The previous implementation listed the entire `elisp/` directory for every package being checked, leading to unnecessary disk I/O (O(N*M) where N is number of packages and M is number of files).
📊 **Measured Improvement:** While environmental network timeouts prevented a full benchmark run, this change reduces disk I/O operations for directory listing from N (currently 5) to 1. This follows best practices for performance-sensitive code by hoisting invariant operations out of loops.

---
*PR created automatically by Jules for task [14599880507078931722](https://jules.google.com/task/14599880507078931722) started by @Jylhis*