### PR TITLE
🎨 Palette: Enhance compilation buffer UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Compilation Buffer Auto-Scroll UX]
+**Learning:** [Users find manual scrolling of long compilation outputs interrupting their flow, especially when looking for the first error.]
+**Action:** [Set `compilation-scroll-output` to `'first-error` to automatically scroll the output during builds, stopping at the first error to save time and cognitive load.]

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -49,6 +49,11 @@
          (c-ts-mode . combobulate-mode)
          (c++-ts-mode . combobulate-mode)))
 
+(use-package compile
+  :ensure nil
+  :custom
+  (compilation-scroll-output 'first-error))
+
 (use-package flymake
   :custom
   (flymake-fringe-indicator-position 'left-fringe)


### PR DESCRIPTION
🎨 Palette: [UX improvement] Enhance compilation buffer UX

💡 **What:** Added a configuration to the built-in `compile` package setting `compilation-scroll-output` to `'first-error`.
🎯 **Why:** Users frequently find manual scrolling of long compilation outputs interrupting their flow. By setting it to auto-scroll but stop at the first error, we save time and cognitive load, improving the developer experience.
📸 **Before/After:** Not applicable (behavioral change).
♿ **Accessibility:** Reduces the need for manual mouse/keyboard scrolling interactions during builds.

Additionally, recorded this critical UX learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [7393813872991445390](https://jules.google.com/task/7393813872991445390) started by @Jylhis*