### PR TITLE
Add jotain-switch-git-status-buffer for quick changed-file jumps

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -456,9 +456,10 @@ parents) you almost never benefit from.
 ### `vc-git` *(built-in / Nix)*
 
 Quick jump to a file git status reports as changed. Runs
-`git status --porcelain=v1 -z' (the -z keeps spaces and
-non-ASCII paths intact — no shell quoting) and offers
-M/A/D/R/C/U/T/?? entries through `completing-read'. Adapted
+`git status --porcelain=v1 -z -uall' (-z keeps spaces and
+non-ASCII paths intact; -uall forces untracked listing
+regardless of status.showUntrackedFiles) and offers
+M/A/R/C/U/T/?? entries through `completing-read'. Adapted
 from Rahul M. Juliato's emacs-solo/switch-git-status-buffer.
 
 ### `magit`

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -453,6 +453,14 @@ Built-in version control. Pinned to Git only — every other
 backend is a slow startup tax (probes every visited file's
 parents) you almost never benefit from.
 
+### `vc-git` *(built-in / Nix)*
+
+Quick jump to a file git status reports as changed. Runs
+`git status --porcelain=v1 -z' (the -z keeps spaces and
+non-ASCII paths intact — no shell quoting) and offers
+M/A/D/R/C/U/T/?? entries through `completing-read'. Adapted
+from Rahul M. Juliato's emacs-solo/switch-git-status-buffer.
+
 ### `magit`
 
 The Git porcelain. Bound C-x g for status, C-x M-g for global

--- a/lisp/init-vc.el
+++ b/lisp/init-vc.el
@@ -25,9 +25,10 @@
   (vc-handled-backends '(Git)))
 
 ;;; @doc Quick jump to a file git status reports as changed. Runs
-;;; `git status --porcelain=v1' and offers M/A/D/R/?? entries
-;;; through `completing-read'. Adapted from Rahul M. Juliato's
-;;; emacs-solo/switch-git-status-buffer.
+;;; `git status --porcelain=v1 -z' (the -z keeps spaces and
+;;; non-ASCII paths intact — no shell quoting) and offers
+;;; M/A/D/R/C/U/T/?? entries through `completing-read'. Adapted
+;;; from Rahul M. Juliato's emacs-solo/switch-git-status-buffer.
 (use-package vc-git
   :ensure nil
   :bind ("C-x C-g" . jotain-switch-git-status-buffer)
@@ -35,9 +36,10 @@
   (declare-function vc-git-root "vc-git" (file))
   (defun jotain-switch-git-status-buffer ()
     "Switch to a file git status reports as changed in this repo.
-Candidates are parsed from `git status --porcelain=v1' (modified,
-added, deleted, renamed, untracked) and offered through
-`completing-read'."
+Candidates are parsed from `git status --porcelain=v1 -z' so paths
+containing spaces or non-ASCII characters arrive verbatim. Modified,
+added, deleted, renamed, copied, unmerged, type-changed, and
+untracked files are offered through `completing-read'."
     (interactive)
     (require 'vc-git)
     (let ((repo-root (vc-git-root default-directory)))
@@ -46,31 +48,39 @@ added, deleted, renamed, untracked) and offered through
         (let* ((expanded-root (expand-file-name repo-root))
                (default-directory expanded-root)
                (cmd-output (shell-command-to-string
-                            "git status --porcelain=v1"))
+                            "git status --porcelain=v1 -z"))
                (target-files
-                (let (files)
-                  (dolist (line (split-string cmd-output "\n" t)
-                                (nreverse files))
-                    (when (> (length line) 3)
-                      (let ((status (substring line 0 2))
-                            (path-info (substring line 3)))
-                        (cond
-                         ((string-match-p "^R" status)
-                          (let ((new-path (cadr (split-string
-                                                 path-info " -> " t))))
-                            (when new-path
-                              (push (cons (format "R  %s" new-path)
-                                          new-path)
-                                    files))))
-                         ((string-match-p "[MAD?]" status)
-                          (push (cons (format "%s %s" status path-info)
-                                      path-info)
-                                files)))))))))
+                (let ((files nil)
+                      (rest (split-string cmd-output "\0" t)))
+                  (while rest
+                    (let ((entry (pop rest)))
+                      (when (> (length entry) 3)
+                        (let ((status (substring entry 0 2))
+                              (path-info (substring entry 3)))
+                          (cond
+                           ;; Rename/copy in -z mode: this entry
+                           ;; holds the OLD path; the next NUL chunk
+                           ;; holds the NEW (current) path. See
+                           ;; git-status(1) "-z".
+                           ((string-match-p "^[RC]" status)
+                            (let ((new-path (and rest (pop rest))))
+                              (when new-path
+                                (push (cons (format "%s %s -> %s"
+                                                    status path-info
+                                                    new-path)
+                                            new-path)
+                                      files))))
+                           ((string-match-p "[MADUT?]" status)
+                            (push (cons (format "%s %s"
+                                                status path-info)
+                                        path-info)
+                                  files)))))))
+                  (nreverse files))))
           (if (not target-files)
               (message "No changed files in this repository.")
             (let* ((selection (completing-read
                                "Switch to git-changed file: "
-                               (mapcar #'car target-files) nil t))
+                               target-files nil t))
                    (file-path (cdr (assoc selection target-files))))
               (when file-path
                 (find-file (expand-file-name file-path

--- a/lisp/init-vc.el
+++ b/lisp/init-vc.el
@@ -25,9 +25,10 @@
   (vc-handled-backends '(Git)))
 
 ;;; @doc Quick jump to a file git status reports as changed. Runs
-;;; `git status --porcelain=v1 -z' (the -z keeps spaces and
-;;; non-ASCII paths intact — no shell quoting) and offers
-;;; M/A/D/R/C/U/T/?? entries through `completing-read'. Adapted
+;;; `git status --porcelain=v1 -z -uall' (-z keeps spaces and
+;;; non-ASCII paths intact; -uall forces untracked listing
+;;; regardless of status.showUntrackedFiles) and offers
+;;; M/A/R/C/U/T/?? entries through `completing-read'. Adapted
 ;;; from Rahul M. Juliato's emacs-solo/switch-git-status-buffer.
 (use-package vc-git
   :ensure nil
@@ -36,10 +37,13 @@
   (declare-function vc-git-root "vc-git" (file))
   (defun jotain-switch-git-status-buffer ()
     "Switch to a file git status reports as changed in this repo.
-Candidates are parsed from `git status --porcelain=v1 -z' so paths
-containing spaces or non-ASCII characters arrive verbatim. Modified,
-added, deleted, renamed, copied, unmerged, type-changed, and
-untracked files are offered through `completing-read'."
+Candidates are parsed from `git status --porcelain=v1 -z -uall' so
+paths containing spaces or non-ASCII characters arrive verbatim
+and untracked files appear regardless of the user's
+`status.showUntrackedFiles' setting. Modified, added, renamed,
+copied, unmerged, type-changed, and untracked files are offered
+through `completing-read'; pure deletions are omitted since the
+working-tree file no longer exists to open."
     (interactive)
     (require 'vc-git)
     (let ((repo-root (vc-git-root default-directory)))
@@ -48,7 +52,7 @@ untracked files are offered through `completing-read'."
         (let* ((expanded-root (expand-file-name repo-root))
                (default-directory expanded-root)
                (cmd-output (shell-command-to-string
-                            "git status --porcelain=v1 -z"))
+                            "git status --porcelain=v1 -z -uall"))
                (target-files
                 (let ((files nil)
                       (rest (split-string cmd-output "\0" t)))
@@ -58,19 +62,18 @@ untracked files are offered through `completing-read'."
                         (let ((status (substring entry 0 2))
                               (path-info (substring entry 3)))
                           (cond
-                           ;; Rename/copy in -z mode: this entry
-                           ;; holds the OLD path; the next NUL chunk
-                           ;; holds the NEW (current) path. See
-                           ;; git-status(1) "-z".
+                           ;; Rename/copy in -z mode: PATH (new) is
+                           ;; on this entry, ORIG_PATH (old) is the
+                           ;; next NUL chunk. See git-status(1).
                            ((string-match-p "^[RC]" status)
-                            (let ((new-path (and rest (pop rest))))
-                              (when new-path
-                                (push (cons (format "%s %s -> %s"
-                                                    status path-info
-                                                    new-path)
-                                            new-path)
-                                      files))))
-                           ((string-match-p "[MADUT?]" status)
+                            (let ((orig-path (and rest (pop rest))))
+                              (push (cons (format "%s %s -> %s"
+                                                  status
+                                                  (or orig-path "?")
+                                                  path-info)
+                                          path-info)
+                                    files)))
+                           ((string-match-p "[MAUT?]" status)
                             (push (cons (format "%s %s"
                                                 status path-info)
                                         path-info)

--- a/lisp/init-vc.el
+++ b/lisp/init-vc.el
@@ -24,6 +24,58 @@
   (vc-follow-symlinks t)
   (vc-handled-backends '(Git)))
 
+;;; @doc Quick jump to a file git status reports as changed. Runs
+;;; `git status --porcelain=v1' and offers M/A/D/R/?? entries
+;;; through `completing-read'. Adapted from Rahul M. Juliato's
+;;; emacs-solo/switch-git-status-buffer.
+(use-package vc-git
+  :ensure nil
+  :bind ("C-x C-g" . jotain-switch-git-status-buffer)
+  :preface
+  (declare-function vc-git-root "vc-git" (file))
+  (defun jotain-switch-git-status-buffer ()
+    "Switch to a file git status reports as changed in this repo.
+Candidates are parsed from `git status --porcelain=v1' (modified,
+added, deleted, renamed, untracked) and offered through
+`completing-read'."
+    (interactive)
+    (require 'vc-git)
+    (let ((repo-root (vc-git-root default-directory)))
+      (if (not repo-root)
+          (message "Not inside a Git repository.")
+        (let* ((expanded-root (expand-file-name repo-root))
+               (default-directory expanded-root)
+               (cmd-output (shell-command-to-string
+                            "git status --porcelain=v1"))
+               (target-files
+                (let (files)
+                  (dolist (line (split-string cmd-output "\n" t)
+                                (nreverse files))
+                    (when (> (length line) 3)
+                      (let ((status (substring line 0 2))
+                            (path-info (substring line 3)))
+                        (cond
+                         ((string-match-p "^R" status)
+                          (let ((new-path (cadr (split-string
+                                                 path-info " -> " t))))
+                            (when new-path
+                              (push (cons (format "R  %s" new-path)
+                                          new-path)
+                                    files))))
+                         ((string-match-p "[MAD?]" status)
+                          (push (cons (format "%s %s" status path-info)
+                                      path-info)
+                                files)))))))))
+          (if (not target-files)
+              (message "No changed files in this repository.")
+            (let* ((selection (completing-read
+                               "Switch to git-changed file: "
+                               (mapcar #'car target-files) nil t))
+                   (file-path (cdr (assoc selection target-files))))
+              (when file-path
+                (find-file (expand-file-name file-path
+                                             expanded-root))))))))))
+
 ;;; @doc The Git porcelain. Bound C-x g for status, C-x M-g for global
 ;;; dispatch, C-c g for the file-specific menu. Refined hunks +
 ;;; whitespace-ignoring diffs are turned on globally.


### PR DESCRIPTION
## Summary

- New command `jotain-switch-git-status-buffer` bound to `C-x C-g`. Runs `git status --porcelain=v1` and offers modified, added, deleted, renamed, and untracked paths through `completing-read`, so mid-feature you can jump straight to one of the handful of files you've actually touched without sifting through every project file or buffer.
- Lives in a new `use-package vc-git :ensure nil` block in `lisp/init-vc.el`, next to its `vc-git-root` dependency. Magit's `C-x g` binding is unchanged.
- Adapted from Rahul M. Juliato's [`emacs-solo/switch-git-status-buffer`](https://rahuljuliato.com/posts/switch-git-status-buffer); renamed to the `jotain-` prefix, status matching widened from `M`/`??` to `[MAD?]` plus `R`, and rewritten to use `default-directory` instead of inlining `git -C` shell-quoted into the command string.

## Test plan

- [ ] `just check-elisp` (paren-check + byte-compile with warnings-as-errors) passes.
- [ ] `just check` (full flake check) passes.
- [ ] In a dirty repo, `C-x C-g` lists the changed files; selecting one opens it.
- [ ] In a clean repo, `C-x C-g` says "No changed files in this repository."
- [ ] Outside a git repo (e.g. `C-x C-f /tmp/ RET`, then `C-x C-g`) says "Not inside a Git repository."
- [ ] After `git mv`, the renamed file appears with an `R` prefix pointing at the new path.
- [ ] `C-h k C-x C-g` shows the docstring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SR3RtQzwsLkqbYXpHedqWu)_