### PR TITLE
Enable visual-wrap-prefix-mode for text-mode buffers

### DIFF
--- a/lisp/init-writing.el
+++ b/lisp/init-writing.el
@@ -13,6 +13,7 @@
   :ensure nil
   :hook
   ((text-mode . visual-line-mode)
+   (text-mode . visual-wrap-prefix-mode)
    (text-mode . variable-pitch-mode)))
 
 (use-package jinx


### PR DESCRIPTION
Pair with the existing visual-line-mode hook so that soft-wrapped
continuation lines preserve indentation context (Emacs 30 built-in,
replaces the old adaptive-wrap ELPA package).

https://claude.ai/code/session_015iNo1WpNKpm5z7zTa391zR