### PR TITLE
🎨 Palette: [UX improvement] Add documentation popups for completion candidates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Contextual documentation for completions without UI jitter
+**Learning:** Displaying documentation popups alongside completion candidates (`corfu-popupinfo-mode`) significantly improves UX by eliminating the need to manually open help buffers. However, instantaneous popups cause disruptive UI flashing when typing quickly.
+**Action:** Always implement a slight initial delay (e.g., `(corfu-popupinfo-delay '(0.5 . 0.2))`) for completion popups to balance immediate contextual help with a smooth, jitter-free typing experience.

--- a/elisp/completion.el
+++ b/elisp/completion.el
@@ -52,8 +52,11 @@
 (use-package corfu
   :ensure t
   :demand t
+  :custom
+  (corfu-popupinfo-delay '(0.5 . 0.2))
   :config
   (global-corfu-mode)
+  (corfu-popupinfo-mode)
   (require 'corfu-history)
   (corfu-history-mode))
 

--- a/elisp/completion.el
+++ b/elisp/completion.el
@@ -56,6 +56,7 @@
   (corfu-popupinfo-delay '(0.5 . 0.2))
   :config
   (global-corfu-mode)
+  (require 'corfu-popupinfo)
   (corfu-popupinfo-mode)
   (require 'corfu-history)
   (corfu-history-mode))


### PR DESCRIPTION
💡 What: Added `corfu-popupinfo-mode` to the completion configuration, along with setting `corfu-popupinfo-delay` to `'(0.5 . 0.2)`.

🎯 Why: To improve the user experience of auto-completion. This displays contextual documentation side-by-side with completion candidates, removing the need for users to switch context or manually look up functions. The added delay prevents disruptive UI flashing (jitter) that happens with instantaneous popups when users are typing fast.

📸 Before/After: Not strictly applicable as a visual test is difficult, but the completion popup will now include a documentation child frame after a 0.5s pause.

♿ Accessibility: Ensures that users relying on visual cues or those who need extra cognitive assistance (via immediate contextual documentation) have access to inline documentation seamlessly, without extra keypresses breaking their flow.

---
*PR created automatically by Jules for task [14335681040876698684](https://jules.google.com/task/14335681040876698684) started by @Jylhis*