### PR TITLE
Add which-key prefix labels and Keybindings reference page

### DIFF
--- a/docs/architecture/modules.mdx
+++ b/docs/architecture/modules.mdx
@@ -56,7 +56,7 @@ GC, encoding, and the sane-defaults baseline. Restores `gc-cons-threshold` to 16
 
 ### `init-keys`
 
-Global bindings only — per-package bindings live in the relevant `use-package` block. Unbinds `C-z` / `C-x C-z` (no accidental suspend on GUI), binds `M-o` to `other-window`, enables `windmove-default-keybindings` (Shift + arrows), and defines `jotain-toggle-window-split` on `C-x j` for rotating a two-window layout.
+Global bindings only — per-package bindings live in the relevant `use-package` block. Unbinds `C-z` / `C-x C-z` (no accidental suspend on GUI), binds `M-o` to `other-window`, enables `windmove-default-keybindings` (Shift + arrows), and defines `jotain-toggle-window-split` on `C-x j` for rotating a two-window layout. Also registers `which-key-add-key-based-replacements` for the cross-cutting `C-c` / `C-x` prefixes (`C-c n` org-roam, `C-c r` eglot-refactor, `C-c o` combobulate, `C-x P` project, etc.) so the prefix menus surface short noun-phrase labels instead of bare command names. See [Keybindings](/keybindings) for the full namespace map.
 
 ### `init-ui`
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,6 +43,7 @@
             "pages": [
               "compilation-mode",
               "finding-information-in-emacs",
+              "keybindings",
               "setting-variables",
               "inspiration"
             ]

--- a/docs/inspiration.mdx
+++ b/docs/inspiration.mdx
@@ -29,3 +29,7 @@ Source: git://git.sv.gnu.org/emacs.git
 
 ## Nix
 - https://wiki.nixos.org/wiki/Emacs
+
+## Keybindings — considered and not adopted
+
+- [general.el to conquer Emacs keybindings](https://bicycleforyourmind.com/generaldotel-to-conquer-emacs-keybindings) — argues for a leader-key system built on [`general.el`](https://github.com/noctuid/general.el). Researched against the built-in alternatives and **rejected** for Jotain: `general.el`'s primary differentiator is `:states` for evil-mode integration, which Jotain does not use. Emacs 30's `keymap-set`, built-in `which-key`, and use-package `:bind` already cover the article's discoverability and leader-key goals without a new dependency. The article's spirit — memorable, categorised, self-documenting prefixes — is instead realised through `which-key-add-key-based-replacements` registered in `init-keys.el`, with the per-package bindings staying colocated with their `use-package` blocks. See [Keybindings](/keybindings) for the resulting namespace map.

--- a/docs/jotain.texi
+++ b/docs/jotain.texi
@@ -61,6 +61,7 @@ Guides
 
 * Finding Information in Emacs:: Self-documenting editor workflow.
 * Compilation Mode::            Build and error navigation.
+* Keybindings::                 Prefix conventions and the namespace map.
 * Setting Variables::           setopt vs.@ setq vs.@ setq-default.
 * Inspiration::                 Upstream configurations and references.
 
@@ -116,6 +117,10 @@ Appendix
 @node Compilation Mode
 @chapter Compilation Mode
 @include compilation-mode.texi
+
+@node Keybindings
+@chapter Keybindings
+@include keybindings.texi
 
 @node Setting Variables
 @chapter Setting Variables

--- a/docs/keybindings.mdx
+++ b/docs/keybindings.mdx
@@ -1,0 +1,105 @@
+---
+title: Keybindings
+description: The Jotain keybinding namespace, organised by prefix
+---
+
+Jotain follows Emacs conventions: only **global** rebindings live in
+[`lisp/init-keys.el`](https://github.com/Jylhis/jotain/blob/main/lisp/init-keys.el);
+per-package bindings stay colocated with the package's `use-package` block.
+[`which-key`](https://github.com/justbur/emacs-which-key) is enabled by
+default, so after any prefix key a paged menu of available continuations
+appears in the echo area. The prefix labels listed below are registered via
+`which-key-add-key-based-replacements` in `init-keys.el`, so they show up in
+those menus instead of the bare command names.
+
+## `C-c` — user namespace
+
+Reserved by Emacs convention for user bindings. Jotain claims the
+following:
+
+| Key | Label | Command |
+| --- | --- | --- |
+| `C-c a` | org-agenda | `org-agenda` |
+| `C-c c` | org-capture | `org-capture` |
+| `C-c d` | dirvish | `dirvish` |
+| `C-c D` | dirvish-side | `dirvish-side` |
+| `C-c g` | magit-file | `magit-file-dispatch` |
+| `C-c h` | consult-history | `consult-history` |
+| `C-c i` | consult-info | `consult-info` |
+| `C-c k` | consult-kmacro | `consult-kmacro` |
+| `C-c l` | org-store-link | `org-store-link` |
+| `C-c m` | — | `consult-man` |
+| `C-c n` | **org-roam** prefix | `n f` find, `n i` insert, `n c` capture |
+| `C-c o` | **combobulate** prefix | structural editing dispatch |
+| `C-c r` | **eglot-refactor** prefix | `r r` rename, `r f` format, `r a` actions, `r o` organize-imports, `r q` quickfix |
+| `C-c t` | toggle-theme | `auto-dark-toggle-appearance` |
+| `C-c RET` | gptel-send | `gptel-send` |
+| `C-c M-RET` | gptel-menu | `gptel-menu` |
+| `C-c M-x` | consult-mode-command | `consult-mode-command` |
+| `C-c C-'` | claude-code-ide | `claude-code-ide-menu` |
+
+## `C-x` — control namespace
+
+Built-in Emacs prefix extended with a handful of Jotain additions:
+
+| Key | Label | Command |
+| --- | --- | --- |
+| `C-x b` | — | `consult-buffer` |
+| `C-x g` | magit-status | `magit-status` |
+| `C-x M-g` | magit-dispatch | `magit-dispatch` |
+| `C-x j` | rotate-window-split | `jotain-toggle-window-split` |
+| `C-x p b` | — | `consult-project-buffer` |
+| `C-x r b` | — | `consult-bookmark` |
+| `C-x t b` | — | `consult-buffer-other-tab` |
+| `C-x u` | vundo | `vundo` |
+| `C-x 1` | — | `jotain-nav-toggle-delete-other-windows` |
+| `C-x P` | **project (projection)** prefix | `projection-map` — multi-language project commands |
+
+## `M-` — meta namespace
+
+| Key | Command |
+| --- | --- |
+| `M-o` | `other-window` |
+| `M-$` | `jinx-correct` |
+| `C-M-$` | `jinx-languages` |
+| `C-=` | `expreg-expand` |
+| `C->` | `mc/mark-next-like-this` |
+| `C-<` | `mc/mark-previous-like-this` |
+| `C-c C-<` | `mc/mark-all-like-this` |
+
+## Disabled by default
+
+| Key | Reason |
+| --- | --- |
+| `C-z` | Accidentally suspending Emacs from a GUI frame is never what you want |
+| `C-x C-z` | Same |
+
+## Mode-local overrides
+
+A few major modes rebind `C-c` leaves locally:
+
+- `dired-mode`: `C-c C-e` → `wdired-change-to-wdired-mode` (toggle writable dired)
+- `helpful-mode`: `C-c C-d` → `helpful-at-point`
+- `sops-mode`: `C-c C-c` save, `C-c C-k` cancel, `C-c C-d` edit
+- `embark` exports: `C-c C-o` → `embark-export`
+
+## Window navigation
+
+Shift + arrow keys move focus between split windows, courtesy of the
+built-in `windmove-default-keybindings`. `M-o` cycles through windows
+linearly; `C-x j` rotates a two-window layout between horizontal and
+vertical splits.
+
+## Why no leader-key framework?
+
+The article ["general.el to conquer Emacs keybindings"](https://bicycleforyourmind.com/generaldotel-to-conquer-emacs-keybindings)
+makes a persuasive case for adopting [`general.el`](https://github.com/noctuid/general.el)
+as a unified keybinding layer. Jotain considered and rejected the
+migration: `general.el`'s primary differentiator is `:states` for
+evil-mode integration, which Jotain does not use, and Emacs 30's
+`keymap-set` plus built-in `which-key` plus use-package `:bind` already
+cover the article's discoverability and leader-key ergonomics without
+an extra dependency. The *spirit* of the article — memorable,
+categorised, self-documenting prefixes — is realised here through the
+`which-key-add-key-based-replacements` table in `init-keys.el`. See
+[Inspiration & Resources](/inspiration) for the full rationale.

--- a/docs/keybindings.mdx
+++ b/docs/keybindings.mdx
@@ -37,6 +37,7 @@ following:
 | `C-c M-RET` | gptel-menu | `gptel-menu` |
 | `C-c M-x` | consult-mode-command | `consult-mode-command` |
 | `C-c C-'` | claude-code-ide | `claude-code-ide-menu` |
+| `C-c C-<` | — | `mc/mark-all-like-this` |
 
 ## `C-x` — control namespace
 
@@ -55,7 +56,10 @@ Built-in Emacs prefix extended with a handful of Jotain additions:
 | `C-x 1` | — | `jotain-nav-toggle-delete-other-windows` |
 | `C-x P` | **project (projection)** prefix | `projection-map` — multi-language project commands |
 
-## `M-` — meta namespace
+## Other global bindings
+
+Single-keystroke globals that don't fit a `C-c` / `C-x` namespace —
+window switching, spell-check, region growth, and multi-cursor.
 
 | Key | Command |
 | --- | --- |
@@ -65,7 +69,6 @@ Built-in Emacs prefix extended with a handful of Jotain additions:
 | `C-=` | `expreg-expand` |
 | `C->` | `mc/mark-next-like-this` |
 | `C-<` | `mc/mark-previous-like-this` |
-| `C-c C-<` | `mc/mark-all-like-this` |
 
 ## Disabled by default
 

--- a/lisp/init-keys.el
+++ b/lisp/init-keys.el
@@ -58,5 +58,45 @@ positions, and focus are preserved during the swap."
   :ensure nil
   :config (windmove-default-keybindings))
 
+;;; @doc Prefix labels for `which-key'. Adopts the "memorable,
+;;; discoverable, categorised" spirit of leader-key frameworks like
+;;; `general.el' without the dependency: each prefix below acquires a
+;;; short noun-phrase label that `which-key' surfaces in place of
+;;; `+prefix' when the user pauses after the prefix key. The actual
+;;; bindings themselves stay colocated with their `use-package' blocks
+;;; (per the convention documented at the top of this file); only the
+;;; cross-cutting prefix metadata lives here.
+;;;
+;;; `which-key' is enabled in init-ui.el — we register through
+;;; `with-eval-after-load' so this module can stay independent of load
+;;; order while still taking effect the moment which-key starts.
+(with-eval-after-load 'which-key
+  (which-key-add-key-based-replacements
+    ;; C-c <letter> — global user namespace.
+    "C-c a"     "org-agenda"
+    "C-c c"     "org-capture"
+    "C-c d"     "dirvish"
+    "C-c D"     "dirvish-side"
+    "C-c g"     "magit-file"
+    "C-c h"     "consult-history"
+    "C-c i"     "consult-info"
+    "C-c k"     "consult-kmacro"
+    "C-c l"     "org-store-link"
+    "C-c n"     "org-roam"
+    "C-c o"     "combobulate"
+    "C-c r"     "eglot-refactor"
+    "C-c t"     "toggle-theme"
+    ;; C-c <punct> — AI and special leaves.
+    "C-c RET"   "gptel-send"
+    "C-c M-RET" "gptel-menu"
+    "C-c C-'"   "claude-code-ide"
+    "C-c M-x"   "consult-mode-command"
+    ;; C-x namespace.
+    "C-x g"     "magit-status"
+    "C-x M-g"   "magit-dispatch"
+    "C-x j"     "rotate-window-split"
+    "C-x u"     "vundo"
+    "C-x P"     "project (projection)"))
+
 (provide 'init-keys)
 ;;; init-keys.el ends here

--- a/nix/info-manual.nix
+++ b/nix/info-manual.nix
@@ -93,6 +93,10 @@ let
       out = "compilation-mode.texi";
     }
     {
+      src = "keybindings.mdx";
+      out = "keybindings.texi";
+    }
+    {
       src = "setting-variables.mdx";
       out = "setting-variables.texi";
     }


### PR DESCRIPTION
## Summary

Researched [`general.el` to conquer Emacs keybindings](https://bicycleforyourmind.com/generaldotel-to-conquer-emacs-keybindings) against Emacs 30 built-ins for this non-evil config and **decided not to migrate**. `general.el`'s primary differentiator is `:states` for evil-mode integration; without evil, the article's core wins (leader-key hierarchy + discoverability) are reachable with `keymap-set` + built-in `which-key` + use-package `:bind`, with no new MELPA dependency.

Adopted the article's *spirit* with three minimal changes:

- **`lisp/init-keys.el`** — added a `with-eval-after-load 'which-key` block that calls `which-key-add-key-based-replacements` for the cross-cutting `C-c` / `C-x` prefixes (`C-c n` org-roam, `C-c r` eglot-refactor, `C-c o` combobulate, `C-x P` project, etc.). Per-package bindings stay colocated with their `use-package` blocks per the existing convention; only the cross-cutting prefix metadata lives centrally.
- **`docs/keybindings.mdx`** — new reference page documenting the full namespace map (`C-c`, `C-x`, `M-`, mode-local overrides, disabled keys), wired into `docs.json`, `jotain.texi`, and `nix/info-manual.nix` so it appears in the Info build (`C-h i d m Jotain RET → Keybindings`).
- **`docs/inspiration.mdx`** — appended a "considered and not adopted" entry that links to the source article and explains the rationale, so future-us doesn't re-litigate.
- **`docs/architecture/modules.mdx`** — extended the `init-keys` paragraph to mention the new prefix labels and link to the reference page.

The full research write-up — including the alternative full-migration plan if the no-go is overridden — lives at the planning artifact for this session.

## Test plan

Local verification was skipped — this sandbox lacks `just`, `nix`, `emacs`, and `makeinfo`. Relying on CI for:

- [ ] `nix flake check` — paren scan, byte-compile-with-warnings-as-errors, statix, deadnix, nixfmt, package builds
- [ ] `devenv test` — env assertions
- [ ] `nix build .#info` — confirms `keybindings.mdx` converts cleanly through pandoc and `makeinfo` accepts the new `@chapter Keybindings` section

Manual verification once merged:

- [ ] `just run`, then press `C-c` and `C-x` with which-key visible — confirm new noun-phrase labels appear next to each prefix.
- [ ] `just info && just run`, then `C-h i d m Jotain RET` — verify the Keybindings chapter appears in the Info manual.
- [ ] `just tty` — confirm labels also render under terminal Emacs.

https://claude.ai/code/session_01KW1TzXP7mhVBM6z6pXAfPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KW1TzXP7mhVBM6z6pXAfPr)_