### PR TITLE
🛡️ Sentinel: [HIGH] Fix directory traversal vulnerability in file trust check

### DIFF
--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -105,8 +105,7 @@
     (defun jotain-trust-local-elisp-files ()
       "Trust elisp files in the current Emacs configuration directory."
       (when (and buffer-file-name
-                 (string-prefix-p (expand-file-name user-emacs-directory)
-                                  (expand-file-name buffer-file-name)))
+                 (file-in-directory-p buffer-file-name user-emacs-directory))
         ;; Mark buffer as safe for byte-compilation
         (setq-local safe-local-variable-values
                     (append safe-local-variable-values


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The function `jotain-trust-local-elisp-files` checked if a file was inside the user's Emacs directory using `string-prefix-p`. This allowed a malicious user to craft a directory path (e.g. `~/.emacs.d-malicious/evil.el`) that would bypass the check, as it shares the same string prefix as the expected directory `~/.emacs.d`.
🎯 **Impact:** Allowed untrusted, potentially malicious Emacs Lisp files to be considered "safe" for automatic local variable evaluation (`elisp-flymake-byte-compile`), leading to potential remote code execution or data exfiltration upon byte-compilation.
🔧 **Fix:** Replaced the vulnerable `string-prefix-p` check with the native Emacs `file-in-directory-p` function, which securely handles path canonicalization and directory containment.
✅ **Verification:** Verified that `file-in-directory-p` correctly rejects prefix spoofing paths using a local `nix shell` emacs invocation, and ran the existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [6583251857777208323](https://jules.google.com/task/6583251857777208323) started by @Jylhis*