### PR TITLE
🎨 Palette: Enable corfu-popupinfo for completion documentation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-17 - Add corfu-popupinfo
+**Learning:** Users benefit greatly from in-editor documentation popups alongside completion candidates. Enabling `corfu-popupinfo-mode` allows users to see function/variable documentation immediately without needing to open a separate help buffer.
+**Action:** Add `(corfu-popupinfo-mode 1)` to completion configurations to enhance discoverability.

--- a/elisp/completion.el
+++ b/elisp/completion.el
@@ -52,10 +52,13 @@
 (use-package corfu
   :ensure t
   :demand t
+  :custom
+  (corfu-popupinfo-delay '(0.5 . 0.2))
   :config
   (global-corfu-mode)
   (require 'corfu-history)
-  (corfu-history-mode))
+  (corfu-history-mode)
+  (corfu-popupinfo-mode 1))
 
 
 (use-package cape


### PR DESCRIPTION
💡 **What**: Enabled `corfu-popupinfo-mode` and configured a sensible popup delay in `elisp/completion.el`.
🎯 **Why**: Users often need to know what a completion candidate does before selecting it. Opening a separate help buffer is disruptive to flow. This adds a helpful, non-intrusive popup right next to the candidate list, making the interface more informative and accessible.
♿ **Accessibility**: Reduces cognitive load and the need for context switching by providing inline documentation exactly when and where it is needed.

Tested by checking the `elisp/completion.el` syntax and Nix formatting.

*Reference: UX enhancement.*

---
*PR created automatically by Jules for task [12927023227443442767](https://jules.google.com/task/12927023227443442767) started by @Jylhis*