### PR TITLE
Improve Mintlify docs: add Guides nav group, favicon, convert orphan pages to mdx

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "Jotain",
+  "favicon": "/favicon.svg",
   "colors": {
     "primary": "#7C3AED",
     "light": "#A78BFA",
@@ -34,6 +35,14 @@
               "configuration/init",
               "configuration/early-init",
               "configuration/packages"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "finding-information-in-emacs",
+              "setting-variables",
+              "inspiration"
             ]
           }
         ]

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#7C3AED"/>
+  <text x="16" y="23" font-family="monospace" font-size="20" font-weight="bold" fill="white" text-anchor="middle">J</text>
+</svg>

--- a/docs/finding-information-in-emacs.mdx
+++ b/docs/finding-information-in-emacs.mdx
@@ -1,7 +1,9 @@
-# Finding Information in Emacs
+---
+title: Finding Information in Emacs
+description: How to use Emacs' built-in help system, Info reader, and introspection tools
+---
 
-> [!NOTE]
-> AI generated
+<Note>AI generated</Note>
 
 Also covers programmatic access for scripts and AI agents via `emacs --batch`.
 

--- a/docs/inspiration.mdx
+++ b/docs/inspiration.mdx
@@ -1,18 +1,23 @@
-# Emacs
+---
+title: Inspiration & Resources
+description: Links to Emacs builds, Nix resources, and related projects
+---
+
+## Emacs
 
 Source: git://git.sv.gnu.org/emacs.git
 
-# Linux
+## Linux
 
 - https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/editors
 - https://github.com/nix-community/emacs-overlay
 
-# MacOS
+## MacOS
 - https://github.com/d12frosted/homebrew-emacs-plus
 - https://github.com/caldwell/build-emacs/tree/master
 - https://github.com/sban/emacs
 
-# Android
+## Android
 - https://mstempl.netlify.app/post/emacs-on-android/
 - https://github.com/nix-community/nix-on-droid/tree/master/pkgs
 - https://www.gnu.org/software/emacs/manual/html_node/emacs/Android.html
@@ -22,5 +27,5 @@ Source: git://git.sv.gnu.org/emacs.git
 - https://github.com/zakkak/android-emacs-toolkit
 
 
-# Nix
+## Nix
 - https://wiki.nixos.org/wiki/Emacs

--- a/docs/setting-variables.mdx
+++ b/docs/setting-variables.mdx
@@ -1,6 +1,7 @@
-# Setting Variables in Emacs Lisp
-
-Quick reference for choosing the right way to set variables in your init file.
+---
+title: Setting Variables in Emacs Lisp
+description: Quick reference for choosing the right way to set variables in your init file
+---
 
 ## Use `setopt` for user options (defcustom)
 


### PR DESCRIPTION
- Add "Guides" navigation group with finding-information-in-emacs,
  setting-variables, and inspiration pages
- Add favicon.svg and favicon field to docs.json
- Convert 3 orphan .md files to .mdx with proper frontmatter
- Convert GitHub-flavored admonitions to Mintlify <Note> components
- Normalize H1 headings to H2 in inspiration (Mintlify uses frontmatter title)

https://claude.ai/code/session_01ADQe7H8sxxqS6m2oUcYYyV