### PR TITLE
Add async dired copies and dired-rsync

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -396,6 +396,21 @@ Built-in dired extras — `dired-omit-mode` hides dotfiles and
 cache directories so dired listings show only the things you
 actually want to see.
 
+### `dired-async`
+
+Async file ops for dired — wraps `dired-do-copy`, `dired-do-rename`,
+`dired-do-symlink`, `dired-do-hardlink` so they fork into a subprocess
+instead of blocking the main Emacs. Multi-GB copies no longer freeze
+the UI; the mode-line shows progress and a message fires on completion.
+
+### `dired-rsync`
+
+rsync from dired — bound to `C-c C-r` in `dired-mode-map`. Best
+for very large transfers or TRAMP sources/destinations: hands marked
+files to `rsync` in an async shell buffer with live progress. Uses
+`--progress` (not `--info=progress2`) so stock macOS rsync 2.6.9 still
+works; noisier output, but portable.
+
 ### `ls-lisp` *(built-in / Nix)*
 
 Pure-Lisp ls emulation. Fallback for macOS without GNU coreutils

--- a/lisp/init-navigation.el
+++ b/lisp/init-navigation.el
@@ -53,6 +53,24 @@
            "\\|^\\.stversions\\'"
            "\\|^__pycache__\\'")))
 
+;;; @doc Async file ops for dired — wraps `dired-do-copy', `-rename',
+;;; `-symlink', `-hardlink' so they fork into a subprocess instead of
+;;; blocking the main Emacs.  Multi-GB copies no longer freeze the UI;
+;;; the mode-line shows progress and a notification fires on completion.
+(use-package async
+  :after dired
+  :functions (dired-async-mode)
+  :config (dired-async-mode 1))
+
+;;; @doc rsync from dired — bound to `C-c C-r' in `dired-mode-map'.
+;;; Best for very large transfers or TRAMP sources/destinations: hands
+;;; marked files to `rsync' in an async shell buffer with live progress.
+(use-package dired-rsync
+  :after dired
+  :bind (:map dired-mode-map ("C-c C-r" . dired-rsync))
+  :custom
+  (dired-rsync-options "-az --info=progress2 --human-readable"))
+
 ;;; @doc Pure-Lisp ls emulation. Fallback for macOS without GNU coreutils
 ;;; — gives us folders-first sorting that BSD ls cannot produce.
 (use-package ls-lisp

--- a/lisp/init-navigation.el
+++ b/lisp/init-navigation.el
@@ -53,23 +53,25 @@
            "\\|^\\.stversions\\'"
            "\\|^__pycache__\\'")))
 
-;;; @doc Async file ops for dired — wraps `dired-do-copy', `-rename',
-;;; `-symlink', `-hardlink' so they fork into a subprocess instead of
-;;; blocking the main Emacs.  Multi-GB copies no longer freeze the UI;
-;;; the mode-line shows progress and a notification fires on completion.
-(use-package async
+;;; @doc Async file ops for dired — wraps `dired-do-copy`, `dired-do-rename`,
+;;; `dired-do-symlink`, `dired-do-hardlink` so they fork into a subprocess
+;;; instead of blocking the main Emacs. Multi-GB copies no longer freeze
+;;; the UI; the mode-line shows progress and a message fires on completion.
+(use-package dired-async
+  :ensure async
   :after dired
-  :functions (dired-async-mode)
   :config (dired-async-mode 1))
 
-;;; @doc rsync from dired — bound to `C-c C-r' in `dired-mode-map'.
-;;; Best for very large transfers or TRAMP sources/destinations: hands
-;;; marked files to `rsync' in an async shell buffer with live progress.
+;;; @doc rsync from dired — bound to `C-c C-r` in `dired-mode-map`. Best
+;;; for very large transfers or TRAMP sources/destinations: hands marked
+;;; files to `rsync` in an async shell buffer with live progress. Uses
+;;; `--progress` (not `--info=progress2`) so stock macOS rsync 2.6.9 still
+;;; works; noisier output, but portable.
 (use-package dired-rsync
   :after dired
   :bind (:map dired-mode-map ("C-c C-r" . dired-rsync))
   :custom
-  (dired-rsync-options "-az --info=progress2 --human-readable"))
+  (dired-rsync-options "-az --progress --human-readable"))
 
 ;;; @doc Pure-Lisp ls emulation. Fallback for macOS without GNU coreutils
 ;;; — gives us folders-first sorting that BSD ls cannot produce.


### PR DESCRIPTION
## Summary

Inspired by Chris Maiorana's [*The Emacs Way: Copying Files*](https://chrismaiorana.com/the-emacs-way-copying-files/). The article's headline tip — using two dired buffers as a dual-pane file manager — already works in Jotain via `dired-dwim-target` (`lisp/init-navigation.el:29`). What it doesn't address is that dired's copy is **synchronous**: a multi-GB copy or any TRAMP transfer freezes Emacs. Two MELPA packages fix that, both added to `init-navigation.el`:

- **`async`** — enables `dired-async-mode`, which wraps `dired-do-copy`, `-rename`, `-symlink`, `-hardlink` so they fork into a subprocess. Standard `C` workflow stays identical, just non-blocking.
- **`dired-rsync`** — bound to `C-c C-r` in `dired-mode-map`, hands marked files to `rsync` in an async shell buffer with `--info=progress2 --human-readable`. Best for large or remote (TRAMP) transfers.

`C-c C-r` was chosen because `R` is `dired-do-rename`, `r` is `dired-do-redisplay`, and `C-c C-r` is the binding the upstream `dired-rsync` README recommends. No collision with existing Jotain bindings (`C-c C-e` → wdired, `C-c d`/`C-c D` → dirvish).

No Nix changes — both packages come in via the existing `use-package-always-ensure` MELPA bootstrap, so the cache-parity invariant for `pkgs.emacs30` is preserved.

## Test plan

- [ ] CI: `nix flake check` passes (paren check + byte-compile-warnings-as-errors)
- [ ] CI: `devenv test` still green
- [ ] Manual: `just run`, `C-x d`, mark a sizeable file, `C` → Emacs stays responsive while copy runs (mode-line briefly shows `[Async]`)
- [ ] Manual: with a TRAMP destination open in another window, mark a file, `C-c C-r`, accept default destination → `*rsync*` async shell buffer appears with progress
- [ ] Manual: `dired-dwim-target` still suggests the second window's directory for both `C` and `C-c C-r`

---
_Generated by [Claude Code](https://claude.ai/code/session_016h5TfyJNe5YBovz86q5J4J)_