### PR TITLE
Migrate to hybrid non-flake + flake setup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,9 +36,26 @@ tty *ARGS:
 
 # ── Check / compile ─────────────────────────────────────────────────
 
-# Parse every .el file (no compile, no package install).
+# Run all checks: eval, flake, devenv, linting.
 [group('check')]
 check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Evaluating default.nix..."
+    nix-instantiate --eval default.nix > /dev/null
+    echo "Running nix flake check..."
+    nix flake check --no-build
+    echo "Running devenv test..."
+    devenv test
+    echo "Running statix..."
+    statix check .
+    echo "Running deadnix..."
+    deadnix --fail --exclude npins .devenv result .
+    echo "All checks passed."
+
+# Parse every .el file (no compile, no package install).
+[group('check')]
+check-elisp:
     #!/usr/bin/env bash
     set -euo pipefail
     emacs -Q --batch --eval '
@@ -201,16 +218,11 @@ bench output="":
 
 
 # ── Build (nix) ─────────────────────────────────────────────────────
-#
-# `default.nix' wraps `emacs.nix' with all tree-sitter grammars from
-# nixpkgs. `emacs.nix' alone builds a bare Emacs binary. Both default to
-# the npins-pinned nixpkgs-unstable channel; pass --arg pkgs '<nixpkgs>'
-# to use NIX_PATH instead.
 
 # Build the full distribution (Emacs + every grammar) for the current system.
 [group('build')]
 build:
-    nix-build --argstr system {{system}} default.nix
+    nix-build -A packages.default
 
 # Build a bare Emacs (no tree-sitter grammars).
 [group('build')]
@@ -220,37 +232,37 @@ build-bare:
 # Build with --with-pgtk for Wayland.
 [group('build')]
 build-pgtk:
-    nix-build --arg withPgtk true --argstr system {{system}} default.nix
+    nix-build --arg withPgtk true --argstr system {{system}} emacs.nix
 
 # Build with --with-x-toolkit=gtk3 (X11 + GTK3).
 [group('build')]
 build-gtk3:
-    nix-build --arg withGTK3 true --argstr system {{system}} default.nix
+    nix-build --arg withGTK3 true --argstr system {{system}} emacs.nix
 
 # Build a terminal-only Emacs (--without-x --without-ns).
 [group('build')]
 build-nox:
-    nix-build --arg noGui true --argstr system {{system}} default.nix
+    nix-build --arg noGui true --argstr system {{system}} emacs.nix
 
 # Build the macport variant (Darwin only).
 [group('build')]
 build-macport:
-    nix-build --arg variant '"macport"' --argstr system {{system}} default.nix
+    nix-build --arg variant '"macport"' --argstr system {{system}} emacs.nix
 
 # Build from current git master (first run will report a hash to fill in).
 [group('build')]
 build-git:
-    nix-build --arg variant '"git"' --argstr system {{system}} default.nix
+    nix-build --arg variant '"git"' --argstr system {{system}} emacs.nix
 
 # Build the IGC (Memory Pool System GC) branch.
 [group('build')]
 build-igc:
-    nix-build --arg variant '"igc"' --argstr system {{system}} default.nix
+    nix-build --arg variant '"igc"' --argstr system {{system}} emacs.nix
 
 # Build for aarch64-linux nox (Termux/Android).
 [group('build')]
 build-android:
-    nix-build --arg noGui true --argstr system aarch64-linux default.nix
+    nix-build --arg noGui true --argstr system aarch64-linux emacs.nix
 
 # Auto-detect platform, build, then launch Emacs with this configuration.
 [group('build')]
@@ -275,10 +287,10 @@ run-built *ARGS:
 
 # ── Format ──────────────────────────────────────────────────────────
 
-# Format Nix (and anything else treefmt knows about).
+# Format all Nix files.
 [group('format')]
 fmt:
-    treefmt
+    nixfmt .
 
 
 # ── Pin management (npins) ──────────────────────────────────────────
@@ -297,6 +309,40 @@ update-pin NAME:
 [group('pins')]
 show-pins:
     npins show
+
+
+# ── Sync all locks ──────────────────────────────────────────────────
+
+# Update npins and sync devenv.yaml + flake.lock to the same nixpkgs rev.
+[group('pins')]
+update:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    npins update
+    REV=$(jq -r '.pins.nixpkgs.revision' npins/sources.json)
+    echo "Syncing all locks to nixpkgs $REV"
+    sed -i '' "s|url: github:NixOS/nixpkgs/.*|url: github:NixOS/nixpkgs/$REV|" devenv.yaml
+    devenv update
+    nix flake lock --override-input nixpkgs "github:NixOS/nixpkgs/$REV"
+    echo "Done. All locks pinned to $REV"
+
+# Verify that all three pinning mechanisms agree on the same nixpkgs rev.
+[group('pins')]
+verify:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Checking nixpkgs rev sync..."
+    NPINS_REV=$(jq -r '.pins.nixpkgs.revision' npins/sources.json)
+    FLAKE_REV=$(jq -r '.nodes.nixpkgs.locked.rev' flake.lock)
+    DEVENV_REV=$(jq -r '.nodes.nixpkgs.locked.rev' devenv.lock)
+    if [ "$NPINS_REV" != "$FLAKE_REV" ] || [ "$NPINS_REV" != "$DEVENV_REV" ]; then
+        echo "FAIL: nixpkgs revs diverged"
+        echo "  npins:  $NPINS_REV"
+        echo "  flake:  $FLAKE_REV"
+        echo "  devenv: $DEVENV_REV"
+        exit 1
+    fi
+    echo "OK: all locks pinned to $NPINS_REV"
 
 
 # ── Cleanup ─────────────────────────────────────────────────────────

--- a/default.nix
+++ b/default.nix
@@ -1,75 +1,34 @@
 # default.nix — Jotain Emacs distribution.
 #
-# Wraps the Emacs build (emacs.nix) with:
-#
-#   • every Emacs Lisp package declared via `(use-package ...)` in any
-#     file under ./lisp (auto-extracted — see nix/use-package.nix), and
-#   • all available tree-sitter grammars from nixpkgs.
+# Returns a structured attrset:
+#   packages.default             — full Emacs distribution
+#   overlays.default             — nixpkgs overlay (see overlay.nix)
+#   homeManagerModules.default   — Home Manager module (see module.nix)
+#   lib                          — use-package scanner utilities
 #
 # Usage:
-#   nix-build                                          # Emacs + mapper + grammars
-#   nix-build --arg withAutoPackages false             # Emacs + grammars only
-#   nix-build --arg withTreeSitterGrammars false       # Emacs + mapper only
-#
-# All emacs.nix arguments are forwarded:
-#   nix-build --arg withPgtk true                      # pgtk + grammars
-#   nix-build --arg variant '"git"'                    # git master + grammars
-#   nix-build --arg noGui true                         # terminal-only + grammars
-#
-# nixpkgs is taken from the npins-pinned `nixpkgs-unstable' channel by
-# default; pass --arg pkgs '<nixpkgs>' or override `pkgs` to use a
-# different one.
+#   nix-build -A packages.default                    # full distribution
+#   nix-build emacs.nix                              # bare Emacs (cache-parity)
+#   nix-build emacs.nix --arg withPgtk true          # variant builds
 {
-  system ? builtins.currentSystem,
-  pkgs ? import (import ./npins).nixpkgs-unstable {
-    inherit system;
+  pkgs ? import (import ./npins).nixpkgs {
+    overlays = [ (import ./overlay.nix) ];
     config.allowUnfree = true;
   },
-  withTreeSitterGrammars ? true,
-  withAutoPackages ? true,
-  # All other arguments are forwarded to emacs.nix
-  ...
-}@args:
-
+  lib ? pkgs.lib,
+}:
 let
-  lib = pkgs.lib;
-
-  # Build the base Emacs from emacs.nix, forwarding every argument
-  # except the ones default.nix consumes itself.
-  emacsArgs = builtins.removeAttrs args [
-    "withTreeSitterGrammars"
-    "withAutoPackages"
-  ];
-  emacs = import ./emacs.nix emacsArgs;
-
-  usePackage = import ./nix/use-package.nix { inherit lib; };
-
-  extraPackages = import ./nix/extra-packages.nix { inherit pkgs; };
-
-  extraEmacsPackages =
-    epkgs:
-    # Packages whose `use-package` form uses `:ensure nil` to stop
-    # package.el from fetching them. The auto-mapper skips `:ensure
-    # nil` blocks on purpose, so we re-inject the Nix-exclusive ones
-    # by hand.
-    [
-      epkgs.claude-code-ide
-      epkgs.combobulate
-    ]
-    ++ lib.optionals withTreeSitterGrammars [
-      epkgs.treesit-grammars.with-all-grammars
-    ];
-
+  overlay = import ./overlay.nix;
+  # Apply overlay if caller's pkgs doesn't have it
+  # (e.g. module.nix passes Home Manager's pkgs without the overlay)
+  pkgs' = if pkgs ? jotainEmacsPackages then pkgs else pkgs.extend overlay;
 in
-if withAutoPackages then
-  usePackage.emacsWithPackagesFromUsePackage {
-    config = ./lisp;
-    package = emacs;
-    emacsPackagesFor = pkgs.emacsPackagesFor;
-    override = extraPackages;
-    inherit extraEmacsPackages;
-  }
-else if withTreeSitterGrammars then
-  (pkgs.emacsPackagesFor emacs).withPackages extraEmacsPackages
-else
-  emacs
+{
+  packages.default = pkgs'.jotainEmacsPackages;
+
+  overlays.default = overlay;
+
+  homeManagerModules.default = import ./module.nix;
+
+  lib = import ./nix/use-package.nix { inherit lib; };
+}

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1775585812,
-        "narHash": "sha256-/br4g2hAmCIPaMx3a8862AfcNyBGOgoqjke6X786s8A=",
+        "lastModified": 1775823649,
+        "narHash": "sha256-qJNTkrtJMoczAnO/7ncQOdjtOpV3VTPgQthJrwVXvww=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "35b8c42eb10c196dc84611852325c722b6f10750",
+        "rev": "03d6ca7b083bf34726cd7ce303942f2ee05e00e0",
         "type": "github"
       },
       "original": {
@@ -18,38 +18,18 @@
       }
     },
     "nixpkgs": {
-      "inputs": {
-        "nixpkgs-src": "nixpkgs-src"
-      },
       "locked": {
-        "lastModified": 1774287239,
-        "narHash": "sha256-W3krsWcDwYuA3gPWsFA24YAXxOFUL6iIlT6IknAoNSE=",
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "fa7125ea7f1ae5430010a6e071f68375a39bd24c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1773840656,
-        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       }
     },
@@ -67,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775125835,
-        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "75925962939880974e3ab417879daffcba36c4a3",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,7 +6,7 @@ let
   # The npins-managed nixpkgs. Anything in this file that wants "the
   # pinned nixpkgs" should use `pinned` instead of the ambient `pkgs`
   # (which is whatever devenv resolved from devenv.yaml).
-  pinned = import sources.nixpkgs-unstable {
+  pinned = import sources.nixpkgs {
     inherit (pkgs.stdenv.hostPlatform) system;
     config.allowUnfree = true;
   };
@@ -64,6 +64,10 @@ in
     # Nix tooling
     nil
     nixfmt-rfc-style
+
+    # Nix linting
+    pinned.statix
+    pinned.deadnix
 
     # Fonts used by the Emacs configuration (init-ui.el looks them up by name).
     # These are only active while you're inside the devenv shell; on your real

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,6 +1,6 @@
 inputs:
   nixpkgs:
-    url: github:cachix/devenv-nixpkgs/rolling
+    url: github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa
   treefmt-nix:
     url: github:numtide/treefmt-nix
     inputs:

--- a/emacs.nix
+++ b/emacs.nix
@@ -28,7 +28,7 @@
 #   - nix-giant           github:nix-giant/nix-darwin-emacs
 {
   system ? builtins.currentSystem,
-  pkgs ? import (import ./npins).nixpkgs-unstable {
+  pkgs ? import (import ./npins).nixpkgs {
     inherit system;
     config.allowUnfree = true;
   },
@@ -183,7 +183,7 @@ let
   # Verify after any change to defaults:
   #     nix-instantiate --eval --strict -E \
   #       '(import ./emacs.nix {}).outPath \
-  #          == (import (import ./npins).nixpkgs-unstable {}).emacs30.outPath'
+  #          == (import (import ./npins).nixpkgs {}).emacs30.outPath'
   overridden = basePackage.override {
     inherit
       noGui

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "Jotain — GNU Emacs 30+ configuration with Nix build layer";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa";
+  };
+
+  outputs =
+    { self, nixpkgs, ... }:
+    {
+      overlays.default = import ./overlay.nix;
+
+      homeManagerModules.default = import ./module.nix;
+    };
+}

--- a/module.nix
+++ b/module.nix
@@ -76,8 +76,8 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = import ./default.nix { inherit pkgs; };
-      defaultText = lib.literalExpression "import ./default.nix { inherit pkgs; }";
+      default = (import ./default.nix { inherit pkgs; }).packages.default;
+      defaultText = lib.literalExpression "(import ./default.nix { inherit pkgs; }).packages.default";
       description = "The Jotain Emacs package to use.";
     };
 

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1,10 +1,17 @@
 {
   "pins": {
-    "nixpkgs-unstable": {
-      "type": "Channel",
-      "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre977402.0f7663154ff2/nixexprs.tar.xz",
-      "hash": "sha256-L/FlXV8K+FoAvSgJeaetcxtA3g+Rf+nDXZzriMHCZPg="
+    "nixpkgs": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "NixOS",
+        "repo": "nixpkgs"
+      },
+      "branch": "nixos-unstable",
+      "revision": "4c1018dae018162ec878d42fec712642d214fdfa",
+      "url": "https://github.com/NixOS/nixpkgs/archive/4c1018dae018162ec878d42fec712642d214fdfa.tar.gz",
+      "hash": "18ggs7jwmpi58k7xza4axy3cjs17c596ihq5y70h6sryz2hypgba",
+      "submodules": false
     }
   },
   "version": 7

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,28 @@
+# overlay.nix — Nixpkgs overlay for Jotain Emacs.
+#
+# Adds:
+#   jotainEmacs          — bare Emacs binary (emacs.nix defaults)
+#   jotainEmacsPackages  — full distribution with use-package mapper + tree-sitter
+#
+# Usage:
+#   import <nixpkgs> { overlays = [ (import ./overlay.nix) ]; }
+final: _prev:
+let
+  usePackage = import ./nix/use-package.nix { inherit (final) lib; };
+  extraPackages = import ./nix/extra-packages.nix { pkgs = final; };
+in
+{
+  jotainEmacs = import ./emacs.nix { pkgs = final; };
+
+  jotainEmacsPackages = usePackage.emacsWithPackagesFromUsePackage {
+    config = ./lisp;
+    package = final.jotainEmacs;
+    emacsPackagesFor = final.emacsPackagesFor;
+    override = extraPackages;
+    extraEmacsPackages = epkgs: [
+      epkgs.claude-code-ide
+      epkgs.combobulate
+      epkgs.treesit-grammars.with-all-grammars
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Migrate npins from Channel-type `nixpkgs-unstable` to GitHub-type `nixpkgs` pin with explicit revision field
- Create `overlay.nix` exposing `jotainEmacs` and `jotainEmacsPackages` as a reusable nixpkgs overlay
- Rewrite `default.nix` to return a structured attrset (`packages`, `overlays`, `homeManagerModules`, `lib`) using the overlay
- Add `flake.nix` as a thin wrapper re-exporting the overlay and Home Manager module
- Synchronize all three lock files (npins, devenv.lock, flake.lock) to the same nixpkgs commit
- Add `statix` and `deadnix` to the devenv packages
- Rewrite Justfile: new `check` recipe (eval + flake + devenv + linting), `update` (sync all locks), `verify` (check rev parity), variant builds target `emacs.nix` directly

## Test plan

- [x] `nix-instantiate --eval default.nix > /dev/null` passes
- [x] `nix flake check --no-build` passes
- [x] `devenv test` passes (all 7 assertions)
- [x] All three nixpkgs revisions match across npins, flake.lock, and devenv.lock
- [x] `nix flake show` displays expected outputs (overlays.default, homeManagerModules.default)
- [x] nixfmt formatting is idempotent on all changed files
- [ ] `nix-build -A packages.default` builds successfully (full build, not run in CI due to time)