### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -217,5 +217,10 @@
      ("Asia/Bangkok" "Bangkok")
      ("Asia/Shanghai" "Shanghai"))))
 
+(use-package network-stream
+  :ensure nil
+  :custom
+  (network-security-level 'high "Enforce strict TLS/SSL policies against deprecated protocols or weak ciphers."))
+
 (provide 'core)
 ;;; core.el ends here


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Emacs default network security level might allow connections over deprecated TLS versions or using weak ciphers, potentially exposing sensitive data (like credentials in `auth-source`) during transit to remote servers.
🎯 Impact: An attacker could potentially intercept or modify traffic between Emacs and remote services if weak ciphers or old protocols are used.
🔧 Fix: Configured `network-stream` to set `network-security-level` to `'high` in `elisp/core.el`, instructing Emacs to reject or warn against unsafe connections.
✅ Verification: Ran smoke tests locally via Nix which all passed. Formatted the codebase. When Emacs makes a connection to a service with a weak TLS configuration, the Network Security Manager (NSM) will now actively intervene.

---
*PR created automatically by Jules for task [15156956604920659847](https://jules.google.com/task/15156956604920659847) started by @Jylhis*