### PR TITLE
🎨 Palette: Auto-scroll compilation output to first error

### DIFF
--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -437,5 +437,10 @@
   :ensure t
   :mode "\\.vue\\'")
 
+(use-package compile
+  :ensure nil
+  :custom
+  (compilation-scroll-output 'first-error))
+
 (provide 'programming)
 ;;; programming.el ends here


### PR DESCRIPTION
**💡 What:**
Configured the built-in `compile` package to automatically scroll its output and stop at the first error.

**🎯 Why:**
The default behavior of Emacs' compilation mode forces users to manually jump to the compilation window and scroll to find the relevant output or the reason a build failed. Setting `compilation-scroll-output` to `'first-error` eliminates this friction, providing immediate context and a much smoother developer experience.

**📸 Before/After:**
*Before*: Running a compilation (like `M-x compile`) opens a window that stays at the top of the output, requiring manual scrolling to see the result or errors.
*After*: The compilation window automatically scrolls along with the output and conveniently stops exactly at the first error encountered.

**♿ Accessibility:**
This reduces the manual interaction (keystrokes/mouse scrolls) required to diagnose build failures, making the interface more efficient and less fatiguing to use, particularly for keyboard-heavy workflows.

---
*PR created automatically by Jules for task [5973244560570373381](https://jules.google.com/task/5973244560570373381) started by @Jylhis*