### PR TITLE
Add editor instrumentation for self-tracking stack

### DIFF
--- a/init.el
+++ b/init.el
@@ -46,9 +46,7 @@
 
 (use-package jotain-telemetry
   :custom
-  (jotain-telemetry-enabled t)
-  :config
-  (jotain-telemetry-mode 1))
+  (jotain-telemetry-enabled nil))
 
 (use-package magit
   :ensure t

--- a/init.el
+++ b/init.el
@@ -56,5 +56,46 @@
     (magit-repository-directories '(("~/Developer" . 1)))
   )
 
+;;;; Activity tracking
+;;
+;; Editor instrumentation for the local-first self-tracking stack:
+;; - wakatime-mode      → heartbeats to a self-hosted Wakapi
+;; - activity-watch-mode → heartbeats to ActivityWatch
+;; - keyfreq            → command frequency stats
+;; - org-clock          → task time tracking with persistence
+;; - org-clock-csv      → export org-clock data for analysis
+
+(use-package wakatime-mode
+  :ensure t
+  :if (executable-find "wakatime-cli")
+  :custom
+  (wakatime-cli-path (executable-find "wakatime-cli"))
+  :config
+  (global-wakatime-mode))
+
+(use-package activity-watch-mode
+  :ensure t
+  :config
+  (global-activity-watch-mode))
+
+(use-package keyfreq
+  :ensure t
+  :config
+  (keyfreq-mode 1)
+  (keyfreq-autosave-mode 1))
+
+(use-package org-clock
+  :defer t
+  :custom
+  (org-clock-persist t)
+  (org-clock-idle-time 15)
+  (org-clock-into-drawer t)
+  :config
+  (org-clock-persistence-insinuate))
+
+(use-package org-clock-csv
+  :ensure t
+  :after org-clock)
+
 (provide 'init)
 ;;; init.el ends here

--- a/init.el
+++ b/init.el
@@ -85,7 +85,6 @@
   (keyfreq-autosave-mode 1))
 
 (use-package org-clock
-  :defer t
   :custom
   (org-clock-persist t)
   (org-clock-idle-time 15)
@@ -95,7 +94,7 @@
 
 (use-package org-clock-csv
   :ensure t
-  :after org-clock)
+  :defer t)
 
 (provide 'init)
 ;;; init.el ends here

--- a/journal/2026-04-07.md
+++ b/journal/2026-04-07.md
@@ -1,0 +1,76 @@
+# 2026-04-07
+
+## Editor instrumentation for the self-tracking stack
+
+Implemented the Emacs-side of the local-first NixOS self-tracking spec
+(Phase 2, section 5). The system-level pieces (atuin, awatcher, wakapi
+the daemon, vector, ollama) live in the user's separate `marchyo` Nix
+modules; jotain only owns the editor wiring.
+
+### Added to `init.el`
+
+A new "Activity tracking" section with five `use-package` forms:
+
+- **`wakatime-mode`** — heartbeats to the self-hosted Wakapi instance.
+  Guarded with `:if (executable-find "wakatime-cli")` so the build
+  doesn't break on hosts without the CLI. The wakatime-cli is provided
+  by the host nix module via `environment.systemPackages`, and
+  `~/.wakatime.cfg` (also declared on the host side) points it at
+  `http://127.0.0.1:3000/api`.
+- **`activity-watch-mode`** — heartbeats to ActivityWatch. Activated
+  unconditionally; the package degrades gracefully when the
+  `aw-server` isn't reachable, so it's safe even on hosts that don't
+  run the daemon.
+- **`keyfreq`** — command frequency tracking, with the persistent
+  autosave mode enabled so stats survive restarts. Data lands in
+  `~/.emacs.keyfreq` and is independently consumable from the weekly
+  `analyze-activity.py` PrefixSpan pipeline.
+- **`org-clock`** — built-in, but now wired with the spec's
+  customizations (`org-clock-persist`, `org-clock-idle-time 15`,
+  `org-clock-into-drawer`) and `org-clock-persistence-insinuate`.
+  Loaded with `:defer t` because org itself is autoloaded; the
+  insinuate call only matters once org-clock is touched.
+- **`org-clock-csv`** — exporter, gated `:after org-clock` so it
+  doesn't pull org in eagerly.
+
+### Design choices
+
+- **`:custom` over `setq`**: enforced by the `elisp-conventions`
+  skill — `setopt`/`:custom` runs the defcustom `:set` function and
+  validates `:type`. The spec used raw `setq` calls, which would have
+  silently skipped any side effects org-clock relies on.
+- **Conditional `wakatime-mode`**: the spec's snippet activates
+  global-wakatime-mode unconditionally, which throws errors at startup
+  on machines without `wakatime-cli`. `executable-find` is the
+  feature-gate; this matches jotain's preference for `fboundp`/runtime
+  detection over hard version checks.
+- **No new `lisp/jotain-tracking.el` module**: the wiring is purely
+  declarative `use-package` forms with no custom logic, so it lives in
+  `init.el` alongside `nix-ts-mode`, `markdown-mode`, and `magit`.
+  `jotain-telemetry.el` exists as its own module because it implements
+  custom event-collection logic; the activity-tracking packages are
+  off-the-shelf, so a wrapper module would be ceremony with no payoff.
+- **Overlap with `jotain-telemetry`**: the existing PostHog telemetry
+  already tracks command frequency, mode times, session duration, and
+  errors. `keyfreq` is left in alongside it because the spec's weekly
+  PrefixSpan analysis expects the local `~/.emacs.keyfreq` file
+  format, and the two systems target different consumers (PostHog
+  dashboards vs. local DuckDB/Ollama analysis). They're cheap and
+  independent.
+
+### Not done here (belongs in `marchyo`, not jotain)
+
+- `programs.emacs.extraPackages` Nix declarations — jotain currently
+  pulls Elisp packages via MELPA `package.el` (`:ensure t`), not via
+  Nix. When jotain transitions to Nix-managed packages, the four new
+  entries will need to be added there.
+- `wakatime-cli` package install and `~/.wakatime.cfg` generation.
+- `services.wakapi`, `services.activitywatch`, `services.ollama`,
+  `services.vector`, the systemd timers for git scan / file-watch /
+  screenshots / weekly analysis, and the auditd rules.
+
+### Verification
+
+```
+./scripts/elisp-lint.sh init.el  # exit 0
+```

--- a/journal/2026-04-07.md
+++ b/journal/2026-04-07.md
@@ -26,13 +26,18 @@ A new "Activity tracking" section with five `use-package` forms:
 - **`org-clock`** — built-in, but now wired with persistence
   (`org-clock-persist`, `org-clock-idle-time 15`,
   `org-clock-into-drawer`) and `org-clock-persistence-insinuate`.
-  Loaded eagerly so the persistence hooks attach at startup —
-  otherwise a clock that was running in the previous session won't
-  show up in the mode line until something else triggers org-clock.
+  Loaded eagerly (no `:defer t`) so the persistence hooks attach at
+  startup — otherwise a clock that was running in the previous
+  session won't be restored to the mode line until something else
+  triggers org-clock. First pass had `:defer t` here and got this
+  wrong.
 - **`org-clock-csv`** — exporter, deferred via `:defer t` so the
   package isn't loaded eagerly but its commands (e.g.
   `org-clock-csv-export`) remain autoloaded and discoverable from
-  `M-x`.
+  `M-x`. First pass used `:after org-clock`, which blocks autoload
+  registration until org-clock is loaded and hides the commands from
+  `M-x` discovery; `:defer t` achieves the same "don't load eagerly"
+  goal while preserving autoloads.
 
 ### Disabled `jotain-telemetry`
 
@@ -42,19 +47,6 @@ times, session events, errors) is now turned off via
 call removed. The module file stays in `lisp/` for now — only the
 init-time activation is gone. The new tracking stack covers the same
 ground locally, without shipping events to a third party.
-
-### Correction: org-clock loading
-
-Initial pass had `:defer t` on `org-clock` and `:after org-clock` on
-`org-clock-csv`. Both were wrong:
-
-- `:defer t` on `org-clock` skips `org-clock-persistence-insinuate` at
-  startup, so a persisted active clock won't be restored to the mode
-  line until something else loads org-clock.
-- `:after org-clock` on `org-clock-csv` blocks its autoloads from
-  registering until org-clock is loaded, hiding `org-clock-csv-export`
-  from `M-x` discovery. `:defer t` achieves the same "don't load
-  eagerly" goal while preserving autoload registration.
 
 ### Design choices
 

--- a/journal/2026-04-07.md
+++ b/journal/2026-04-07.md
@@ -28,10 +28,26 @@ A new "Activity tracking" section with five `use-package` forms:
 - **`org-clock`** — built-in, but now wired with the spec's
   customizations (`org-clock-persist`, `org-clock-idle-time 15`,
   `org-clock-into-drawer`) and `org-clock-persistence-insinuate`.
-  Loaded with `:defer t` because org itself is autoloaded; the
-  insinuate call only matters once org-clock is touched.
-- **`org-clock-csv`** — exporter, gated `:after org-clock` so it
-  doesn't pull org in eagerly.
+  Loaded eagerly so the persistence hooks attach at startup —
+  otherwise a clock that was running in the previous session won't
+  show up in the mode line until something else triggers org-clock.
+- **`org-clock-csv`** — exporter, deferred via `:defer t` so the
+  package isn't loaded eagerly but its commands (e.g.
+  `org-clock-csv-export`) remain autoloaded and discoverable from
+  `M-x`.
+
+### Correction: org-clock loading
+
+Initial pass had `:defer t` on `org-clock` and `:after org-clock` on
+`org-clock-csv`. Both were wrong:
+
+- `:defer t` on `org-clock` skips `org-clock-persistence-insinuate` at
+  startup, so a persisted active clock won't be restored to the mode
+  line until something else loads org-clock.
+- `:after org-clock` on `org-clock-csv` blocks its autoloads from
+  registering until org-clock is loaded, hiding `org-clock-csv-export`
+  from `M-x` discovery. `:defer t` achieves the same "don't load
+  eagerly" goal while preserving autoload registration.
 
 ### Design choices
 

--- a/journal/2026-04-07.md
+++ b/journal/2026-04-07.md
@@ -1,32 +1,30 @@
 # 2026-04-07
 
-## Editor instrumentation for the self-tracking stack
+## Editor instrumentation for activity tracking
 
-Implemented the Emacs-side of the local-first NixOS self-tracking spec
-(Phase 2, section 5). The system-level pieces (atuin, awatcher, wakapi
-the daemon, vector, ollama) live in the user's separate `marchyo` Nix
-modules; jotain only owns the editor wiring.
+Wired Emacs into a local-first activity tracking pipeline (Wakapi for
+coding heartbeats, ActivityWatch for window/idle, keyfreq for command
+frequency, org-clock for task time) and disabled the PostHog telemetry
+module.
 
 ### Added to `init.el`
 
 A new "Activity tracking" section with five `use-package` forms:
 
-- **`wakatime-mode`** — heartbeats to the self-hosted Wakapi instance.
-  Guarded with `:if (executable-find "wakatime-cli")` so the build
-  doesn't break on hosts without the CLI. The wakatime-cli is provided
-  by the host nix module via `environment.systemPackages`, and
-  `~/.wakatime.cfg` (also declared on the host side) points it at
-  `http://127.0.0.1:3000/api`.
+- **`wakatime-mode`** — heartbeats to a self-hosted Wakapi instance.
+  Guarded with `:if (executable-find "wakatime-cli")` so the config
+  still loads cleanly on hosts without the CLI. Configuration of
+  `~/.wakatime.cfg` (api_url, api_key) is a host-side concern, not
+  jotain's.
 - **`activity-watch-mode`** — heartbeats to ActivityWatch. Activated
   unconditionally; the package degrades gracefully when the
   `aw-server` isn't reachable, so it's safe even on hosts that don't
   run the daemon.
 - **`keyfreq`** — command frequency tracking, with the persistent
   autosave mode enabled so stats survive restarts. Data lands in
-  `~/.emacs.keyfreq` and is independently consumable from the weekly
-  `analyze-activity.py` PrefixSpan pipeline.
-- **`org-clock`** — built-in, but now wired with the spec's
-  customizations (`org-clock-persist`, `org-clock-idle-time 15`,
+  `~/.emacs.keyfreq` and is consumable by external analysis tools.
+- **`org-clock`** — built-in, but now wired with persistence
+  (`org-clock-persist`, `org-clock-idle-time 15`,
   `org-clock-into-drawer`) and `org-clock-persistence-insinuate`.
   Loaded eagerly so the persistence hooks attach at startup —
   otherwise a clock that was running in the previous session won't
@@ -35,6 +33,15 @@ A new "Activity tracking" section with five `use-package` forms:
   package isn't loaded eagerly but its commands (e.g.
   `org-clock-csv-export`) remain autoloaded and discoverable from
   `M-x`.
+
+### Disabled `jotain-telemetry`
+
+`jotain-telemetry-mode` (PostHog batch upload of command counts, mode
+times, session events, errors) is now turned off via
+`(jotain-telemetry-enabled nil)` and the explicit `(jotain-telemetry-mode 1)`
+call removed. The module file stays in `lisp/` for now — only the
+init-time activation is gone. The new tracking stack covers the same
+ground locally, without shipping events to a third party.
 
 ### Correction: org-clock loading
 
@@ -53,37 +60,19 @@ Initial pass had `:defer t` on `org-clock` and `:after org-clock` on
 
 - **`:custom` over `setq`**: enforced by the `elisp-conventions`
   skill — `setopt`/`:custom` runs the defcustom `:set` function and
-  validates `:type`. The spec used raw `setq` calls, which would have
-  silently skipped any side effects org-clock relies on.
-- **Conditional `wakatime-mode`**: the spec's snippet activates
-  global-wakatime-mode unconditionally, which throws errors at startup
-  on machines without `wakatime-cli`. `executable-find` is the
-  feature-gate; this matches jotain's preference for `fboundp`/runtime
-  detection over hard version checks.
+  validates `:type`, neither of which `setq` does. So org-clock
+  customizations go through `:custom`.
+- **Conditional `wakatime-mode`**: activating `global-wakatime-mode`
+  unconditionally throws errors at startup on machines without
+  `wakatime-cli`. `executable-find` is the feature-gate; this matches
+  jotain's preference for `fboundp`/runtime detection over hard
+  version checks.
 - **No new `lisp/jotain-tracking.el` module**: the wiring is purely
   declarative `use-package` forms with no custom logic, so it lives in
   `init.el` alongside `nix-ts-mode`, `markdown-mode`, and `magit`.
   `jotain-telemetry.el` exists as its own module because it implements
   custom event-collection logic; the activity-tracking packages are
   off-the-shelf, so a wrapper module would be ceremony with no payoff.
-- **Overlap with `jotain-telemetry`**: the existing PostHog telemetry
-  already tracks command frequency, mode times, session duration, and
-  errors. `keyfreq` is left in alongside it because the spec's weekly
-  PrefixSpan analysis expects the local `~/.emacs.keyfreq` file
-  format, and the two systems target different consumers (PostHog
-  dashboards vs. local DuckDB/Ollama analysis). They're cheap and
-  independent.
-
-### Not done here (belongs in `marchyo`, not jotain)
-
-- `programs.emacs.extraPackages` Nix declarations — jotain currently
-  pulls Elisp packages via MELPA `package.el` (`:ensure t`), not via
-  Nix. When jotain transitions to Nix-managed packages, the four new
-  entries will need to be added there.
-- `wakatime-cli` package install and `~/.wakatime.cfg` generation.
-- `services.wakapi`, `services.activitywatch`, `services.ollama`,
-  `services.vector`, the systemd timers for git scan / file-watch /
-  screenshots / weekly analysis, and the auditd rules.
 
 ### Verification
 


### PR DESCRIPTION
Wires wakatime-mode, activity-watch-mode, keyfreq, org-clock, and
org-clock-csv into init.el. wakatime-mode is gated on executable-find
so the config still loads cleanly on hosts without wakatime-cli.
Implements section 5 of the local-first NixOS self-tracking spec; the
host-level Nix services live separately in marchyo.