### PR TITLE
⚡ Bolt: [performance improvement] Optimize org file search I/O

### DIFF
--- a/elisp/utils.el
+++ b/elisp/utils.el
@@ -31,11 +31,12 @@ Each directory will be searched recursively for .org files."
   "Find all .org files recursively in DIRECTORY, ignoring hidden folders."
   (when (and directory (file-exists-p directory) (file-directory-p directory))
     (let ((files '()))
-      (dolist (file (directory-files-recursively directory "\\.org\\'" t
+      ;; PERFORMANCE OPTIMIZATION: Pass `nil` for INCLUDE-DIRECTORIES
+      ;; to natively filter out directories without the overhead of `file-regular-p` stats
+      (dolist (file (directory-files-recursively directory "\\.org\\'" nil
                                                  (lambda (dir)
                                                    (not (string-match-p "\\(^\\|/\\)\\." (file-name-nondirectory dir))))))
-        (when (file-regular-p file)
-          (push (file-truename file) files)))
+        (push (file-truename file) files))
       (nreverse files))))
 
 (defun jotain-utils-update-org-agenda-files (&optional directories)


### PR DESCRIPTION
💡 **What**: Optimized the `jotain-utils-find-org-files-recursively` function in `elisp/utils.el` to natively filter out directories instead of doing it manually per-file. Also created `.jules/bolt.md` to document this learning.

🎯 **Why**: Previously, the function asked `directory-files-recursively` to include directories (by passing `t`) and then iterated over every matching result to manually check `(file-regular-p file)`. This forced Emacs to make a redundant `stat` system call on every single file it found. By passing `nil` instead, Emacs handles the directory filtering internally and much more efficiently.

📊 **Impact**: Reduces I/O overhead from unnecessary `stat` calls. Performance scales linearly (O(N) improvement) with the number of `.org` files found, making file finding and agenda updates tangibly faster for users with extensive setups.

🔬 **Measurement**: Verified using `nix shell nixpkgs#emacs -c emacs --batch -L elisp -L tests -l elisp/platform.el -l elisp/utils.el -l tests/test-utils.el -f ert-run-tests-batch-and-exit`. All 11 `utils` tests pass successfully in ~0.009s. Formatted via `nix run .#formatter.x86_64-linux -- elisp/utils.el`.

---
*PR created automatically by Jules for task [16908716165336158633](https://jules.google.com/task/16908716165336158633) started by @Jylhis*