### PR TITLE
Run prog-mode-hook in YAML buffers

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -960,7 +960,9 @@ files. Adds module-name completion and Jinja2 highlighting.
 ### `yaml-mode`
 
 YAML major mode. Loaded on demand for the dozens of YAML-shaped
-files in any modern repo (CI, k8s, helm).
+files in any modern repo (CI, k8s, helm). YAML derives from
+`text-mode' upstream, so we re-fire `prog-mode-hook' to get the
+full editor surface (line numbers, flymake, indent guides, …).
 
 ### `csv-mode`
 

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -959,10 +959,17 @@ files. Adds module-name completion and Jinja2 highlighting.
 
 ### `yaml-mode`
 
-YAML major mode. Loaded on demand for the dozens of YAML-shaped
-files in any modern repo (CI, k8s, helm). YAML derives from
-`text-mode' upstream, so we re-fire `prog-mode-hook' to get the
-full editor surface (line numbers, flymake, indent guides, …).
+YAML major mode (MELPA). Loaded on demand for the dozens of
+YAML-shaped files in any modern repo (CI, k8s, helm). YAML derives
+from `text-mode' upstream, so we re-fire `prog-mode-hook' to get
+the full editor surface (line numbers, flymake, indent guides, …).
+
+### `yaml-ts-mode` *(built-in / Nix)*
+
+Built-in tree-sitter YAML mode (Emacs 29+). Same prog-mode
+hook tweak as `yaml-mode'; kept in its own use-package block so
+users running the built-in mode aren't forced to install the
+MELPA `yaml-mode' package by `use-package-always-ensure'.
 
 ### `csv-mode`
 

--- a/lisp/init-lang-data.el
+++ b/lisp/init-lang-data.el
@@ -7,10 +7,24 @@
 
 ;;; Code:
 
+(defun jotain-lang-data--enable-prog-mode-features ()
+  "Run `prog-mode-hook' in a `text-mode'-derived config buffer.
+Both `yaml-mode' (MELPA) and the built-in `yaml-ts-mode' derive
+from `text-mode', so none of the prog-mode niceties — line
+numbers, flymake, editorconfig, dtrt-indent, hl-todo,
+breadcrumb, indent-bars, fill-column indicator — ever fire in
+YAML buffers.  Re-running the hook reaches them without having
+to enumerate every minor mode separately, and without changing
+the mode's upstream parent."
+  (run-hooks 'prog-mode-hook))
+
 ;;; @doc YAML major mode. Loaded on demand for the dozens of YAML-shaped
-;;; files in any modern repo (CI, k8s, helm).
+;;; files in any modern repo (CI, k8s, helm). YAML derives from
+;;; `text-mode' upstream, so we re-fire `prog-mode-hook' to get the
+;;; full editor surface (line numbers, flymake, indent guides, …).
 (use-package yaml-mode
-  :defer t)
+  :defer t
+  :hook ((yaml-mode yaml-ts-mode) . jotain-lang-data--enable-prog-mode-features))
 
 ;;; @doc CSV major mode with column alignment. csv-align-mode renders
 ;;; separators visually so wide files become readable without

--- a/lisp/init-lang-data.el
+++ b/lisp/init-lang-data.el
@@ -15,16 +15,28 @@ numbers, flymake, editorconfig, dtrt-indent, hl-todo,
 breadcrumb, indent-bars, fill-column indicator — ever fire in
 YAML buffers.  Re-running the hook reaches them without having
 to enumerate every minor mode separately, and without changing
-the mode's upstream parent."
-  (run-hooks 'prog-mode-hook))
+the mode's upstream parent.  The `derived-mode-p' guard makes
+this a no-op if the buffer's mode ever (re)parents onto
+`prog-mode', preventing the hook from firing twice."
+  (unless (derived-mode-p 'prog-mode)
+    (run-hooks 'prog-mode-hook)))
 
-;;; @doc YAML major mode. Loaded on demand for the dozens of YAML-shaped
-;;; files in any modern repo (CI, k8s, helm). YAML derives from
-;;; `text-mode' upstream, so we re-fire `prog-mode-hook' to get the
-;;; full editor surface (line numbers, flymake, indent guides, …).
+;;; @doc YAML major mode (MELPA). Loaded on demand for the dozens of
+;;; YAML-shaped files in any modern repo (CI, k8s, helm). YAML derives
+;;; from `text-mode' upstream, so we re-fire `prog-mode-hook' to get
+;;; the full editor surface (line numbers, flymake, indent guides, …).
 (use-package yaml-mode
   :defer t
-  :hook ((yaml-mode yaml-ts-mode) . jotain-lang-data--enable-prog-mode-features))
+  :hook (yaml-mode . jotain-lang-data--enable-prog-mode-features))
+
+;;; @doc Built-in tree-sitter YAML mode (Emacs 29+). Same prog-mode
+;;; hook tweak as `yaml-mode'; kept in its own use-package block so
+;;; users running the built-in mode aren't forced to install the
+;;; MELPA `yaml-mode' package by `use-package-always-ensure'.
+(use-package yaml-ts-mode
+  :ensure nil
+  :defer t
+  :hook (yaml-ts-mode . jotain-lang-data--enable-prog-mode-features))
 
 ;;; @doc CSV major mode with column alignment. csv-align-mode renders
 ;;; separators visually so wide files become readable without


### PR DESCRIPTION
## Summary

`yaml-mode` (MELPA) and the built-in `yaml-ts-mode` both derive from `text-mode`, so `prog-mode-hook` never fires for YAML files. That means none of the prog-mode niceties wired up in `init-prog.el` / `init-ui.el` reach YAML buffers:

- `display-line-numbers-mode`
- `display-fill-column-indicator-mode`
- `flymake-mode`
- `editorconfig-mode`
- `dtrt-indent-mode`
- `hl-todo-mode`
- `breadcrumb-local-mode`
- `indent-bars-mode`

Painful when editing the dozens of YAML files in any modern repo (CI, k8s, helm).

This change adds a tiny helper that re-fires `prog-mode-hook` and hooks it from both `yaml-mode-hook` and `yaml-ts-mode-hook` (the latter is independent — `yaml-ts-mode` is built-in, not part of the `yaml-mode` package). The upstream parent stays `text-mode`; we just reach the hook contents from inside YAML buffers.

If we later want the same treatment for other `text-mode`-derived config formats (e.g. `jinja2-mode`), the helper is reusable — add the hook to that mode's `:hook` list.

## Test plan

- [ ] Open a YAML file (`flake.lock` won't do — use `.github/workflows/ci.yml`); verify line numbers, indent bars, hl-todo, breadcrumb, fill-column indicator, and the flymake mode-line indicator are all on.
- [ ] `M-x describe-mode` shows the active minor modes include the prog-mode set.
- [ ] Open a non-YAML `text-mode` file (e.g. plain `.txt`) and confirm those minor modes are NOT on — i.e. the change is scoped to YAML.
- [ ] `nix flake check` passes (CI).


---
_Generated by [Claude Code](https://claude.ai/code/session_015vZro3yv14XLeqs3kAMzPZ)_