### PR TITLE
🎨 Palette: Add documentation popups to completion

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Add documentation popups to completion]
+**Learning:** Adding `corfu-popupinfo-mode` improves UX significantly by surfacing documentation directly during completion, preventing users from needing to switch buffers or manually look up symbols. A small delay (`corfu-popupinfo-delay`) is crucial to avoid flashing popups on every keystroke.
+**Action:** When adding completion tools, always consider whether inline documentation can be enabled gracefully with a delay.

--- a/elisp/completion.el
+++ b/elisp/completion.el
@@ -55,7 +55,10 @@
   :config
   (global-corfu-mode)
   (require 'corfu-history)
-  (corfu-history-mode))
+  (corfu-history-mode)
+  (require 'corfu-popupinfo)
+  (corfu-popupinfo-mode)
+  (setq corfu-popupinfo-delay '(0.5 . 0.2)))
 
 
 (use-package cape


### PR DESCRIPTION
💡 What: Enabled `corfu-popupinfo-mode` for inline completion documentation and set a custom delay `'(0.5 . 0.2)` to prevent flicker.

🎯 Why: Surfacing documentation directly in the completion UI improves the user experience significantly by removing the need to manually search for or open separate documentation buffers when inspecting candidate symbols or functions.

♿ Accessibility: Ensures that descriptive text accompanies short, potentially cryptic completion symbols, which aids in comprehension and creates a more inclusive, discoverable interface.

---
*PR created automatically by Jules for task [344751796810669168](https://jules.google.com/task/344751796810669168) started by @Jylhis*