### PR TITLE
🎨 Palette: Improve duplicate buffer names with uniquify

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2023-10-24 - Uniquify Buffer Names
+**Learning:** In a codebase or environment with many identically-named files (e.g., `index.js` or `__init__.py`), relying on plain buffer names leads to severe navigation friction. Native `uniquify` solves this by seamlessly appending directory contexts.
+**Action:** Always enable `uniquify` with forward slash style for duplicate buffers to reduce friction without cluttering the UI.

--- a/elisp/core.el
+++ b/elisp/core.el
@@ -82,6 +82,14 @@
   :init
   (savehist-mode))
 
+(use-package uniquify
+  :ensure nil
+  :custom
+  (uniquify-buffer-name-style 'forward "Use forward slash style for duplicate buffer names")
+  (uniquify-separator "/" "Separator for uniquify buffer names")
+  (uniquify-after-kill-buffer-p t "Rename buffers after killing to keep names unique")
+  (uniquify-ignore-buffers-re "^\\*" "Ignore special buffers"))
+
 (use-package simple
   :ensure nil
   :custom


### PR DESCRIPTION
💡 What: Enabled the `uniquify` package in Emacs core configuration.
🎯 Why: When opening multiple files with the same name (like `init.el` from different repositories, or `__init__.py`/`index.js`), Emacs by default appends `<1>`, `<2>`, making it impossible to tell which is which. Using `uniquify` with forward slash style appends the parent directory to the buffer name, providing clear context at a glance.
📸 Before/After: Before `init.el<2>`, After `elisp/init.el`.
♿ Accessibility: Reduces cognitive load and confusion when navigating between open buffers.

---
*PR created automatically by Jules for task [9928222994979690523](https://jules.google.com/task/9928222994979690523) started by @Jylhis*