### PR TITLE
Fix infinite recursion in home-manager module

### DIFF
--- a/nix/modules/home/default.nix
+++ b/nix/modules/home/default.nix
@@ -86,10 +86,10 @@ in
 
       home.packages = [ cfg.package ]
         ++ lib.optionals cfg.includeRuntimeDeps (
-          lspServers
+        lspServers
           ++ cliTools
           ++ fonts
-        );
+      );
 
       home.sessionVariables = lib.mkMerge [
         (lib.mkIf (!cfg.enableDaemon) {
@@ -107,7 +107,7 @@ in
     }
 
     # fonts.fontconfig is Linux-only in home-manager; nix-darwin doesn't have it
-    (lib.optionalAttrs (cfg.includeRuntimeDeps && pkgs.stdenv.isLinux) {
+    (lib.mkIf (cfg.includeRuntimeDeps && pkgs.stdenv.isLinux) {
       fonts.fontconfig.enable = true;
     })
   ]);


### PR DESCRIPTION
Resolves the infinite recursion error `error: infinite recursion encountered` during `checking the derivation 'checks.aarch64-linux.test-module-enabled'` when running `nix flake check`.

The issue originates from checking `pkgs.stdenv.isLinux` directly within `lib.optionalAttrs` inside `config` block. Replacing it with `lib.mkIf (cfg.includeRuntimeDeps && pkgs.stdenv.isLinux)` fixes the evaluation and ensures tests pass evaluation.

---
*PR created automatically by Jules for task [3603781315269182544](https://jules.google.com/task/3603781315269182544) started by @Jylhis*