### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Emacs network security

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -217,5 +217,11 @@
      ("Asia/Bangkok" "Bangkok")
      ("Asia/Shanghai" "Shanghai"))))
 
+;; Network security
+(use-package network-stream
+  :ensure nil
+  :custom
+  (network-security-level 'high "Enforce strict TLS/SSL policies against deprecated protocols or weak ciphers"))
+
 (provide 'core)
 ;;; core.el ends here


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Weak TLS/SSL policies could allow deprecated protocols or weak ciphers to be used for Emacs network connections. Emacs's default `network-security-level` might not be strict enough against modern threats, leaving network streams potentially vulnerable to downgrade attacks or weak encryption.
🎯 **Impact**: Potentially enables MITM attacks or interception via weak ciphers.
🔧 **Fix**: Set `network-security-level` to `'high` via the built-in `network-stream` package. This enforces strict TLS/SSL policies globally across Emacs network connections.
✅ **Verification**: Run `just test` or `just test-smoke` locally. Tests should pass without failures, and formatting tests via `nix run .#formatter` should also be successful.

---
*PR created automatically by Jules for task [4522357737525303980](https://jules.google.com/task/4522357737525303980) started by @Jylhis*