### PR TITLE
Optimize CI performance and cost

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,21 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot configuration.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "nix" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "nix"
+    directory: "/"
     schedule:
       interval: "weekly"
+    # Collapse all flake input bumps into a single weekly PR so the
+    # CI matrix runs once per cycle instead of once per input.
+    groups:
+      nix-inputs:
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 # CI for the Jotain Emacs configuration.
 #
-# Three jobs run in parallel on Ubuntu and macOS:
+# Two jobs run in parallel on Ubuntu and macOS:
 #
 #   check — nix flake check (formatting, statix, deadnix, elisp-lint,
-#           elisp-compile, package evaluation)
+#           elisp-compile, and package builds — jotainEmacs,
+#           jotainEmacsPackages, options-doc are all flake checks, so
+#           running a separate `nix build` job would duplicate work)
 #   test  — devenv test (dev environment assertions from devenv.nix)
-#   build — nix build (full distribution with tree-sitter grammars)
 #
 # The jylhis cachix cache is used for pulling pre-built artifacts and
 # pushing newly built ones (when CACHIX_AUTH_TOKEN is available).
@@ -19,12 +20,19 @@ on:
       - main
       - master
 
+# Cancel superseded runs on PR branches; keep protected-branch runs
+# intact so post-merge cache pushes always finish.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/next' }}
+
 permissions:
   contents: read
 
 jobs:
   check:
     name: Lint & check
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -41,10 +49,11 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: nix flake check
-        run: nix flake check
+        run: nix flake check --print-build-logs
 
   test:
     name: Dev environment
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -68,23 +77,3 @@ jobs:
 
       - name: devenv test
         run: devenv test
-
-  build:
-    name: Build
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: cachix/install-nix-action@v31
-
-      - uses: cachix/cachix-action@v16
-        with:
-          name: jylhis
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - name: nix build
-        run: nix build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,20 @@ name: Deploy docs
 on:
   push:
     branches: [main]
+    # Only re-publish when something that affects the rendered site
+    # actually changes.  Everything else (lisp/, test/, Justfile, …)
+    # has no effect on docs and should not trigger a Pages build.
+    paths:
+      - "docs/**"
+      - "nix/options-doc.nix"
+      - "nix/info-manual.nix"
+      - "emacs.nix"
+      - "overlay.nix"
+      - "module.nix"
+      - "module-system.nix"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/pages.yml"
   workflow_dispatch:
 
 permissions:
@@ -22,6 +36,7 @@ concurrency:
 jobs:
   build:
     name: Build docs
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -53,6 +68,7 @@ jobs:
   deploy:
     name: Deploy
     needs: build
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ All recipes assume the devenv shell is active. `direnv` handles this via `.envrc
 devenv shell -- just check
 ```
 
-CI (`.github/workflows/ci.yml`) runs three parallel jobs on Ubuntu and macOS: `check` (`nix flake check`), `test` (`devenv test` — the seven `enterTest` assertions in `devenv.nix`), and `build` (`nix build`). The `jylhis` cachix cache is used for pulling and pushing artifacts.
+CI (`.github/workflows/ci.yml`) runs two parallel jobs on Ubuntu and macOS: `check` (`nix flake check`, which already builds `packages-default`, `packages-emacs`, and `options-doc` as flake checks — so a separate `nix build` job would duplicate work) and `test` (`devenv test` — the seven `enterTest` assertions in `devenv.nix`). A workflow-level `concurrency` group cancels superseded runs on PR branches while preserving protected-branch runs so post-merge cache pushes always finish. The `jylhis` cachix cache is used for pulling and pushing artifacts.
 
 ## Common commands
 


### PR DESCRIPTION
## Summary
- Drop the redundant `build` job; `nix flake check` already builds `jotainEmacs`, `jotainEmacsPackages`, and `options-doc` as flake checks (`nix/checks.nix`), so running a separate `nix build` doubled the work on every push.
- Add a workflow-level `concurrency` group that cancels superseded runs on PR branches while preserving protected-branch (`main` / `master` / `next`) runs so post-merge cache pushes always finish. Add per-job `timeout-minutes` ceilings.
- Scope the Pages workflow with a `paths:` filter so lisp-only pushes to `main` stop rebuilding docs.
- Group Dependabot updates (nix flake inputs and a new `github-actions` ecosystem) so weekly bumps yield one PR per ecosystem instead of one per input.

## Test plan
- [ ] CI run on this PR passes `check` and `test` on Ubuntu + macOS.
- [ ] Pushing a second commit on this branch cancels the in-progress run instead of stacking.
- [ ] After merge, Pages workflow does not trigger on subsequent lisp-only pushes to `main`; does trigger on changes under `docs/**` / flake / doc-producing Nix modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)