### PR TITLE
Disable automatic Eglot autostart for programming modes

### DIFF
--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -74,22 +74,11 @@
 ;; the read buffer cuts the number of read(2) calls dramatically.
 (setopt read-process-output-max (* 4 1024 1024))
 
-;;; @doc Built-in LSP client. Per-language `eglot-ensure` hooks live
-;;; here so all LSP wiring is visible in one place; per-language
-;;; mode regexes stay in their `init-lang-*` file. C-c r is the
-;;; refactor prefix (rename/format/code-actions).
+;;; @doc Built-in LSP client. Start manually with `M-x eglot` in
+;;; trusted projects. C-c r is the refactor prefix
+;;; (rename/format/code-actions).
 (use-package eglot
   :ensure nil
-  ;; Per-language modules register modes only; auto-start lives here.
-  :hook
-  ((dockerfile-mode
-    go-mode go-ts-mode
-    nix-ts-mode
-    python-mode python-ts-mode
-    rust-mode rust-ts-mode
-    tsx-ts-mode
-    typescript-mode typescript-ts-mode)
-   . eglot-ensure)
   :custom
   (eglot-autoshutdown t)
   (eglot-extend-to-xref t)


### PR DESCRIPTION
### Motivation
- The change removes an automatic `eglot-ensure` hook that started language servers when opening common programming files, which could run project-controlled tooling in untrusted repositories without explicit user intent.

### Description
- Removed the `:hook` block that auto-invoked `eglot-ensure` for multiple major modes so Eglot is started only manually (e.g. with `M-x eglot`).
- Updated the Eglot doc comment to instruct manual startup in trusted projects while keeping existing keybindings and server wiring intact.
- Left other Eglot customizations and `eglot-server-programs` entries unchanged so behavior after explicit startup is preserved.

### Testing
- Attempted to run `just check-elisp`, but the test command could not be executed in this environment because `just` is not installed, so no automated Elisp checks completed (failed to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022bba0e5c8326a3c115e7fdb6262b)