### PR TITLE
Add window-resize repeat-map and Ergonomics doc chapter

### DIFF
--- a/docs/architecture/modules.mdx
+++ b/docs/architecture/modules.mdx
@@ -56,7 +56,7 @@ GC, encoding, and the sane-defaults baseline. Restores `gc-cons-threshold` to 16
 
 ### `init-keys`
 
-Global bindings only — per-package bindings live in the relevant `use-package` block. Unbinds `C-z` / `C-x C-z` (no accidental suspend on GUI), binds `M-o` to `other-window`, enables `windmove-default-keybindings` (Shift + arrows), and defines `jotain-toggle-window-split` on `C-x j` for rotating a two-window layout. Also registers `which-key-add-key-based-replacements` for the cross-cutting `C-c` / `C-x` prefixes (`C-c n` org-roam, `C-c r` eglot-refactor, `C-c o` combobulate, `C-x P` project, etc.) so the prefix menus surface short noun-phrase labels instead of bare command names. See [Keybindings](/keybindings) for the full namespace map.
+Global bindings only — per-package bindings live in the relevant `use-package` block. Unbinds `C-z` / `C-x C-z` (no accidental suspend on GUI), binds `M-o` to `other-window`, enables `windmove-default-keybindings` (Shift + arrows), defines `jotain-toggle-window-split` on `C-x j` for rotating a two-window layout, and ships a window-resize `repeat-map` so `C-x ^ ^ ^` keeps enlarging without re-pressing `C-x`. Also registers `which-key-add-key-based-replacements` for the cross-cutting `C-c` / `C-x` prefixes (`C-c n` org-roam, `C-c r` eglot-refactor, `C-c o` combobulate, `C-x P` project, etc.) so the prefix menus surface short noun-phrase labels instead of bare command names. See [Keybindings](/keybindings) for the full namespace map and [Ergonomics](/ergonomics) for the repeat-maps rationale.
 
 ### `init-ui`
 

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -46,7 +46,11 @@ auto-creates missing parent directories on find-file.
 
 Repeat-mode lets you press the trailing key alone after a prefix
 command (e.g. C-x o o o instead of C-x o C-x o). Built-in,
-enabled globally.
+enabled globally. `repeat-exit-timeout' clears the transient map
+after two idle seconds so the user doesn't have to think about
+exiting it — the ergonomic "one-shot modifier" pattern. A
+window-resize repeat-map filling the one gap in the built-in
+coverage lives in init-keys.el.
 
 ### `uniquify` *(built-in / Nix)*
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -51,6 +51,7 @@
               "finding-information-in-emacs",
               "keybindings",
               "setting-variables",
+              "ergonomics",
               "inspiration"
             ]
           }

--- a/docs/ergonomics.mdx
+++ b/docs/ergonomics.mdx
@@ -47,14 +47,17 @@ window resizing. Jotain adds one in `lisp/init-keys.el`:
 (defvar-keymap jotain-window-resize-repeat-map
   :repeat t
   "^" #'enlarge-window
+  "v" #'shrink-window
   "}" #'enlarge-window-horizontally
   "{" #'shrink-window-horizontally)
 ```
 
-So `C-x ^ ^ ^` keeps growing the window vertically, and
-`C-x } } } { {` widens then narrows it without re-pressing `C-x`. The
-2-second `repeat-exit-timeout` (in `init-core.el`) clears the overlay
-automatically — no `C-g` needed.
+So `C-x ^ ^ ^ v` overshoots vertically then corrects, and
+`C-x } } } { {` widens then narrows horizontally — all without
+re-pressing `C-x`. `shrink-window` has no default key binding, so `v`
+only activates *inside* the repeat overlay (after another entry
+command has already fired). The 2-second `repeat-exit-timeout` (in
+`init-core.el`) clears the overlay automatically — no `C-g` needed.
 
 ## Extending repeat-maps
 

--- a/docs/ergonomics.mdx
+++ b/docs/ergonomics.mdx
@@ -1,0 +1,122 @@
+---
+title: Ergonomics
+description: One-shot modifiers, repeat-maps, and reducing chord strain in Jotain
+---
+
+# Ergonomics
+
+Long Emacs sessions punish the modifier-holding fingers. Protesilaos
+Stavrou's [keyboard ergonomics writing](https://protesilaos.com/keeb/)
+argues for replacing **held** modifier chords with **one-shot
+modifiers** — tap-then-press — so that the only fingers under load
+are the ones actually typing characters. Most of Prot's solution lives
+in keyboard firmware (split keyboards, QMK one-shot mods, thumb
+clusters). The Emacs side of the same idea is **`repeat-mode`** plus a
+small set of `repeat-map`s.
+
+This page explains what Jotain enables out of the box, how to extend
+it, and what to look at next if you want to push further.
+
+## Repeat-mode: the Emacs-native one-shot
+
+`repeat-mode` is built into Emacs 28+ and enabled globally in
+`init-core.el`. After running a command tagged with a `repeat-map`,
+Emacs installs that map as a transient overlay: the *bare* trailing
+keys keep running related commands until you press anything else (or
+2 s pass — configured via `repeat-exit-timeout`).
+
+The everyday wins are all built-in:
+
+| Type once    | Then keep typing | What happens                  |
+| ------------ | ---------------- | ----------------------------- |
+| `M-o`        | `o o o`          | Cycle through windows         |
+| `C-/`        | `/ / /`          | Undo, undo, undo              |
+| `C-x →`      | `→ →`            | Cycle through buffers         |
+| `M-g n`      | `n n n`          | Jump through compilation errors |
+| `C-x o`      | `o O`            | `other-window` forward/back   |
+
+These come from Emacs itself; Jotain just turns the mode on. Run `M-x
+describe-repeat-maps` to see every active map at any moment.
+
+## Jotain-specific maps
+
+The only built-in command family missing a sensible repeat-map is
+window resizing. Jotain adds one in `lisp/init-keys.el`:
+
+```elisp
+(defvar-keymap jotain-window-resize-repeat-map
+  :repeat t
+  "^" #'enlarge-window
+  "}" #'enlarge-window-horizontally
+  "{" #'shrink-window-horizontally)
+```
+
+So `C-x ^ ^ ^` keeps growing the window vertically, and
+`C-x } } } { {` widens then narrows it without re-pressing `C-x`. The
+2-second `repeat-exit-timeout` (in `init-core.el`) clears the overlay
+automatically — no `C-g` needed.
+
+## Extending repeat-maps
+
+To add your own, drop a `defvar-keymap` into `lisp/init-keys.el` (or
+the module owning the commands) and tag it with `:repeat t`. Every
+command bound in the map gets `repeat-map` set automatically. For
+example, paragraph navigation:
+
+```elisp
+(defvar-keymap my-paragraph-repeat-map
+  :repeat t
+  "{" #'backward-paragraph
+  "}" #'forward-paragraph)
+```
+
+Now `M-{ { {` walks backward through paragraphs without holding Meta.
+
+## Pinky-stretch escape hatches Jotain already takes
+
+A few existing bindings are quiet ergonomic wins:
+
+- **`M-o` → `other-window`** (instead of `C-x o`) — one chord, no
+  prefix sequence, both hands involved.
+- **`C-z` and `C-x C-z` disabled** — removes a foot-gun and frees `C-z`
+  for personal use.
+- **`windmove-default-keybindings`** — `Shift-<arrow>` to move
+  directionally between windows, no chord required.
+- **macOS `Cmd` → Meta** (`init-core.el`) — Meta lives under the
+  thumb, not the pinky.
+
+## Beyond Emacs: the rest of Prot's advice
+
+Most of Prot's recommendations are outside Emacs's reach:
+
+- **Caps Lock → Ctrl** is fine, but reinforces left-pinky overuse.
+  Prefer a keyboard with thumb-reachable Ctrl (or remap *both* sides).
+- **Split keyboards** (Prot uses an Iris) let each hand stay in its
+  natural posture and put modifiers under the thumbs.
+- **Firmware one-shot mods** (QMK, ZMK) let any key act as a modifier
+  for a single subsequent press. This is the hardware analogue of
+  `repeat-mode`.
+
+These are out of scope for an Emacs config, but worth knowing about
+when the in-editor wins above stop being enough.
+
+## Optional: `modifier-bar-mode`
+
+Emacs 30 ships `modifier-bar-mode`, a tool-bar widget that lets you
+tap `Ctrl`/`Meta`/`Super`/`Hyper` and have it apply to the next
+keypress — a clickable one-shot modifier. Jotain disables the
+tool-bar entirely in `early-init.el` for a clean UI, so this is
+**off by default**. To enable it for yourself, add to your
+`custom.el` or a personal init fragment:
+
+```elisp
+(tool-bar-mode 1)
+(modifier-bar-mode 1)
+```
+
+## Further reading
+
+- [Irreal: "Emacs Keyboard Ergonomics"](https://irreal.org/blog/?p=13788) — the post that prompted this page.
+- [Protesilaos's mechanical keyboards index](https://protesilaos.com/keeb/) — RSI background, Iris choice, QMK config.
+- `M-x describe-repeat-maps` — list every repeat-map currently active.
+- `(info "(emacs) Repeating")` — the official Emacs manual section.

--- a/docs/jotain.texi
+++ b/docs/jotain.texi
@@ -67,6 +67,7 @@ Guides
 * Compilation Mode::            Build and error navigation.
 * Keybindings::                 Prefix conventions and the namespace map.
 * Setting Variables::           setopt vs.@ setq vs.@ setq-default.
+* Ergonomics::                  One-shot modifiers and repeat-maps.
 * Inspiration::                 Upstream configurations and references.
 
 Appendix
@@ -133,6 +134,10 @@ Appendix
 @node Setting Variables
 @chapter Setting Variables
 @include setting-variables.texi
+
+@node Ergonomics
+@chapter Ergonomics
+@include ergonomics.texi
 
 @node Inspiration
 @chapter Inspiration

--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -150,9 +150,15 @@ immediately for writes."
 
 ;;; @doc Repeat-mode lets you press the trailing key alone after a prefix
 ;;; command (e.g. C-x o o o instead of C-x o C-x o). Built-in,
-;;; enabled globally.
+;;; enabled globally. `repeat-exit-timeout' clears the transient map
+;;; after two idle seconds so the user doesn't have to think about
+;;; exiting it — the ergonomic "one-shot modifier" pattern. A
+;;; window-resize repeat-map filling the one gap in the built-in
+;;; coverage lives in init-keys.el.
 (use-package repeat
   :ensure nil
+  :custom
+  (repeat-exit-timeout 2)
   :config (repeat-mode 1))
 
 ;;; @doc Disambiguate same-name buffers by directory prefix instead of

--- a/lisp/init-keys.el
+++ b/lisp/init-keys.el
@@ -98,5 +98,26 @@ positions, and focus are preserved during the swap."
     "C-x u"     "vundo"
     "C-x P"     "project (projection)"))
 
+;;;; Repeat maps — Emacs-native "one-shot modifier" pattern
+;;
+;; `repeat-mode' (enabled in init-core.el) lets a tagged command be
+;; repeated with single keystrokes immediately after its first
+;; invocation: type the chord once, then keep typing the trailing
+;; key.  Many built-in commands ship their own repeat-maps already
+;; (`other-window', `next-buffer', `undo', `next-error', …) — so
+;; `M-o o o' and `C-/ /' Just Work.  The maps below fill the
+;; remaining gap for commands that don't have one out of the box.
+;; See the "Ergonomics" chapter of the Info manual for background.
+
+;; After `C-x ^', `C-x }', or `C-x {', single `^', `}', or `{'
+;; keystrokes keep resizing the window. Cleared by
+;; `repeat-exit-timeout' (2 s, set in init-core.el).
+(defvar-keymap jotain-window-resize-repeat-map
+  :doc "Repeat map for window-resize commands."
+  :repeat t
+  "^" #'enlarge-window
+  "}" #'enlarge-window-horizontally
+  "{" #'shrink-window-horizontally)
+
 (provide 'init-keys)
 ;;; init-keys.el ends here

--- a/lisp/init-keys.el
+++ b/lisp/init-keys.el
@@ -109,13 +109,16 @@ positions, and focus are preserved during the swap."
 ;; remaining gap for commands that don't have one out of the box.
 ;; See the "Ergonomics" chapter of the Info manual for background.
 
-;; After `C-x ^', `C-x }', or `C-x {', single `^', `}', or `{'
-;; keystrokes keep resizing the window. Cleared by
-;; `repeat-exit-timeout' (2 s, set in init-core.el).
+;; After `C-x ^', `C-x }', or `C-x {', single `^', `v', `}', or `{'
+;; keystrokes keep resizing the window. `shrink-window' has no
+;; default key binding but joins the overlay once any other entry
+;; command has fired, so `C-x ^ ^ v v' overshoots and corrects.
+;; Cleared by `repeat-exit-timeout' (2 s, set in init-core.el).
 (defvar-keymap jotain-window-resize-repeat-map
   :doc "Repeat map for window-resize commands."
   :repeat t
   "^" #'enlarge-window
+  "v" #'shrink-window
   "}" #'enlarge-window-horizontally
   "{" #'shrink-window-horizontally)
 

--- a/nix/info-manual.nix
+++ b/nix/info-manual.nix
@@ -105,6 +105,10 @@ let
       out = "setting-variables.texi";
     }
     {
+      src = "ergonomics.mdx";
+      out = "ergonomics.texi";
+    }
+    {
       src = "inspiration.mdx";
       out = "inspiration.texi";
     }


### PR DESCRIPTION
## Summary

Prompted by [Irreal #13788](https://irreal.org/blog/?p=13788), which surfaces
Prot's keyboard-ergonomics recommendation to replace **held** modifier
chords with **one-shot modifiers** (tap-then-press). Prot's solution is
mostly firmware-level — but the in-Emacs equivalent is `repeat-mode` with
custom `repeat-map`s, which Jotain already enables in `init-core.el` without
adding any maps. This PR closes that gap minimally.

- **`lisp/init-keys.el`** — add `jotain-window-resize-repeat-map`. After
  `C-x ^`, `C-x }`, or `C-x {`, bare `^`/`}`/`{` keep resizing. Window
  resizing is the only common command family without a built-in repeat-map
  in Emacs 30; everything else (`M-o o o`, `C-/ /`, `C-x → →`, `M-g n n`)
  already Just Works.
- **`lisp/init-core.el`** — set `repeat-exit-timeout` to 2 s so the
  transient overlay clears itself; the user shouldn't have to think about
  exiting.
- **`docs/ergonomics.mdx`** — new guide explaining the pattern, listing
  built-in repeat-maps users can lean on, and showing how to extend.
  Wired into Mintlify nav (`docs.json`), Info manifest
  (`nix/info-manual.nix`), and the master Texinfo TOC (`docs/jotain.texi`).
- **`docs/configuration/package-reference.mdx`** — refreshed in lockstep
  with the updated `repeat` `;;; @doc` so the `packages-doc-in-sync` check
  stays green.

## Judgment call worth flagging

The approved plan included enabling `modifier-bar-mode` (Emacs 30's in-frame
tap-modifier widget). On closer inspection it lives inside the **tool-bar**,
which Jotain explicitly disables in `early-init.el` for a clean UI —
enabling `modifier-bar-mode` would either no-op silently or force the
tool-bar back on, contradicting Jotain's design. I kept it as a documented
one-line opt-in in the Ergonomics guide instead. Happy to flip the default
on if you'd prefer the chrome.

## Scope deliberately left out

- `god-mode` / `devil-mode` / `evil-mode` — bigger philosophical shift,
  not aligned with the Orthodox-Emacs feel.
- `key-chord-mode` — timing-based, fragile, not what Prot recommends.
- Per-major-mode repeat-maps (dired, magit) — defer until the global one
  beds in.
- OS-level Caps→Ctrl / symmetric Ctrl placement — out of scope for an
  Emacs config; mentioned in the Ergonomics page for context.

## Test plan

- [ ] `nix flake check` — covers paren-check, byte-compile (warnings as
  errors), `packages-doc-in-sync`, treefmt/statix/deadnix, and the package
  builds.
- [ ] `just info` produces a `jotain.info` containing the new **Ergonomics**
  chapter; `C-h i d m Jotain RET` from inside the wrapper Emacs finds it.
- [ ] Interactive smoke (via `just run`):
  - `C-x ^ ^ ^` enlarges vertically three times in a row.
  - `C-x } }` widens twice without re-pressing `C-x`.
  - After ~2 s of inactivity the repeat overlay clears (verifies
    `repeat-exit-timeout`).
  - `M-x describe-repeat-maps` lists `jotain-window-resize-repeat-map`.

https://claude.ai/code/session_017x9HG3NFBJBaG3fHQup2Up

---
_Generated by [Claude Code](https://claude.ai/code/session_017x9HG3NFBJBaG3fHQup2Up)_