### PR TITLE
🎨 Palette: [UX improvement] Auto-scroll compilation output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+# Palette's Journal
+
+## UX and Accessibility Learnings
+
+## 2026-03-31 - [Automatically scroll compilation output to first error]
+**Learning:** [Users find it tedious to manually scroll through compilation logs to find errors when a build fails. By default, Emacs does not scroll the compilation buffer, leaving the user at the top of the output.]
+**Action:** [Configure the built-in `compile` package in `elisp/programming.el` to set `compilation-scroll-output` to `'first-error`. This will automatically scroll the build output and stop at the first error, making it much easier to identify and fix issues immediately, greatly improving developer UX.]

--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -437,5 +437,10 @@
   :ensure t
   :mode "\\.vue\\'")
 
+(use-package compile
+  :ensure nil
+  :custom
+  (compilation-scroll-output 'first-error "Automatically scroll output during builds for improved UX"))
+
 (provide 'programming)
 ;;; programming.el ends here


### PR DESCRIPTION
💡 **What:** Configured the built-in `compile` package to automatically scroll the compilation buffer and stop at the first error.
🎯 **Why:** When developers trigger a build that fails, Emacs by default leaves the cursor at the top of the compilation buffer, forcing them to manually scroll down to find the root cause. Setting `compilation-scroll-output` to `'first-error` automatically takes the user exactly where they need to be.
📸 **Before/After:** No visual style changes, interaction change only.
♿ **Accessibility:** Reduces required keyboard/mouse interactions to navigate large text buffers after build failures, lowering cognitive and physical friction during the debug cycle.

---
*PR created automatically by Jules for task [12039954754287693763](https://jules.google.com/task/12039954754287693763) started by @Jylhis*