### PR TITLE
Enable Org Babel evaluation confirmation

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -29,7 +29,7 @@
   (org-pretty-entities         t)
   (org-src-fontify-natively    t)
   (org-src-tab-acts-natively   t)
-  (org-confirm-babel-evaluate  nil)
+  (org-confirm-babel-evaluate  t)
   (org-log-done                'time)
   (org-return-follows-link     t)
   (org-fold-catch-invisible-edits 'show-and-error)


### PR DESCRIPTION
### Motivation
- Restore Org's safety interlock by re-enabling confirmation for Babel source block execution because the previous configuration set `org-confirm-babel-evaluate` to `nil`, which permits silent execution of code blocks.

### Description
- Change `(org-confirm-babel-evaluate  nil)` to `(org-confirm-babel-evaluate  t)` in `lisp/init-org.el` to require confirmation before evaluating Org Babel source blocks and preserve the existing Org configuration.

### Testing
- Validated the change by inspecting `lisp/init-org.el` to confirm it now contains `(org-confirm-babel-evaluate  t)`; attempted to run `just check-elisp` but `just` is not available in the current environment so full automated Elisp checks could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022e72997c8326bb9022ffb3b63475)