### PR TITLE
🎨 Palette: Add corfu-popupinfo for completion documentation

### DIFF
--- a/elisp/completion.el
+++ b/elisp/completion.el
@@ -55,7 +55,8 @@
   :config
   (global-corfu-mode)
   (require 'corfu-history)
-  (corfu-history-mode))
+  (corfu-history-mode)
+  (corfu-popupinfo-mode))
 
 
 (use-package cape

--- a/elisp/completion.el
+++ b/elisp/completion.el
@@ -56,6 +56,7 @@
   (global-corfu-mode)
   (require 'corfu-history)
   (corfu-history-mode)
+  (require 'corfu-popupinfo)
   (corfu-popupinfo-mode))
 
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,16 @@
+1. We have a failure in github actions complaining about Node.js 20 actions deprecation but the actual failure is `Process completed with exit code 1.` at `.github/workflows/determinate-ci.yml`, likely in the step `nix flake check`.
+2. Wait, the problem is in `nix flake check`. When we ran `nix flake check` it timed out locally.
+Let's see if there's any test failure. Wait, there is a `tests/test-completion.el` failure for `corfu-popupinfo-enabled`. Why? Wait, in `test-completion.el`, we check for `(should corfu-popupinfo-mode)`. But `corfu-popupinfo-mode` is turned on asynchronously or globally? No, in `elisp/completion.el`:
+```elisp
+(use-package corfu
+  ...
+  :config
+  (global-corfu-mode)
+  (require 'corfu-history)
+  (corfu-history-mode)
+  (corfu-popupinfo-mode))
+```
+Wait! `corfu-popupinfo-mode` is a separate package/file in the `corfu` package, so we need to require it!
+`(require 'corfu-popupinfo)`
+Because in the test `test-completion.el`, `corfu-history-mode` works but `corfu-history-mode` is required. `global-corfu-mode` is autoloaded.
+Let's check `elisp/completion.el`.

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+nix shell nixpkgs#emacs -c emacs --batch -L elisp -L tests -l elisp/platform.el -l elisp/completion.el -l tests/test-completion.el -f ert-run-tests-batch-and-exit

--- a/tests/test-completion.el
+++ b/tests/test-completion.el
@@ -69,6 +69,13 @@
   (should (boundp 'corfu-history-mode))
   (should corfu-history-mode))
 
+(ert-deftest test-completion/corfu-popupinfo-enabled ()
+  "Test that corfu-popupinfo mode is enabled."
+  :tags '(unit)
+  (should (fboundp 'corfu-popupinfo-mode))
+  (should (boundp 'corfu-popupinfo-mode))
+  (should corfu-popupinfo-mode))
+
 ;;; Cape Configuration
 
 (ert-deftest test-completion/cape-completers-registered ()


### PR DESCRIPTION
**Palette**: 🎨 Adds `corfu-popupinfo-mode` to the modern completion setup.

💡 **What**: Enabled `corfu-popupinfo-mode` in the `corfu` package configuration and added a test to ensure it remains enabled.
🎯 **Why**: Displays in-editor documentation popups directly alongside the autocompletion candidates, removing the need to manually trigger documentation or look elsewhere while coding. This gives users an intuitive and frictionless experience.
♿ **Accessibility**: Improves cognitive accessibility by providing immediate contextual documentation right where the user's focus already is.

---
*PR created automatically by Jules for task [6276737318928967517](https://jules.google.com/task/6276737318928967517) started by @Jylhis*