### PR TITLE
Wire pre-commit, CI, flake, and reproducible package set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Evaluate nix expressions
+        run: ./scripts/nix-eval-check.sh
+
+      - name: Lint elisp
+        run: |
+          status=0
+          for f in lisp/*.el test/*.el; do
+            [ -e "$f" ] || continue
+            ./scripts/elisp-lint.sh "$f" || status=$?
+          done
+          exit "$status"
+
+      - name: Run ERT suite
+        run: |
+          nix-shell -p emacs-nox --run \
+            'emacs --batch -L lisp -L test -l test/jotain-run-tests.el -f ert-run-tests-batch-and-exit'
+
+  build:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Build jotain emacs distribution
+        run: nix-build default.nix --no-out-link

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ devenv.local.yaml
 # direnv
 .direnv
 
-# pre-commit
-.pre-commit-config.yaml
 
 # Nix
 result

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Pre-commit hooks for jotain.
+#
+# Install once after entering the devenv shell:
+#   pre-commit install
+#
+# All hooks shell out to scripts in scripts/ so the same logic runs
+# from the Justfile, CI, and pre-commit.
+repos:
+  - repo: local
+    hooks:
+      - id: treefmt
+        name: treefmt
+        entry: treefmt
+        language: system
+        pass_filenames: false
+
+      - id: elisp-lint
+        name: elisp-lint
+        entry: ./scripts/elisp-lint.sh
+        language: script
+        files: \.el$
+
+      - id: nix-eval-check
+        name: nix-eval-check
+        entry: ./scripts/nix-eval-check.sh
+        language: script
+        files: \.nix$
+        pass_filenames: false

--- a/Justfile
+++ b/Justfile
@@ -67,7 +67,38 @@ run *ARGS:
 clean:
   rm -rf eln-cache result custom.el transient elpa auto-save-list
 
-# ── Tests ──────────────────────────────────────────────────────────
+# ── Tests / lint / check ───────────────────────────────────────────
 
+# Run the full ERT suite via the aggregate loader.  Prefers the
+# devenv-provided emacs when available so the recipe works on hosts
+# without a system emacs in PATH.
 test:
-  emacs --batch -L lisp -L test -l test/jotain-telemetry-test.el -f ert-run-tests-batch-and-exit
+  #!/usr/bin/env bash
+  set -euo pipefail
+  if command -v emacs >/dev/null 2>&1; then
+    emacs --batch -L lisp -L test -l test/jotain-run-tests.el -f ert-run-tests-batch-and-exit
+  else
+    devenv shell -- emacs --batch -L lisp -L test -l test/jotain-run-tests.el -f ert-run-tests-batch-and-exit
+  fi
+
+# Lint every .el file under lisp/ and test/.
+lint:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  status=0
+  for f in lisp/*.el test/*.el; do
+    [ -e "$f" ] || continue
+    ./scripts/elisp-lint.sh "$f" || status=$?
+  done
+  exit "$status"
+
+# Format the tree via treefmt (provided by devenv).
+fmt:
+  treefmt
+
+# Verify nix expressions evaluate.
+nix-check:
+  ./scripts/nix-eval-check.sh
+
+# Run lint + nix-check + tests — the same gates CI runs.
+check: lint nix-check test

--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,20 @@ let
   emacsArgs = builtins.removeAttrs args [ "withTreeSitterGrammars" ];
   emacs = import ./emacs.nix emacsArgs;
 
+  # MELPA / ELPA packages that init.el expects.  Provided via Nix so
+  # the wrapper is reproducible — :ensure t in init.el becomes a
+  # no-op because the packages are already on the load-path.
+  jotainEmacsPackages =
+    epkgs: with epkgs; [
+      magit
+      nix-ts-mode
+      markdown-mode
+      wakatime-mode
+      activity-watch-mode
+      keyfreq
+      org-clock-csv
+    ];
+
   # All tree-sitter grammars for Emacs (275 grammars from nixpkgs)
   # Uses the NixOS-recommended emacsPackages.treesit-grammars mechanism:
   # https://wiki.nixos.org/wiki/Emacs
@@ -35,9 +49,7 @@ let
     );
 
 in
-if withTreeSitterGrammars then
-  (pkgs.emacsPackagesFor emacs).withPackages (epkgs: [
-    (allTreeSitterGrammars epkgs)
-  ])
-else
-  emacs
+(pkgs.emacsPackagesFor emacs).withPackages (
+  epkgs:
+  (jotainEmacsPackages epkgs) ++ lib.optional withTreeSitterGrammars (allTreeSitterGrammars epkgs)
+)

--- a/devenv.nix
+++ b/devenv.nix
@@ -31,6 +31,18 @@
     };
   };
 
+  # Pre-commit binary lives in the dev shell so contributors can
+  # `pre-commit install` once and let `.pre-commit-config.yaml` (in
+  # the repo root) drive the actual hooks.  This avoids pulling in
+  # the cachix/git-hooks.nix flake input.
+  packages = [ pkgs.pre-commit ];
+
+  enterShell = ''
+    if [ -d .git ] && [ ! -f .git/hooks/pre-commit ]; then
+      pre-commit install --install-hooks >/dev/null 2>&1 || true
+    fi
+  '';
+
   claude.code = {
     enable = true;
     mcpServers = {

--- a/early-init.el
+++ b/early-init.el
@@ -9,6 +9,22 @@
 ;;; Code:
 
 (message "Early start of Jotain")
+
+;; Defer GC during startup, then restore a sane threshold.  Shaves real
+;; time off init by avoiding GC runs while the bulk of bytecode is loaded.
+(setq gc-cons-threshold most-positive-fixnum)
+
+(defun jotain--restore-gc-threshold ()
+  "Restore `gc-cons-threshold' to a normal value after startup."
+  (setq gc-cons-threshold (* 16 1024 1024)))
+
+(add-hook 'emacs-startup-hook #'jotain--restore-gc-threshold)
+
+;; `init.el' calls `package-initialize' explicitly, so suppress the
+;; automatic init that would otherwise run between early-init and init —
+;; without this, package.el initializes twice.
+(setq package-enable-at-startup nil)
+
 ;; In noninteractive sessions, prioritize non-byte-compiled source files to
 ;; prevent the use of stale byte-code. Otherwise, it saves us a little IO time
 ;; to skip the mtime checks on every *.elc file.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Jotain — a custom GNU Emacs distribution";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        # `nix build` → the wrapped Emacs distribution.  Forwards into
+        # the existing default.nix so the classic build path
+        # (`nix-build default.nix`) and the flake build stay in sync.
+        packages = {
+          default = import ./default.nix { inherit system pkgs; };
+          emacs-nox = import ./default.nix {
+            inherit system pkgs;
+            noGui = true;
+          };
+          emacs-pgtk = import ./default.nix {
+            inherit system pkgs;
+            withPgtk = true;
+          };
+        };
+
+        # `nix develop` → a thin shell with just the host tools needed
+        # to drive the Justfile.  The full devenv (treefmt, eask,
+        # ellsp, git-hooks, ...) still lives in `devenv.nix` and is
+        # entered via `devenv shell`.
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.just
+            pkgs.nix
+            pkgs.emacs-nox
+          ];
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
+}

--- a/journal/2026-04-07.md
+++ b/journal/2026-04-07.md
@@ -71,3 +71,196 @@ ground locally, without shipping events to a third party.
 ```
 ./scripts/elisp-lint.sh init.el  # exit 0
 ```
+
+## Dev environment smoke test & analysis
+
+Verified the development environment from a fresh sandbox shell.
+
+### What was verified
+
+- `devenv shell` enters cleanly (~22s cold). Inside the shell:
+  - `emacs` → `emacs-nox 30.2` from `/nix/store/...`
+  - `eask` → 0.12.9
+  - `treefmt`, `nixfmt`, `python3 3.13.12` all present
+  - `nix-build`, `just`, `git` available on host
+- `just test` equivalent (`emacs --batch -L lisp -L test -l
+  test/jotain-telemetry-test.el -f ert-run-tests-batch-and-exit`)
+  passes **41/41** ERT tests in ~6 ms.
+- `lsp.enable = false` in `devenv.nix` correctly suppresses the
+  `ellsp` build (which would otherwise pull node + buildNpmPackage
+  on every shell entry).
+
+### Friction observed
+
+- Bare `bash -c` in this sandbox inherits `PATH=/root/.nix-profile/bin:$PATH`
+  with the literal string `$PATH` unexpanded, so `git`, `ls`, etc. are
+  missing until PATH is explicitly fixed. This is a sandbox quirk, not
+  a jotain issue, but worth noting for future automation.
+
+### Improvement suggestions (analysis only — not yet applied)
+
+1. **Pre-commit hooks are referenced but not wired.** `.gitignore`
+   excludes `.pre-commit-config.yaml`, `scripts/nix-eval-check.sh`'s
+   header says "Intended as a pre-commit check", and `treefmt` is
+   already enabled in `devenv.nix` — but no `git-hooks.hooks` block
+   exists. Adding a `git-hooks` (or `pre-commit`) section to
+   `devenv.nix` to run `treefmt`, `scripts/elisp-lint.sh`, and
+   `scripts/nix-eval-check.sh` would close the loop and make the
+   existing scripts actually fire.
+
+2. **No CI workflow.** No `.github/workflows/`. A minimal job that
+   runs `nix-build default.nix` (or just `emacs.nix`) plus the ERT
+   suite would catch regressions on PRs. The build is binary-cached
+   so cost is low.
+
+3. **`just test` doesn't go through devenv.** It calls bare `emacs`,
+   so it only works inside the devenv shell or on hosts that already
+   have an Emacs in `PATH`. Either invoke via `devenv shell -- ...`
+   or document the requirement. Also: it hardcodes one test file —
+   adding more test files later means editing the recipe. Loading
+   all `test/*-test.el` via a small loader (or `eask test`) would
+   scale better.
+
+4. **Hardcoded PostHog API key in `lisp/jotain-telemetry.el:34`.**
+   Even though telemetry is disabled by default, shipping a real
+   write key in source isn't ideal — anyone running with
+   `jotain-telemetry-enabled t` and no env override sends to the
+   author's project. Suggest defaulting to `nil` and requiring
+   `POSTHOG_API_KEY` (or a per-host customize file) to opt in.
+
+5. **`init.el` mixes MELPA `:ensure t` with the Nix-built Emacs.**
+   Tree-sitter grammars are managed reproducibly via Nix, but
+   `magit`, `nix-ts-mode`, `markdown-mode`, `wakatime-mode`,
+   `activity-watch-mode`, `keyfreq`, `org-clock-csv` come from
+   MELPA at runtime. That undermines the reproducibility story of
+   `default.nix`. Two paths forward: (a) move these into
+   `default.nix` via `emacsPackagesFor` / `withPackages` so the
+   wrapper ships them, or (b) explicitly document that MELPA is the
+   source of truth for non-grammar packages and Nix only provides
+   the Emacs binary + grammars.
+
+6. **`early-init.el` could raise `gc-cons-threshold` for startup.**
+   The standard `(setq gc-cons-threshold most-positive-fixnum)` +
+   reset on `emacs-startup-hook` shaves real time off init. Also
+   missing: `(setq package-enable-at-startup nil)` if the intent is
+   to manage activation manually (currently `init.el` calls
+   `package-initialize` explicitly, so the early-init's silence on
+   this means package.el initializes twice).
+
+7. **`devenv.yaml` has no flake.** Project mixes `devenv.yaml`
+   inputs (devenv-style) with classic `default.nix` (channels via
+   `<nixpkgs>`). A `flake.nix` would unify input pinning, let
+   `nix build` work without `<nixpkgs>` in `NIX_PATH`, and let
+   devenv consume the same locked nixpkgs.
+
+8. **`scripts/elisp-lint.sh` is regex-only.** It catches obvious
+   issues but won't see e.g. unbalanced parens, undefined symbols,
+   docstring problems. Running `emacs --batch -f
+   batch-byte-compile` (or `package-lint` / `checkdoc`) on `.el`
+   files would add a real lint pass for cheap.
+
+9. **Tests have no aggregate runner.** Adding `lisp/`-wide test
+   loader (`(dolist (f (directory-files "test" t "-test\\.el$"))
+   (load f))`) avoids hand-listing each module in the Justfile.
+
+10. **`jotain-telemetry-test.el` uses `(setenv "POSTHOG_API_KEY"
+    nil)` to "neutralize" the env var.** This works in modern Emacs
+    (which treats nil-value `setenv` as `unsetenv`), but is
+    deprecated; `unsetenv` is the documented form.
+
+No code changes made — these are observations from reading the
+config. Happy to implement any of them on request.
+
+## Implementation pass
+
+Followed up by implementing 9 of the 10 suggestions above (#10 was
+reverted — see below).
+
+### Done
+
+1. **Pre-commit wired** — added `.pre-commit-config.yaml` (treefmt,
+   `scripts/elisp-lint.sh`, `scripts/nix-eval-check.sh`) and put
+   `pkgs.pre-commit` into `devenv.nix` packages with an `enterShell`
+   hook that runs `pre-commit install` on first shell entry.
+   Removed `.pre-commit-config.yaml` from `.gitignore`.
+
+   I tried the cleaner devenv-native `git-hooks.hooks` block first,
+   but adding the `git-hooks.nix` flake input requires devenv to
+   re-lock — and devenv 2.0.6's internal locker fails in this
+   sandbox (DNS for `github.com` from inside its lock fetcher
+   doesn't honor the HTTP proxy, even though every other tool here
+   does). The vanilla pre-commit path needs no new flake input and
+   is identical in user-visible behavior.
+
+2. **CI workflow** — `.github/workflows/ci.yml` runs nix-eval-check,
+   elisp-lint over every `lisp/*.el` and `test/*.el`, the ERT suite
+   via `jotain-run-tests.el`, and `nix-build default.nix`. Cancels
+   in-progress runs on the same ref. Triggers on push to
+   `main`/`next` and on PRs.
+
+3. **`just test` is devenv-aware** — wraps the emacs invocation in
+   `command -v emacs` and falls back to `devenv shell --` so it
+   works from a bare host shell. Also added `just lint`,
+   `just fmt`, `just nix-check`, and `just check` (lint + nix-check
+   + test — the same gates CI runs).
+
+4. **PostHog API key default → nil** in `lisp/jotain-telemetry.el`.
+   The hardcoded write key is gone; users must opt in via
+   `customize` or `POSTHOG_API_KEY`.
+
+5. **MELPA packages bundled via Nix** — `default.nix` now feeds
+   `magit`, `nix-ts-mode`, `markdown-mode`, `wakatime-mode`,
+   `activity-watch-mode`, `keyfreq`, `org-clock-csv` through
+   `(emacsPackagesFor emacs).withPackages`. All seven exist in
+   `nixpkgs.emacsPackages` (verified by attribute probe). The
+   `:ensure t` lines in `init.el` become harmless no-ops because
+   the packages are already on the load-path.
+
+6. **Startup tweaks in `early-init.el`** — defer GC during startup
+   via `(setq gc-cons-threshold most-positive-fixnum)` and a named
+   `jotain--restore-gc-threshold` reset on `emacs-startup-hook`
+   (named function, not a lambda — the linter complains about
+   lambdas in `add-hook`). Also `(setq package-enable-at-startup
+   nil)` so package.el doesn't double-init alongside `init.el`'s
+   explicit `(package-initialize)`.
+
+7. **`flake.nix`** — minimal wrapper exposing
+   `packages.default` / `emacs-nox` / `emacs-pgtk` (each `import
+   ./default.nix { … }`), a thin `devShells.default` with just
+   `just` + `nix` + `emacs-nox` (the heavy devenv stays in
+   `devenv.nix`), and `formatter = nixfmt-rfc-style`.
+
+8. **Real byte-compile in `scripts/elisp-lint.sh`** — runs
+   `emacs -Q --batch -L <dir> -f batch-byte-compile FILE`. Errors
+   fail the script; warnings are reported but non-fatal.
+   Auto-includes the sibling `lisp/` on the load-path when linting
+   `test/*.el` so `(require 'jotain-telemetry)` resolves. Cleans up
+   the produced `.elc` via a trap.
+
+9. **Aggregate test loader** — `test/jotain-run-tests.el`
+   `directory-files`-loads every `*-test.el`, used by both the
+   Justfile and CI so adding new test modules requires zero
+   recipe edits.
+
+### Reverted
+
+10. **`(setenv VAR nil)` → `(unsetenv VAR)`** — wrong premise. The
+    `nixpkgs` `emacs-nox 30.2` build's `env.elc` does **not**
+    define `unsetenv` as a function (verified: `(symbol-function
+    'unsetenv)` → `nil` even after `(require 'env)`; `(featurep
+    'env)` → `t`). `setenv` is a C subr in this build. So
+    `(setenv VAR nil)` is the supported pattern here, not a
+    deprecated form. Reverted the test macros back to their
+    original shape.
+
+### Verification
+
+Inside `devenv shell`:
+
+- `just check` → lint + nix-eval-check + 41/41 ERT tests, all
+  green.
+- `nix-instantiate default.nix` → produces
+  `emacs-with-packages-30.2.drv`.
+- `treefmt --fail-on-change` → 0 changed.
+- `pre-commit` binary present at
+  `/nix/store/...-pre-commit-4.5.1/bin/pre-commit`.

--- a/lisp/jotain-telemetry.el
+++ b/lisp/jotain-telemetry.el
@@ -31,9 +31,12 @@
 Telemetry is still silently disabled if no API key is configured."
   :type 'boolean)
 
-(defcustom jotain-telemetry-api-key "phc_IKKkL2DWB3zpFreX1quIuHNI7MBnaUOkA8HUpTP5taX"
+(defcustom jotain-telemetry-api-key nil
   "PostHog project API key (write-only).
-The environment variable POSTHOG_API_KEY takes precedence."
+Defaults to nil so jotain ships with telemetry effectively disabled
+even if `jotain-telemetry-enabled' is flipped on.  Set this via
+`customize-variable' or let the environment variable
+POSTHOG_API_KEY take precedence."
   :type '(choice (const :tag "None" nil) string))
 
 (defcustom jotain-telemetry-host "https://eu.i.posthog.com"

--- a/scripts/elisp-lint.sh
+++ b/scripts/elisp-lint.sh
@@ -60,6 +60,35 @@ if grep -qn "(add-hook '.*-hook.*(lambda" "$FILE"; then
   WARNINGS=$((WARNINGS + 1))
 fi
 
+# 9. Real byte-compile pass — catches unbalanced parens, undefined
+# symbols, free variables, and obsolete functions that the regex checks
+# above can't see.  Errors fail; warnings are reported but don't fail.
+if command -v emacs >/dev/null 2>&1; then
+  bc_log=$(mktemp)
+  trap 'rm -f "$bc_log" "${FILE%.el}.elc"' EXIT
+  load_dir="$(dirname "$FILE")"
+  # When linting under test/, the sibling lisp/ holds the modules under
+  # test, so put it on the load path too.
+  extra_load_args=()
+  if [ -d "$(dirname "$FILE")/../lisp" ]; then
+    extra_load_args+=(-L "$(dirname "$FILE")/../lisp")
+  fi
+  if ! emacs -Q --batch \
+       -L "$load_dir" \
+       "${extra_load_args[@]}" \
+       --eval "(setq byte-compile-error-on-warn nil)" \
+       -f batch-byte-compile "$FILE" >"$bc_log" 2>&1; then
+    cat "$bc_log"
+    echo "ERROR [$FILE]: Byte-compile failed"
+    ERRORS=$((ERRORS + 1))
+  else
+    if grep -q "Warning" "$bc_log"; then
+      grep "Warning" "$bc_log" | head -10
+      WARNINGS=$((WARNINGS + 1))
+    fi
+  fi
+fi
+
 # Summary
 if [ $ERRORS -gt 0 ] || [ $WARNINGS -gt 0 ]; then
   echo "---"

--- a/test/jotain-run-tests.el
+++ b/test/jotain-run-tests.el
@@ -1,0 +1,23 @@
+;;; jotain-run-tests.el --- Aggregate ERT runner for jotain -*- lexical-binding:t; -*-
+
+;;; Commentary:
+
+;; Loads every `*-test.el' file under this directory and runs all ERT
+;; tests in batch mode.  Used by the Justfile and CI to avoid having
+;; to hand-list each test module.
+;;
+;; Usage:
+;;   emacs --batch -L lisp -L test -l test/jotain-run-tests.el \
+;;         -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+
+(let* ((this-file (or load-file-name buffer-file-name))
+       (test-dir (file-name-directory this-file)))
+  (dolist (f (directory-files test-dir t "-test\\.el\\'"))
+    (load f nil t)))
+
+(provide 'jotain-run-tests)
+;;; jotain-run-tests.el ends here


### PR DESCRIPTION
Implement the dev-environment improvements identified in today's journal pass:

- Pre-commit hooks via .pre-commit-config.yaml + pkgs.pre-commit in devenv.nix, with an enterShell installer.  Hooks shell out to the existing scripts/elisp-lint.sh and scripts/nix-eval-check.sh, and to treefmt.
- GitHub Actions workflow (.github/workflows/ci.yml) running nix-eval-check, elisp-lint over lisp/ + test/, the ERT suite via the new aggregate runner, and nix-build default.nix.
- Justfile gains lint / fmt / nix-check / check targets, and the test recipe transparently re-enters devenv when emacs is not on PATH.  Tests now load via test/jotain-run-tests.el so adding new test modules requires no recipe edits.
- default.nix bundles magit, nix-ts-mode, markdown-mode, wakatime-mode, activity-watch-mode, keyfreq, and org-clock-csv through emacsPackagesFor so the wrapped Emacs is reproducible end-to-end; init.el's :ensure t becomes a no-op.
- Minimal flake.nix wrapping default.nix for nix build / nix develop, with formatter = nixfmt-rfc-style.
- early-init.el defers GC during startup and sets package-enable-at-startup nil so package.el does not double-init alongside init.el's explicit (package-initialize).
- jotain-telemetry-api-key now defaults to nil; the hardcoded PostHog write key is gone.
- scripts/elisp-lint.sh adds a real byte-compile pass that catches unbalanced parens, undefined symbols, and obsolete functions (errors fail; warnings non-fatal).  Auto-extends the load path with sibling lisp/ when linting under test/.

Verified inside devenv shell: just check is green (lint + nix-eval-check + 41/41 ERT tests), nix-instantiate default.nix produces emacs-with-packages-30.2.drv, and treefmt --fail-on-change reports 0 changed.

https://claude.ai/code/session_018EbKWCEHGrVUUFdTqygbXD