### PR TITLE
Close gaps from "Stealing from the Best Emacs Configs"

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -290,6 +290,12 @@ actual file rather than #foo# auto-save side files. Also strips
 trailing whitespace except on the current line so you don't
 fight your own cursor.
 
+### `re-builder` *(built-in / Nix)*
+
+Make `M-x re-builder' use string syntax — the same form you'd
+paste into `re-search-forward' — instead of the default `read'
+syntax that requires escaping every backslash twice.
+
 ## `init-completion.el` — Minibuffer + in-buffer completion
 
 ### `minibuffer` *(built-in / Nix)*
@@ -333,6 +339,11 @@ grep family so candidates have room to breathe.
 Adds annotation columns (file size, mode, docstring, …) to every
 completion list. Pairs with vertico to make minibuffer choices
 self-explanatory.
+
+### `isearch` *(built-in / Nix)*
+
+Show match counts like `(3/12)' in the isearch prompt while
+typing. Built-in (Emacs 27+); replaces what `anzu' used to provide.
 
 ### `consult`
 

--- a/lisp/init-completion.el
+++ b/lisp/init-completion.el
@@ -107,6 +107,15 @@
   :demand t
   :config (marginalia-mode 1))
 
+;;; @doc Show match counts like `(3/12)' in the isearch prompt while
+;;; typing. Built-in (Emacs 27+); replaces what `anzu' used to provide.
+(use-package isearch
+  :ensure nil
+  :custom
+  (isearch-lazy-count t)
+  (lazy-count-prefix-format "(%s/%s) ")
+  (lazy-count-suffix-format nil))
+
 ;;;; Consult — the big binding table
 
 ;;; @doc Consult provides preview-as-you-go variants of nearly every

--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -250,17 +250,21 @@ immediately for writes."
   (savehist-additional-variables '(kill-ring search-ring regexp-search-ring))
   :config
   (savehist-mode 1)
-  ;; Strip text properties from kill-ring entries before they hit the
-  ;; savehist file — propertised strings serialize to enormous blobs of
-  ;; face/font-lock metadata that nobody needs across sessions.
-  (add-hook 'savehist-save-hook
-            (lambda ()
-              (setq kill-ring
-                    (mapcar (lambda (entry)
-                              (if (stringp entry)
-                                  (substring-no-properties entry)
-                                entry))
-                            kill-ring)))))
+
+  ;; Strip text properties from every ring savehist persists, so the
+  ;; savehist file doesn't bloat with face/font-lock metadata from
+  ;; whatever buffer the strings were copied out of. Named so the hook
+  ;; can be removed cleanly when the config is re-evaluated.
+  (defun jotain-core--savehist-strip-properties ()
+    "Strip text properties from persisted rings before serialization."
+    (dolist (ring '(kill-ring search-ring regexp-search-ring))
+      (set ring (mapcar (lambda (entry)
+                          (if (stringp entry)
+                              (substring-no-properties entry)
+                            entry))
+                        (symbol-value ring)))))
+
+  (add-hook 'savehist-save-hook #'jotain-core--savehist-strip-properties))
 
 ;;; @doc Built-in bookmark store. State file is themed under var/ so it
 ;;; joins the rest of Jotain's persistent state.

--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -245,8 +245,22 @@ immediately for writes."
 ;;; across sessions. Built-in, enabled globally.
 (use-package savehist
   :ensure nil
-  :custom (savehist-file (jotain-var-file "savehist.el"))
-  :config (savehist-mode 1))
+  :custom
+  (savehist-file (jotain-var-file "savehist.el"))
+  (savehist-additional-variables '(kill-ring search-ring regexp-search-ring))
+  :config
+  (savehist-mode 1)
+  ;; Strip text properties from kill-ring entries before they hit the
+  ;; savehist file — propertised strings serialize to enormous blobs of
+  ;; face/font-lock metadata that nobody needs across sessions.
+  (add-hook 'savehist-save-hook
+            (lambda ()
+              (setq kill-ring
+                    (mapcar (lambda (entry)
+                              (if (stringp entry)
+                                  (substring-no-properties entry)
+                                entry))
+                            kill-ring)))))
 
 ;;; @doc Built-in bookmark store. State file is themed under var/ so it
 ;;; joins the rest of Jotain's persistent state.

--- a/lisp/init-editing.el
+++ b/lisp/init-editing.el
@@ -71,5 +71,12 @@
   (super-save-delete-trailing-whitespace 'except-current-line)
   :config (super-save-mode 1))
 
+;;; @doc Make `M-x re-builder' use string syntax — the same form you'd
+;;; paste into `re-search-forward' — instead of the default `read'
+;;; syntax that requires escaping every backslash twice.
+(use-package re-builder
+  :ensure nil
+  :custom (reb-re-syntax 'string))
+
 (provide 'init-editing)
 ;;; init-editing.el ends here


### PR DESCRIPTION
## Summary

Audited the 16 quality-of-life settings from [Emacs Redux's roundup](https://emacsredux.com/blog/2026/04/07/stealing-from-the-best-emacs-configs/) of Doom/Purcell/Prot/Centaur configs. **13 were already in place** (bidi, `redisplay-skip-fontification-on-input`, `read-process-output-max`, non-focused window cursor/highlight, `save-interprogram-paste-before-kill`, `kill-do-not-save-duplicates`, auto-chmod shebangs, `ffap-machine-p-known`, `window-combination-resize`, winner + reversible `C-x 1`, `set-mark-command-repeat-pop`, recenter-after-save-place, `help-window-select`). This PR closes the remaining three.

- **`lisp/init-core.el`** — `savehist` now persists `kill-ring` + `search-ring` + `regexp-search-ring`, with a pre-save hook that strips text properties so the savehist file doesn't bloat with copied font-lock metadata.
- **`lisp/init-editing.el`** — `re-builder` defaults to `string` syntax so what you build in the buffer drops directly into `re-search-forward`.
- **`lisp/init-completion.el`** — `isearch` shows `(n/total)` match counts in the prompt; built-in since Emacs 27, replaces what `anzu` used to provide.

No new packages, no architectural shifts; ~15 lines of Elisp across three module files.

## Test plan

- [ ] `nix flake check` is green (treefmt, statix, deadnix, elisp paren-check, elisp byte-compile with warnings-as-errors).
- [ ] `devenv test` is green.
- [ ] Interactive smoke (in a `just run` session):
  - `C-s foo` in a multi-match buffer shows `(n/total)` in the prompt.
  - `M-x re-builder` accepts plain regex strings without double-escaped backslashes.
  - Kill a few items with `M-w`, restart Emacs, `M-y` — yanks from the previous session appear; `var/savehist.el` shows kill-ring strings without `#(...)` propertised syntax.

---
_Generated by [Claude Code](https://claude.ai/code/session_011hRCJwnveTTMVVq9QU6E8z)_