### PR TITLE
Bind Emacs 30 replace-regexp-as-diff family under M-s

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -299,6 +299,14 @@ Per-mode overrides go in the language module via a named hook:
     (setq-local comment-multi-line nil))
   (add-hook 'foo-mode-hook #'my-foo-mode-setup)
 
+### `replace` *(built-in / Nix)*
+
+Emacs 30 ships `replace-regexp-as-diff' and
+`multi-file-replace-regexp-as-diff' — run a regex replacement, but
+see the result as a unified diff first and either apply it as a
+patch or abort. Worth reaching for on any non-trivial refactor.
+The dired-marked variant is bound in `init-navigation.el'.
+
 ### `expreg`
 
 Treesit-aware semantic region expansion. Smaller, faster
@@ -432,7 +440,10 @@ capf finds nothing useful.
 
 Built-in directory editor — Jotain's primary file manager.
 The custom block below tames cross-platform ls quirks (BSD on
-macOS lacks `--group-directories-first` and `--dired`).
+macOS lacks `--group-directories-first` and `--dired`). `M-s R`
+previews a regex replacement across the contents of all marked
+files as a unified diff (Emacs 30's
+`dired-do-replace-regexp-as-diff').
 
 ### `dired-x` *(built-in / Nix)*
 

--- a/lisp/init-editing.el
+++ b/lisp/init-editing.el
@@ -58,6 +58,16 @@
   (comment-empty-lines t)
   (comment-auto-fill-only-comments t))
 
+;;; @doc Emacs 30 ships `replace-regexp-as-diff' and
+;;; `multi-file-replace-regexp-as-diff' — run a regex replacement, but
+;;; see the result as a unified diff first and either apply it as a
+;;; patch or abort. Worth reaching for on any non-trivial refactor.
+;;; The dired-marked variant is bound in `init-navigation.el'.
+(use-package replace
+  :ensure nil
+  :bind (("M-s R"   . replace-regexp-as-diff)
+         ("M-s M-R" . multi-file-replace-regexp-as-diff)))
+
 ;;; @doc Treesit-aware semantic region expansion. Smaller, faster
 ;;; successor to expand-region; produces better expansions with
 ;;; much less code now that treesit is everywhere.

--- a/lisp/init-navigation.el
+++ b/lisp/init-navigation.el
@@ -11,8 +11,9 @@
 ;;; @doc Built-in directory editor — Jotain's primary file manager.
 ;;; The custom block below tames cross-platform ls quirks (BSD on
 ;;; macOS lacks `--group-directories-first` and `--dired`). `M-s R`
-;;; previews a regex rename across all marked files as a unified
-;;; diff (Emacs 30's `dired-do-replace-regexp-as-diff').
+;;; previews a regex replacement across the contents of all marked
+;;; files as a unified diff (Emacs 30's
+;;; `dired-do-replace-regexp-as-diff').
 (use-package dired
   :ensure nil
   :custom

--- a/lisp/init-navigation.el
+++ b/lisp/init-navigation.el
@@ -10,7 +10,9 @@
 
 ;;; @doc Built-in directory editor — Jotain's primary file manager.
 ;;; The custom block below tames cross-platform ls quirks (BSD on
-;;; macOS lacks `--group-directories-first` and `--dired`).
+;;; macOS lacks `--group-directories-first` and `--dired`). `M-s R`
+;;; previews a regex rename across all marked files as a unified
+;;; diff (Emacs 30's `dired-do-replace-regexp-as-diff').
 (use-package dired
   :ensure nil
   :custom
@@ -34,7 +36,9 @@
   (dired-create-destination-dirs 'ask)
   (dired-free-space nil)
   (dired-vc-rename-file t)
-  :hook (dired-mode . dired-hide-details-mode))
+  :hook (dired-mode . dired-hide-details-mode)
+  :bind (:map dired-mode-map
+              ("M-s R" . dired-do-replace-regexp-as-diff)))
 
 ;;; @doc Built-in dired extras — `dired-omit-mode` hides dotfiles and
 ;;; cache directories so dired listings show only the things you


### PR DESCRIPTION
## Summary

Emacs 30 ships `replace-regexp-as-diff` and its multi-file / dired companions: run a regex replacement, see the result as a unified diff first, then apply as a patch (or abort). Lifesaver for non-trivial refactors — but invisible at `M-x` only.

Inspired by [Preview Regex Replacements as Diffs in Emacs](https://emacsredux.com/blog/2026/02/28/preview-regex-replacements-as-diffs/).

Bindings, all under the existing `M-s` search prefix (uppercase `R` so it doesn't clash with consult's `M-s r` = `consult-ripgrep`):

| Key | Command | Scope |
| --- | --- | --- |
| `M-s R` | `replace-regexp-as-diff` | global |
| `M-s M-R` | `multi-file-replace-regexp-as-diff` | global |
| `M-s R` | `dired-do-replace-regexp-as-diff` | `dired-mode-map` (shadows global) |

Changes:

- `lisp/init-editing.el` — new `use-package replace :ensure nil` block with the two global bindings and a `;;; @doc` block (so which-key + the Info manual pick it up).
- `lisp/init-navigation.el` — extend the existing `dired` use-package block with a `:bind` clause for `M-s R`, and add a one-liner to its `@doc` mentioning the feature.

No new packages, no new top-level prefixes, no Eglot/`C-c r` changes.

## Test plan

- [ ] `nix flake check` / `just check-elisp` — paren-check + byte-compile-with-warnings-as-errors must stay green (CI covers this).
- [ ] `just run`: in a prog-mode buffer, `M-s R` prompts for regex + replacement, then opens a `*Diff*` buffer.
- [ ] `M-s M-R` from anywhere prompts for files and shows a combined diff.
- [ ] In a dired buffer with marked files, `M-s R` dispatches to `dired-do-replace-regexp-as-diff` (verify with `C-h k M-s R`).
- [ ] With which-key open, pressing `M-s` lists `R` and `M-R` alongside the existing consult entries.


---
_Generated by [Claude Code](https://claude.ai/code/session_013vxkmRbhvF4C9TShhpBKrZ)_