### PR TITLE
Add Unicode emoji rendering and emoji.el picker

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -127,6 +127,12 @@ A dense, IDE-style modeline with LSP/eglot status, project
 buffer info, and Nerd Font glyphs. Loaded after init so the
 primary frame doesn't redraw before fonts are ready.
 
+### `emoji` *(built-in / Nix)*
+
+Built-in emoji picker (Emacs 29+): `C-x 8 e e' inserts by name,
+`C-x 8 e s' searches, `C-x 8 e l' opens the full list, `C-x 8 e d'
+describes the emoji at point.  `which-key' surfaces the prefix.
+
 ### `display-line-numbers` *(built-in / Nix)*
 
 Built-in line numbers — only on programming and config buffers,

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -149,7 +149,7 @@ availability on the right display."
                            return f)))
       (when family
         (set-fontset-font t 'emoji  (font-spec :family family) frame 'prepend)
-        (set-fontset-font t 'symbol (font-spec :family family) frame 'append)))))
+        (set-fontset-font t 'symbol (font-spec :family family) frame 'prepend)))))
 
 (jotain-ui-apply-emoji-font)
 (add-hook 'server-after-make-frame-hook #'jotain-ui-apply-emoji-font)

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -144,11 +144,12 @@ Without this, code points like U+1F389 render as tofu when the
 default face's font lacks them.  FRAME is used to probe font
 availability on the right display."
   (when (display-graphic-p frame)
-    (when-let* ((family (cl-loop for f in jotain-emoji-font-preferences
-                                 when (find-font (font-spec :family f) frame)
-                                 return f)))
-      (set-fontset-font t 'emoji  (font-spec :family family) frame 'prepend)
-      (set-fontset-font t 'symbol (font-spec :family family) frame 'append))))
+    (let ((family (cl-loop for f in jotain-emoji-font-preferences
+                           when (find-font (font-spec :family f) frame)
+                           return f)))
+      (when family
+        (set-fontset-font t 'emoji  (font-spec :family family) frame 'prepend)
+        (set-fontset-font t 'symbol (font-spec :family family) frame 'append)))))
 
 (jotain-ui-apply-emoji-font)
 (add-hook 'server-after-make-frame-hook #'jotain-ui-apply-emoji-font)

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -127,6 +127,39 @@ attributes are applied globally so all frames see the update."
 (jotain-ui-apply-font)
 (add-hook 'server-after-make-frame-hook #'jotain-ui-apply-font)
 
+(defcustom jotain-emoji-font-preferences
+  (if (eq system-type 'darwin)
+      '("Apple Color Emoji" "Noto Color Emoji" "Symbola")
+    '("Noto Color Emoji" "Segoe UI Emoji" "Symbola"))
+  "Ordered list of family names to try for the `emoji' and `symbol' charsets.
+The first installed family wins.  macOS ships Apple Color Emoji
+system-wide; Linux/Home-Manager pulls in Noto Color Emoji through
+`services.jotain' so the default is available without extra setup."
+  :type '(repeat string)
+  :group 'jotain-ui)
+
+(defun jotain-ui-apply-emoji-font (&optional frame)
+  "Install a colour-emoji fallback for the `emoji' and `symbol' fontsets.
+Without this, code points like U+1F389 render as tofu when the
+default face's font lacks them.  FRAME is used to probe font
+availability on the right display."
+  (when (display-graphic-p frame)
+    (when-let* ((family (cl-loop for f in jotain-emoji-font-preferences
+                                 when (find-font (font-spec :family f) frame)
+                                 return f)))
+      (set-fontset-font t 'emoji  (font-spec :family family) frame 'prepend)
+      (set-fontset-font t 'symbol (font-spec :family family) frame 'append))))
+
+(jotain-ui-apply-emoji-font)
+(add-hook 'server-after-make-frame-hook #'jotain-ui-apply-emoji-font)
+
+;;; @doc Built-in emoji picker (Emacs 29+): `C-x 8 e e' inserts by name,
+;;; `C-x 8 e s' searches, `C-x 8 e l' opens the full list, `C-x 8 e d'
+;;; describes the emoji at point.  `which-key' surfaces the prefix.
+(use-package emoji
+  :ensure nil
+  :defer t)
+
 ;;;; Built-in display tweaks
 
 ;; Don't draw cursors or highlight selections in non-focused windows.

--- a/module-system.nix
+++ b/module-system.nix
@@ -78,6 +78,13 @@ in
       editorScript
       visualScript
     ];
+    # Colour-emoji fallback for the `emoji' / `symbol' fontsets wired
+    # in lisp/init-ui.el.  Skipped on Darwin: macOS provides Apple
+    # Color Emoji system-wide, and nix-darwin's `fonts.packages' has a
+    # different shape from NixOS's.
+    fonts.packages = lib.mkIf pkgs.stdenv.hostPlatform.isLinux [
+      pkgs.noto-fonts-color-emoji
+    ];
     environment.variables = lib.mkIf cfg.defaultEditor {
       EDITOR = lib.mkOverride 900 "${lib.getBin editorScript}/bin/jotain-editor";
       VISUAL = lib.mkOverride 900 "${lib.getBin visualScript}/bin/jotain-visual";

--- a/module.nix
+++ b/module.nix
@@ -76,6 +76,11 @@ let
     ]
     ++ lib.optional cfg.sonarlint.enable pkgs.sonarlintLs;
 
+  # Colour-emoji fallback for the `emoji' / `symbol' fontsets wired in
+  # lisp/init-ui.el.  macOS ships Apple Color Emoji system-wide, so the
+  # Nix font would just bloat the closure there.
+  emojiFontPackages = lib.optional isLinux pkgs.noto-fonts-color-emoji;
+
   runtimePath = lib.makeBinPath runtimeDeps;
 
   # Wrapper around `emacs` that always passes --init-directory, so the
@@ -200,6 +205,7 @@ in
       # that ships inside cfg.package.
       (lib.hiPrio emacsWrapper)
     ]
+    ++ emojiFontPackages
     ++ lib.optional (cfg.client.enable && pkgs.stdenv.isLinux) (lib.hiPrio clientDesktopItem);
 
     # Install the Jotain Emacs configuration into ~/.config/emacs so the


### PR DESCRIPTION
## Summary

Prompted by [Unicode and Emoji Support in Emacs](https://rahuljuliato.com/posts/unicode-emojis). The article walks through Emacs's built-in Unicode workflow (`C-x 8 RET`, `C-x =`, ZWJ + VS-16 sequences) and notes that **font coverage is what makes those sequences actually render**. Jotain had none of that wired up — code points outside the Nerd Font's coverage rendered as tofu, and the built-in `emoji.el` picker was unreferenced.

Three layers, one PR:

- **`lisp/init-ui.el`** — `jotain-emoji-font-preferences` (platform-aware default: Apple Color Emoji on macOS, Noto Color Emoji elsewhere) + `jotain-ui-apply-emoji-font`, which calls `set-fontset-font` for the `emoji` and `symbol` charsets. Wired into the same top-level call + `server-after-make-frame-hook` pattern as the existing `jotain-ui-apply-font`. Also adds a `use-package emoji :ensure nil :defer t` block so `C-x 8 e {e,s,l,d}` are available out of the box (which-key already exposes the prefix).
- **`module.nix`** — `noto-fonts-color-emoji` goes into `home.packages` on Linux only (Darwin gets Apple Color Emoji system-wide, so the Nix font is dead weight there).
- **`module-system.nix`** — same on NixOS via `fonts.packages`, gated by `lib.mkIf pkgs.stdenv.hostPlatform.isLinux`.

`emacs.nix` is untouched, so the upstream cache-parity invariant (`CLAUDE.md` §"Nix build layer") still holds.

## Test plan

- [ ] `just check` passes (covers byte-compile-with-warnings-as-errors via `nix flake check` / `elisp-compile`).
- [ ] On a Linux GUI frame, `M-: (find-font (font-spec :family "Noto Color Emoji"))` returns non-nil.
- [ ] `M-: (fontset-font (frame-parameter nil 'font) ?🎉)` returns the chosen emoji font, not nil.
- [ ] In `*scratch*`, `🎉🇫🇮❤️‍🔥1️⃣` renders in colour, not tofu.
- [ ] `C-x 8 e` shows `emoji-insert / emoji-search / emoji-list / emoji-describe` via which-key; `M-x emoji-insert` works.
- [ ] On macOS, the same checks pass with `Apple Color Emoji` instead of `Noto Color Emoji`.
- [ ] `nix flake check` still passes (statix / deadnix / treefmt unaffected).

Plan file: `/root/.claude/plans/https-rahuljuliato-com-posts-unicode-emo-snazzy-bumblebee.md`

https://claude.ai/code/session_01CMgG71vi7iYZ9zMfZgdSig

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMgG71vi7iYZ9zMfZgdSig)_