### PR TITLE
Fix dashboard behavior to ignore dired buffers

### DIFF
--- a/elisp/dashboard.el
+++ b/elisp/dashboard.el
@@ -11,7 +11,10 @@ When Emacs is launched with file arguments, those buffers are
 visited before this function runs, so we skip the dashboard."
   ;; Optimization: Use `or` with `seq-find` to avoid traversing the buffer list
   ;; twice (previously `seq-some` followed by `seq-find`).
-  (or (seq-find #'buffer-file-name (buffer-list))
+  (or (seq-find (lambda (b)
+                  (or (buffer-file-name b)
+                      (with-current-buffer b (bound-and-true-p dired-directory))))
+                (buffer-list))
       (enlight)))
 
 (use-package enlight

--- a/tests/test-dashboard.el
+++ b/tests/test-dashboard.el
@@ -1,0 +1,46 @@
+;;; test-dashboard.el --- Tests for dashboard.el -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'dired)
+(require 'enlight)
+(require 'dashboard)
+
+(ert-deftest dashboard-initial-buffer-no-file-visiting-buffers ()
+  "Test that the dashboard opens when there are no file-visiting or dired buffers."
+  ;; Create a temporary buffer list that does not contain file or dired buffers
+  (cl-letf (((symbol-function 'buffer-list)
+             (lambda ()
+               (list (get-buffer-create "*scratch*")
+                     (get-buffer-create "*Messages*")))))
+    (should (equal (jotain-dashboard-initial-buffer) (enlight)))))
+
+(ert-deftest dashboard-initial-buffer-with-file-visiting-buffer ()
+  "Test that the dashboard is skipped when there is a file-visiting buffer."
+  (let ((file-buf (get-buffer-create "test-file.txt")))
+    (unwind-protect
+        (with-current-buffer file-buf
+          (setq buffer-file-name "/tmp/test-file.txt")
+          (cl-letf (((symbol-function 'buffer-list)
+                     (lambda ()
+                       (list (get-buffer-create "*scratch*")
+                             file-buf))))
+            (should-not (equal (jotain-dashboard-initial-buffer) (enlight)))
+            (should (equal (jotain-dashboard-initial-buffer) file-buf))))
+      (kill-buffer file-buf))))
+
+(ert-deftest dashboard-initial-buffer-with-dired-buffer ()
+  "Test that the dashboard is skipped when there is a dired buffer."
+  (let ((dir-buf (get-buffer-create "test-dir")))
+    (unwind-protect
+        (with-current-buffer dir-buf
+          (setq dired-directory "/tmp/test-dir/")
+          (cl-letf (((symbol-function 'buffer-list)
+                     (lambda ()
+                       (list (get-buffer-create "*scratch*")
+                             dir-buf))))
+            (should-not (equal (jotain-dashboard-initial-buffer) (enlight)))
+            (should (equal (jotain-dashboard-initial-buffer) dir-buf))))
+      (kill-buffer dir-buf))))
+
+(provide 'test-dashboard)
+;;; test-dashboard.el ends here


### PR DESCRIPTION
Previously, Emacs would launch the dashboard even if a user opened a directory explicitly via CLI (e.g. `emacs /path/to/dir`) because the directory buffer wouldn't have a `buffer-file-name`. 

This change modifies the `jotain-dashboard-initial-buffer` condition to check if any buffer is visiting a file OR has `dired-directory` bound and set. It also adds tests using `ert-deftest` to verify the behavior for empty, file, and directory buffer conditions.

---
*PR created automatically by Jules for task [4989212418731524602](https://jules.google.com/task/4989212418731524602) started by @Jylhis*