### PR TITLE
🛡️ Sentinel: [security improvement] Enhance network security level

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -217,5 +217,10 @@
      ("Asia/Bangkok" "Bangkok")
      ("Asia/Shanghai" "Shanghai"))))
 
+(use-package network-stream
+  :ensure nil
+  :custom
+  (network-security-level 'high "Enhance network security for TLS/SSL connections"))
+
 (provide 'core)
 ;;; core.el ends here


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Enhance network security level

🚨 Severity: ENHANCEMENT
💡 Vulnerability: The default network security level (`network-security-level`) in Emacs is `'medium`, which might allow connections to endpoints with known vulnerabilities or weak cryptography under certain circumstances.
🎯 Impact: It leaves Emacs configurations vulnerable when communicating over untrusted networks.
🔧 Fix: By setting `network-security-level` to `'high` in `elisp/core.el`, Emacs will enforce stricter TLS/SSL connection policies, actively preventing connections to endpoints using deprecated protocols (like SSLv3 or TLSv1.0) or weak cipher suites.
✅ Verification: Ran format checks and unit tests. Inspected that Emacs core configurations correctly initialize with the new security baseline.

---
*PR created automatically by Jules for task [15093357987242253123](https://jules.google.com/task/15093357987242253123) started by @Jylhis*