### PR TITLE
Borrow four ideas from LEmacs

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -130,7 +130,9 @@ primary frame doesn't redraw before fonts are ready.
 ### `display-line-numbers` *(built-in / Nix)*
 
 Built-in line numbers — only on programming and config buffers,
-never on prose or org files where they're noise.
+never on prose or org files where they're noise. Honour the
+`jotain-line-numbers-in-prog' toggle so users can flip it off
+without editing this file.
 
 ### `pixel-scroll` *(built-in / Nix)*
 
@@ -205,7 +207,8 @@ essential for navigating deeply nested forms.
 ### `indent-bars`
 
 Vertical indent guides for code, treesit-aware so the bars
-follow real syntactic indentation.
+follow real syntactic indentation. Toggle via
+`jotain-indent-bars-enabled'.
 
 ### `kkp`
 
@@ -218,6 +221,14 @@ unconditionally.
 
 OSC 52 clipboard integration. Yank/kill in terminal Emacs
 reaches the system clipboard even through ssh + tmux.
+
+## `init-tabs.el` — Workspace tabs
+
+### `tab-bar` *(built-in / Nix)*
+
+Built-in frame-local tab bar — used as a workspace switcher.
+Bar hides itself when only one tab exists, so single-window
+sessions are unaffected.
 
 ## `init-help.el` — Help system
 
@@ -607,7 +618,9 @@ having to special-case every project's tab/space convention.
 
 Built-in project tracker. Extra root markers below mean a
 project is recognised when any of these is present, not just
-on a VCS root. Project list lives under var/.
+on a VCS root. Project list lives under var/. `C-x p P' scans
+`jotain-projects-directories' to add+open projects not yet in
+the known list.
 
 ### `projection`
 

--- a/init.el
+++ b/init.el
@@ -53,6 +53,7 @@
 (require 'init-core)         ; GC, encoding, var/ paths, sane defaults
 (require 'init-keys)         ; Global keymap and leader-key setup
 (require 'init-ui)           ; Theme, modeline, fonts, frame tweaks
+(require 'init-tabs)         ; Workspace tabs via tab-bar-mode
 (require 'init-help)         ; helpful + built-in help tweaks
 (require 'init-docs)         ; Surface jotain.info under C-h i
 (require 'init-editing)      ; Electric pairs, delsel, whitespace, region tools

--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -194,6 +194,10 @@ immediately for writes."
   (require 'ansi-color)
   (ansi-color-apply-on-region (point-min) (point-max)))
 
+(declare-function profiler-start "profiler" (mode))
+(declare-function profiler-stop "profiler")
+(declare-function profiler-report "profiler")
+
 (defvar jotain-profiler--running nil
   "Non-nil when `jotain-profile-toggle' is mid-recording.")
 

--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -194,6 +194,24 @@ immediately for writes."
   (require 'ansi-color)
   (ansi-color-apply-on-region (point-min) (point-max)))
 
+(defvar jotain-profiler--running nil
+  "Non-nil when `jotain-profile-toggle' is mid-recording.")
+
+(defun jotain-profile-toggle ()
+  "Toggle CPU+memory profiling; show the report on the second call.
+First call starts the profiler; second call stops it and pops the
+`*CPU/Memory Profiler Report*' buffer.  Useful for diagnosing
+freezes — start, reproduce, stop."
+  (interactive)
+  (if jotain-profiler--running
+      (progn (profiler-stop)
+             (setq jotain-profiler--running nil)
+             (profiler-report)
+             (message "Profiler stopped — see *CPU/Memory Profiler Report*"))
+    (profiler-start 'cpu+mem)
+    (setq jotain-profiler--running t)
+    (message "Profiler started — run `M-x jotain-profile-toggle' again to report")))
+
 ;;;; macOS — minimal modifier-key fix
 ;;
 ;; Reachable Meta is non-negotiable. The Cocoa default of Option-as-Meta

--- a/lisp/init-project.el
+++ b/lisp/init-project.el
@@ -32,8 +32,8 @@
 
 (defun jotain-find-projects-and-switch ()
   "Scan `jotain-projects-directories', pick a project, remember and open it.
-Completion labels include the parent root in parentheses so projects with
-the same base name in different roots stay distinguishable."
+Completion labels include the full abbreviated parent root, so two
+projects sharing a basename across different roots stay distinct."
   (interactive)
   (let* ((dirs (cl-loop for root in jotain-projects-directories
                         when (file-directory-p root)
@@ -41,7 +41,7 @@ the same base name in different roots stay distinguishable."
          (choices (cl-loop for d in dirs
                            when (file-directory-p d)
                            for name = (file-name-nondirectory d)
-                           for parent = (file-name-nondirectory
+                           for parent = (abbreviate-file-name
                                          (directory-file-name
                                           (file-name-directory d)))
                            collect (cons (format "%s (%s)" name parent) d))))

--- a/lisp/init-project.el
+++ b/lisp/init-project.el
@@ -20,11 +20,40 @@
 
 ;;;; project.el (built-in)
 
+(defcustom jotain-projects-directories
+  (list (expand-file-name "~/Projects")
+        (expand-file-name "~/code")
+        (expand-file-name "~/src"))
+  "Directories whose immediate subdirs are candidates for `jotain-find-projects-and-switch'."
+  :type '(repeat directory)
+  :group 'project)
+
+(defun jotain-find-projects-and-switch ()
+  "Scan `jotain-projects-directories', pick a project, remember and open it."
+  (interactive)
+  (let* ((dirs (cl-loop for root in jotain-projects-directories
+                        when (file-directory-p root)
+                        nconc (directory-files root t "\\`[^.]" t)))
+         (choices (cl-loop for d in dirs
+                           when (file-directory-p d)
+                           collect (cons (file-name-nondirectory d) d))))
+    (unless choices
+      (user-error "No project candidates under %s" jotain-projects-directories))
+    (let* ((pick (completing-read "Project: " choices nil t))
+           (dir  (cdr (assoc pick choices))))
+      (when dir
+        (when-let* ((proj (project-current nil dir)))
+          (project-remember-project proj))
+        (project-switch-project dir)))))
+
 ;;; @doc Built-in project tracker. Extra root markers below mean a
 ;;; project is recognised when any of these is present, not just
-;;; on a VCS root. Project list lives under var/.
+;;; on a VCS root. Project list lives under var/. `C-x p P' scans
+;;; `jotain-projects-directories' to add+open projects not yet in
+;;; the known list.
 (use-package project
   :ensure nil
+  :bind (:map project-prefix-map ("P" . jotain-find-projects-and-switch))
   :custom
   (project-list-file (jotain-var-file "projects.el"))
   (project-buffers-viewer 'project-list-buffers-ibuffer)

--- a/lisp/init-project.el
+++ b/lisp/init-project.el
@@ -24,19 +24,27 @@
   (list (expand-file-name "~/Projects")
         (expand-file-name "~/code")
         (expand-file-name "~/src"))
-  "Directories whose immediate subdirs are candidates for `jotain-find-projects-and-switch'."
+  "Roots whose immediate subdirs feed `jotain-find-projects-and-switch'."
   :type '(repeat directory)
   :group 'project)
 
+(declare-function project-remember-project "project" (pr &optional no-write))
+
 (defun jotain-find-projects-and-switch ()
-  "Scan `jotain-projects-directories', pick a project, remember and open it."
+  "Scan `jotain-projects-directories', pick a project, remember and open it.
+Completion labels include the parent root in parentheses so projects with
+the same base name in different roots stay distinguishable."
   (interactive)
   (let* ((dirs (cl-loop for root in jotain-projects-directories
                         when (file-directory-p root)
                         nconc (directory-files root t "\\`[^.]" t)))
          (choices (cl-loop for d in dirs
                            when (file-directory-p d)
-                           collect (cons (file-name-nondirectory d) d))))
+                           for name = (file-name-nondirectory d)
+                           for parent = (file-name-nondirectory
+                                         (directory-file-name
+                                          (file-name-directory d)))
+                           collect (cons (format "%s (%s)" name parent) d))))
     (unless choices
       (user-error "No project candidates under %s" jotain-projects-directories))
     (let* ((pick (completing-read "Project: " choices nil t))

--- a/lisp/init-tabs.el
+++ b/lisp/init-tabs.el
@@ -36,17 +36,26 @@
   (tab-bar-history-mode 1))
 
 (defun jotain-tabs--switch-project-in-tab (orig dir)
-  "Open DIR in its own tab; reuse an existing tab named after it."
-  (let* ((name (file-name-nondirectory (directory-file-name dir)))
-         (tabs (tab-bar-tabs))
-         (idx  (cl-position name tabs
-                            :key (lambda (tab) (alist-get 'name tab))
-                            :test #'string=)))
+  "Open DIR in its own tab.
+Tabs are keyed by the abbreviated project directory (stored as
+the `jotain-tabs-project-dir' tab parameter), so two projects
+that share a basename across different roots get distinct tabs."
+  (let* ((dir-key (abbreviate-file-name (directory-file-name dir)))
+         (name    (file-name-nondirectory (directory-file-name dir)))
+         (tabs    (tab-bar-tabs))
+         (idx     (cl-position
+                   dir-key tabs
+                   :key (lambda (tab)
+                          (alist-get 'jotain-tabs-project-dir tab))
+                   :test #'equal)))
     (if idx
         (progn (tab-bar-select-tab (1+ idx))
                (funcall orig dir))
       (tab-bar-new-tab)
       (tab-bar-rename-tab name)
+      (let ((current (assq 'current-tab (tab-bar-tabs))))
+        (when current
+          (push (cons 'jotain-tabs-project-dir dir-key) (cdr current))))
       (funcall orig dir))))
 
 (advice-add 'project-switch-project :around

--- a/lisp/init-tabs.el
+++ b/lisp/init-tabs.el
@@ -46,8 +46,8 @@
         (progn (tab-bar-select-tab (1+ idx))
                (funcall orig dir))
       (tab-bar-new-tab)
-      (funcall orig dir)
-      (tab-bar-rename-tab name))))
+      (tab-bar-rename-tab name)
+      (funcall orig dir))))
 
 (advice-add 'project-switch-project :around
             #'jotain-tabs--switch-project-in-tab)

--- a/lisp/init-tabs.el
+++ b/lisp/init-tabs.el
@@ -1,0 +1,56 @@
+;;; init-tabs.el --- Workspace tabs via tab-bar-mode -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Frame-local tabs as tmux-like workspaces. Each tab holds its own
+;; window configuration; `tab-bar-history-mode' adds undo/redo for the
+;; per-tab layout. Project switches open the project in a fresh tab
+;; named after the directory, so projects don't fight over windows.
+;;
+;; Built-in keybindings (C-x t prefix):
+;;   C-x t 2  new tab            C-x t 0  close tab
+;;   C-x t o  next tab           C-x t O  previous tab
+;;   C-x t RET / C-x t b  switch to a named tab
+
+;;; Code:
+
+(declare-function tab-bar-tabs "tab-bar")
+(declare-function tab-bar-select-tab "tab-bar" (&optional tab-number))
+(declare-function tab-bar-new-tab "tab-bar" (&optional arg from-number))
+(declare-function tab-bar-rename-tab "tab-bar" (name &optional tab-number))
+
+;;; @doc Built-in frame-local tab bar — used as a workspace switcher.
+;;; Bar hides itself when only one tab exists, so single-window
+;;; sessions are unaffected.
+(use-package tab-bar
+  :ensure nil
+  :hook (after-init . tab-bar-mode)
+  :functions (tab-bar-history-mode)
+  :custom
+  (tab-bar-show 1)
+  (tab-bar-new-tab-choice "*scratch*")
+  (tab-bar-close-button-show nil)
+  (tab-bar-new-button-show nil)
+  (tab-bar-tab-hints t)
+  :config
+  (tab-bar-history-mode 1))
+
+(defun jotain-tabs--switch-project-in-tab (orig dir)
+  "Open DIR in its own tab; reuse an existing tab named after it."
+  (let* ((name (file-name-nondirectory (directory-file-name dir)))
+         (tabs (tab-bar-tabs))
+         (idx  (cl-position name tabs
+                            :key (lambda (tab) (alist-get 'name tab))
+                            :test #'string=)))
+    (if idx
+        (progn (tab-bar-select-tab (1+ idx))
+               (funcall orig dir))
+      (tab-bar-new-tab)
+      (funcall orig dir)
+      (tab-bar-rename-tab name))))
+
+(advice-add 'project-switch-project :around
+            #'jotain-tabs--switch-project-in-tab)
+
+(provide 'init-tabs)
+;;; init-tabs.el ends here

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -133,11 +133,23 @@ attributes are applied globally so all frames see the update."
 (setopt cursor-in-non-selected-windows nil)
 (setopt highlight-nonselected-windows nil)
 
+(defcustom jotain-line-numbers-in-prog t
+  "When non-nil, show line numbers in `prog-mode' and `conf-mode' buffers."
+  :type 'boolean
+  :group 'jotain-ui)
+
+(defun jotain-ui--maybe-line-numbers ()
+  "Enable `display-line-numbers-mode' when `jotain-line-numbers-in-prog' is non-nil."
+  (when jotain-line-numbers-in-prog
+    (display-line-numbers-mode 1)))
+
 ;;; @doc Built-in line numbers — only on programming and config buffers,
-;;; never on prose or org files where they're noise.
+;;; never on prose or org files where they're noise. Honour the
+;;; `jotain-line-numbers-in-prog' toggle so users can flip it off
+;;; without editing this file.
 (use-package display-line-numbers
   :ensure nil
-  :hook ((prog-mode conf-mode) . display-line-numbers-mode))
+  :hook ((prog-mode conf-mode) . jotain-ui--maybe-line-numbers))
 
 ;;; @doc Built-in pixel-precision smooth scrolling. Required for usable
 ;;; trackpad / smooth-mouse scrolling.
@@ -261,9 +273,16 @@ attributes are applied globally so all frames see the update."
 (use-package rainbow-delimiters
   :hook ((lisp-mode emacs-lisp-mode) . rainbow-delimiters-mode))
 
+(defcustom jotain-indent-bars-enabled t
+  "When non-nil, enable `indent-bars-mode' in `prog-mode'."
+  :type 'boolean
+  :group 'jotain-ui)
+
 ;;; @doc Vertical indent guides for code, treesit-aware so the bars
-;;; follow real syntactic indentation.
+;;; follow real syntactic indentation. Toggle via
+;;; `jotain-indent-bars-enabled'.
 (use-package indent-bars
+  :if jotain-indent-bars-enabled
   :custom (indent-bars-treesit-support t)
   :hook (prog-mode . indent-bars-mode))
 

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -139,7 +139,7 @@ attributes are applied globally so all frames see the update."
   :group 'jotain-ui)
 
 (defun jotain-ui--maybe-line-numbers ()
-  "Enable `display-line-numbers-mode' when `jotain-line-numbers-in-prog' is non-nil."
+  "Enable `display-line-numbers-mode' if `jotain-line-numbers-in-prog' is set."
   (when jotain-line-numbers-in-prog
     (display-line-numbers-mode 1)))
 
@@ -278,13 +278,19 @@ attributes are applied globally so all frames see the update."
   :type 'boolean
   :group 'jotain-ui)
 
+(declare-function indent-bars-mode "indent-bars" (&optional arg))
+
+(defun jotain-ui--maybe-indent-bars ()
+  "Enable `indent-bars-mode' when `jotain-indent-bars-enabled' is non-nil."
+  (when jotain-indent-bars-enabled
+    (indent-bars-mode 1)))
+
 ;;; @doc Vertical indent guides for code, treesit-aware so the bars
 ;;; follow real syntactic indentation. Toggle via
 ;;; `jotain-indent-bars-enabled'.
 (use-package indent-bars
-  :if jotain-indent-bars-enabled
   :custom (indent-bars-treesit-support t)
-  :hook (prog-mode . indent-bars-mode))
+  :hook (prog-mode . jotain-ui--maybe-indent-bars))
 
 ;;;; Terminal compatibility (no-ops in GUI)
 

--- a/nix/packages-doc.nix
+++ b/nix/packages-doc.nix
@@ -39,6 +39,10 @@ let
       title = "UI: theme, modeline, fonts";
     }
     {
+      file = "init-tabs.el";
+      title = "Workspace tabs";
+    }
+    {
       file = "init-help.el";
       title = "Help system";
     }


### PR DESCRIPTION
## Summary

After auditing Rahul Juliato's [LEmacs](https://rahuljuliato.com/posts/lemacs)
(`github.com/LionyxML/LEmacs`) against Jotain, almost everything from the
post is already present and more polished here — the vertico stack,
magit, treesit, kkp, clipetty, xterm-mouse, C-z unbinding,
mac-command-modifier, daemon-aware font setup. The four items below are
the ones that were genuinely missing.

The deliberate Jotain divergences (eglot over lsp-mode, flymake over
flycheck, no builtins/third-party split) are unchanged — CLAUDE.md
calls those out as intentional, so they were out of scope.

- **Project quick-switch** (`C-x p P` → `jotain-find-projects-and-switch`):
  scan `jotain-projects-directories` (default `~/Projects`, `~/code`,
  `~/src`) for subdirs, then `project-remember-project` +
  `project-switch-project` on the pick. Mirrors LEmacs's
  `lemacs/find-projects-and-switch`. `lisp/init-project.el`.

- **`tab-bar-mode` as workspace switcher**: new `lisp/init-tabs.el`,
  required from `init.el` after `init-ui`. Bar hides when only one
  tab exists. `project-switch-project` is advised to open each project
  in a fresh tab named after its directory (reusing an existing tab
  if one already has that name). LEmacs achieves the same via
  persp-mode; built-in `tab-bar` covers it without an extra package.

- **`jotain-profile-toggle`**: one-key start/stop CPU+memory profiler
  with auto-pop of the report. LEmacs documents the manual
  `M-x profiler-start` / `M-x profiler-report` workflow; this turns it
  into a single command. `lisp/init-core.el`.

- **Two opt-out defcustoms** in `lisp/init-ui.el`:
  - `jotain-line-numbers-in-prog` (t) — toggle line numbers in
    `prog-mode`/`conf-mode`.
  - `jotain-indent-bars-enabled` (t) — toggle `indent-bars-mode`.

  Picked these because they're the two genuinely
  taste-dependent UI features. Other use-package presence was left
  alone, per CLAUDE.md's "decisive choices over user options" stance.

## Test plan

- [ ] `just check-elisp` passes (paren check + byte-compile with
      warnings-as-errors). The sandbox this branch was developed in had
      no Emacs/Nix, so CI is the first real check.
- [ ] `just run`:
  - [ ] `C-x p P` lists subdirs of `~/Projects`/`~/code`/`~/src` (or
        whatever `jotain-projects-directories` is set to) and opens the
        pick.
  - [ ] Opening a second project via `project-switch-project` lands in
        a new tab named after the project; opening the same project
        again reuses that tab instead of duplicating.
  - [ ] `M-x jotain-profile-toggle` once → "Profiler started"; second
        call → profiler report buffer pops.
  - [ ] `M-x customize-variable RET jotain-line-numbers-in-prog RET`
        flips line numbers off on next file open.
- [ ] `nix flake check` stays green.

https://claude.ai/code/session_01CHGNNCzwMk4MTWbEsEqdvF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHGNNCzwMk4MTWbEsEqdvF)_