### PR TITLE
Bind transpose-sentences/paragraphs and combobulate drag commands

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -302,6 +302,16 @@ Treats CamelCase / snake_case word parts as separate words for
 M-f / M-b / M-d. Built-in. Programming-mode only — prose still
 gets whole-word motion.
 
+### `emacs` *(built-in / Nix)*
+
+Bindings for the two transpose commands Emacs ships without
+defaults, so the prose-level family (sentence, paragraph) is
+reachable alongside the built-in C-t (chars), M-t (words),
+C-x C-t (lines), and C-M-t (sexps, tree-sitter aware in Emacs
+30+). Caveat: transpose-lines works on real newlines, so it
+gives surprising results under visual-line-mode where wrapped
+"lines" are visual only.
+
 ### `newcomment` *(built-in / Nix)*
 
 Defaults for the built-in comment commands (M-;, C-x C-;, M-j).

--- a/lisp/init-editing.el
+++ b/lisp/init-editing.el
@@ -36,6 +36,19 @@
   :ensure nil
   :hook ((prog-mode . subword-mode)))
 
+;;; @doc Bindings for the two transpose commands Emacs ships without
+;;; defaults, so the prose-level family (sentence, paragraph) is
+;;; reachable alongside the built-in C-t (chars), M-t (words),
+;;; C-x C-t (lines), and C-M-t (sexps, tree-sitter aware in Emacs
+;;; 30+). Caveat: transpose-lines works on real newlines, so it
+;;; gives surprising results under visual-line-mode where wrapped
+;;; "lines" are visual only.
+(use-package emacs
+  :ensure nil
+  :bind
+  (("C-x M-t"   . transpose-sentences)
+   ("C-x C-M-t" . transpose-paragraphs)))
+
 ;;; @doc Defaults for the built-in comment commands (M-;, C-x C-;, M-j).
 ;;; `comment-multi-line' makes M-j continue inside an open block
 ;;; comment instead of closing/reopening; `extra-line' style puts

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -66,7 +66,10 @@
   :ensure nil ; Provided by Nix
   :defer t
   :commands combobulate-mode
-  :custom (combobulate-key-prefix "C-c o"))
+  :custom (combobulate-key-prefix "C-c o")
+  :bind (:map combobulate-key-map
+              ("M-P" . combobulate-drag-up)
+              ("M-N" . combobulate-drag-down)))
 
 ;;;; Eglot
 


### PR DESCRIPTION
## Summary

Inspired by [_Transpose All The Things_](https://emacsredux.com/blog/2026/03/04/transpose-all-the-things/):

- Bind `transpose-sentences` to `C-x M-t` and `transpose-paragraphs` to `C-x C-M-t`, extending the existing `C-x C-t` (transpose-lines) family so the prose-level transpose commands are reachable from the keyboard (they ship with no defaults, which is why they're so rarely used).
- Add `M-P` / `M-N` for `combobulate-drag-up` / `combobulate-drag-down` inside `combobulate-key-map`, giving tree-sitter-aware sibling reordering alongside `C-M-t`'s treesit-aware `transpose-sexps`.
- Doc comment in `init-editing.el` notes the `transpose-lines` + `visual-line-mode` caveat from the post.

## Test plan

- [ ] `just check` (full flake checks: treefmt, statix, deadnix, elisp-lint, byte-compile-warnings-as-errors, package eval)
- [ ] `just run`, then in `*scratch*` use `C-x M-t` between two sentences and `C-x C-M-t` between two paragraphs — `C-h k` should resolve to `transpose-sentences` / `transpose-paragraphs`.
- [ ] In a tree-sitter buffer (e.g. `.py`, `.rs`, `.nix`) with `M-x combobulate-mode`, press `M-P` / `M-N` on a sibling node and confirm it moves up/down; `C-h k M-P` should resolve to `combobulate-drag-up`.

https://claude.ai/code/session_017ucnFaaXdDmVDBNizqivdU

---
_Generated by [Claude Code](https://claude.ai/code/session_017ucnFaaXdDmVDBNizqivdU)_