### PR TITLE
🎨 Palette: Auto-scroll compile buffer to first error

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette Journal
+
+## 2024-03-28 - Compile Buffer Auto-Scrolling
+**Learning:** The default behavior of the compilation buffer does not scroll output, forcing users to manually navigate to the first error.
+**Action:** Configured `compile` package with `compilation-scroll-output` set to `'first-error` to automatically scroll output during builds.

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -9,6 +9,11 @@
   :hook
   (prog-mode . display-line-numbers-mode))
 
+(use-package compile
+  :ensure nil
+  :custom
+  (compilation-scroll-output 'first-error))
+
 (use-package treesit
   :ensure nil
   :custom


### PR DESCRIPTION
💡 **What**: Configured the built-in `compile` package with `(compilation-scroll-output 'first-error)`.
🎯 **Why**: When running builds or tests using Emacs compilation mode, the output buffer does not scroll by default. This forces users to manually scroll down or run a command to find the first error. Setting this variable automatically scrolls the buffer to the first error, providing immediate feedback.
📸 **Before/After**:
- Before: Running a build pops up a compilation buffer at the top of the output. If the error is 50 lines down, the user must scroll.
- After: The compilation buffer automatically scrolls so the first error is visible.
♿ **Accessibility**: Reduces unnecessary keystrokes and visual scanning required to locate build errors.

---
*PR created automatically by Jules for task [11210236031975203279](https://jules.google.com/task/11210236031975203279) started by @Jylhis*