### PR TITLE
🛡️ Sentinel: [security improvement] Enforce strict TLS certificate verification

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -29,6 +29,8 @@
   (read-buffer-completion-ignore-case t "Ignore case when reading buffer name")
   (read-file-name-completion-ignore-case t "Ignore case for file completion")
   (load-prefer-newer t "Always load newer compiled files")
+  (network-security-level 'high "Enable high network security level for TLS connections")
+  (gnutls-verify-error t "Reject invalid TLS certificates")
   :config
   ;; Enable modes
   (context-menu-mode 1)           ; Enable context menu for vertico


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Emacs default network security settings may allow connections with weak cryptography or accept invalid TLS certificates in some contexts depending on the environment and default `network-security-level`.
🎯 **Impact:** Potential Man-in-the-Middle (MitM) attacks when Emacs downloads packages, contacts Language Servers, queries APIs (like LLM backends or JIRA), or fetches external resources.
🔧 **Fix:** Hardened `elisp/core.el` to strictly enforce TLS certificate validity (`gnutls-verify-error t`) and elevate the `network-security-level` to `'high` to reject known weak ciphers and unsafe connections globally.
✅ **Verification:** Verified that Emacs starts successfully and fast unit tests continue to pass without network configuration regressions.

---
*PR created automatically by Jules for task [6285731349655530563](https://jules.google.com/task/6285731349655530563) started by @Jylhis*