### PR TITLE
🎨 Palette: Auto-scroll compilation output to first error

### DIFF
--- a/elisp/programming.el
+++ b/elisp/programming.el
@@ -9,6 +9,11 @@
   :hook
   (prog-mode . display-line-numbers-mode))
 
+(use-package compile
+  :ensure nil
+  :custom
+  (compilation-scroll-output 'first-error))
+
 (use-package treesit
   :ensure nil
   :custom


### PR DESCRIPTION
💡 **What:** Added configuration for Emacs' built-in `compile` package to set `compilation-scroll-output` to `'first-error`.
🎯 **Why:** When running builds, tests, or other compilation commands, the output buffer normally stays at the top. Setting this variable automatically scrolls the buffer as new output arrives and intelligently stops scrolling when the first error is encountered. This saves the user from manually scrolling to find why a build failed.
♿ **Accessibility/UX:** Reduces repetitive manual scrolling and keystrokes required to diagnose build failures, making the feedback loop much more ergonomic and intuitive.

---
*PR created automatically by Jules for task [2721228063073680479](https://jules.google.com/task/2721228063073680479) started by @Jylhis*