### PR TITLE
🎨 Palette: [UX improvement] Better buffer names for files with identical names

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Uniquify missing
+**Learning:** Emacs' default buffer name collision strategy adds `<2>`, `<3>`, which is hard to distinguish for users with many files of the same name.
+**Action:** Always enable `uniquify` and set it to `forward` to prefix buffer names with their directory path (e.g., `src/index.ts` instead of `index.ts<2>`), improving buffer switching UX significantly.

--- a/elisp/core.el
+++ b/elisp/core.el
@@ -154,6 +154,14 @@
   :custom
   (ffap-machine-p-known 'reject)) ; Don't attempt to ping unknown hostnames
 
+(use-package uniquify
+  :ensure nil
+  :custom
+  (uniquify-buffer-name-style 'forward "Use directory names to disambiguate buffers (e.g. dir/file.txt)")
+  (uniquify-separator "/" "Use a slash to separate directory and file name")
+  (uniquify-after-kill-buffer-p t "Rename buffers when conflicts are resolved")
+  (uniquify-ignore-buffers-re "^\\*" "Ignore internal buffers"))
+
 ;;; Essential packages
 (use-package super-save
   :ensure t


### PR DESCRIPTION
- **What:** Configured the built-in `uniquify` package to prefix duplicate buffer names with their directory path (e.g., `src/index.ts` instead of `index.ts<2>`).
- **Why:** Emacs' default behavior of appending `<2>`, `<3>` makes it very difficult to distinguish between identically named files (like `index.ts`, `main.go`, `README.md`) when switching buffers.
- **Accessibility:** Reduces cognitive load and improves spatial awareness when navigating large projects with standard file naming conventions.

---
*PR created automatically by Jules for task [14839455844980906213](https://jules.google.com/task/14839455844980906213) started by @Jylhis*