### PR TITLE
Harden editor wrappers against option injection

### DIFF
--- a/module-system.nix
+++ b/module-system.nix
@@ -29,7 +29,7 @@ let
 
   # Fallback script for EDITOR when the daemon is not running.
   editorFallback = pkgs.writeShellScript "jotain-editor-fallback" ''
-    exec ${lib.getBin cfg.package}/bin/emacs -nw "$@"
+    exec ${lib.getBin cfg.package}/bin/emacs -nw -- "$@"
   '';
 
   # EDITOR — terminal-friendly emacsclient (works over SSH, in git commit, etc.)
@@ -37,6 +37,7 @@ let
     exec ${lib.getBin cfg.package}/bin/emacsclient \
       --tty \
       --alternate-editor=${editorFallback} \
+      -- \
       "$@"
   '';
 
@@ -45,6 +46,7 @@ let
     exec ${lib.getBin cfg.package}/bin/emacsclient \
       --create-frame \
       --alternate-editor=${lib.getBin cfg.package}/bin/emacs \
+      -- \
       "$@"
   '';
 in

--- a/module.nix
+++ b/module.nix
@@ -89,7 +89,7 @@ let
   # Fallback script for EDITOR when the daemon is not running.
   # Goes through emacsWrapper so --init-directory is preserved.
   editorFallback = pkgs.writeShellScript "jotain-editor-fallback" ''
-    exec ${emacsWrapper}/bin/emacs -nw "$@"
+    exec ${emacsWrapper}/bin/emacs -nw -- "$@"
   '';
 
   # EDITOR — terminal-friendly emacsclient (works over SSH, in git commit, etc.)
@@ -97,6 +97,7 @@ let
     exec ${lib.getBin cfg.package}/bin/emacsclient \
       --tty \
       --alternate-editor=${editorFallback} \
+      -- \
       "$@"
   '';
 
@@ -105,6 +106,7 @@ let
     exec ${lib.getBin cfg.package}/bin/emacsclient \
       --create-frame \
       --alternate-editor=${emacsWrapper}/bin/emacs \
+      -- \
       "$@"
   '';
 


### PR DESCRIPTION
### Motivation
- Prevent option-injection where attacker-controlled filenames beginning with `--` could be interpreted as `emacsclient`/`emacs` options when invoked via the `EDITOR`/`VISUAL` wrappers.

### Description
- Insert `--` before `"$@"` in the Home Manager and system module wrapper scripts (`editorFallback`, `jotain-editor`, and `jotain-visual`) in `module.nix` and `module-system.nix` so subsequent arguments are forced to be positional filenames rather than parsed options.

### Testing
- Attempted to run the repository ERT/syntax check via `just check-elisp`, but the `just` helper is not available in this container so the automated check could not be executed (no automated tests ran successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022ae760f88326a691542b6fe984ff)