### PR TITLE
🎨 Palette: [UX] Auto-scroll compilation output to first error

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-27 - Automatic Compilation Scrolling
+**Learning:** Emacs compilation output requires manual scrolling by default, which interrupts workflow and provides a poor developer UX when identifying errors.
+**Action:** Configure the built-in `compile` package with `(compilation-scroll-output 'first-error)` to automatically scroll the compilation buffer until the first error is reached, keeping the focus on actionable feedback without manual intervention.

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -437,5 +437,10 @@
   :ensure t
   :mode "\\.vue\\'")
 
+(use-package compile
+  :ensure nil
+  :custom
+  (compilation-scroll-output 'first-error))
+
 (provide 'programming)
 ;;; programming.el ends here


### PR DESCRIPTION
💡 **What:** Configured the built-in `compile` package with `(compilation-scroll-output 'first-error)`. Also documented this learning in `.Jules/palette.md`.
🎯 **Why:** Emacs compilation output requires manual scrolling by default. When running tests or builds, this interrupts workflow. Auto-scrolling to the first error keeps focus on actionable feedback without manual intervention, drastically improving the developer experience.
📸 **Before/After:** Not directly visual (interaction change). Before, developers would have to switch to the compile buffer and scroll to find the first error. After, the buffer scrolls automatically.
♿ **Accessibility:** Reduces the number of keystrokes/mouse scrolls required to find errors during the development loop.

---
*PR created automatically by Jules for task [6868602763885428848](https://jules.google.com/task/6868602763885428848) started by @Jylhis*