### PR TITLE
ci: drop multi-platform matrix, run only x86_64-linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 # CI for the Jotain Emacs configuration.
 #
-# Two jobs run in parallel across four platforms (x86_64-linux,
-# aarch64-linux, x86_64-darwin, aarch64-darwin):
+# Two jobs run in parallel on x86_64-linux:
 #
 #   check — nix flake check (formatting, statix, deadnix, elisp-lint,
 #           elisp-compile, and package builds — jotainEmacs,
@@ -33,22 +32,9 @@ permissions:
 
 jobs:
   check:
-    name: Check (${{ matrix.system }})
+    name: Check
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            system: x86_64-linux
-          - os: ubuntu-24.04-arm
-            system: aarch64-linux
-          # macos-15-intel replaces retired macos-13; available until ~Aug 2027
-          - os: macos-15-intel
-            system: x86_64-darwin
-          - os: macos-latest
-            system: aarch64-darwin
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -63,21 +49,9 @@ jobs:
         run: nix flake check --print-build-logs
 
   test:
-    name: Dev environment (${{ matrix.system }})
+    name: Dev environment
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            system: x86_64-linux
-          - os: ubuntu-24.04-arm
-            system: aarch64-linux
-          - os: macos-15-intel
-            system: x86_64-darwin
-          - os: macos-latest
-            system: aarch64-darwin
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ All recipes assume the devenv shell is active. `direnv` handles this via `.envrc
 devenv shell -- just check
 ```
 
-CI (`.github/workflows/ci.yml`) runs two parallel jobs across all four supported platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`): `check` (`nix flake check`, which already builds `packages-default`, `packages-emacs`, `packages-info`, and `options-doc` as flake checks — so a separate `nix build` job would duplicate work) and `test` (`devenv test` — the seven `enterTest` assertions in `devenv.nix`). A workflow-level `concurrency` group cancels superseded runs on PR branches while preserving protected-branch runs so post-merge cache pushes always finish. The `jylhis` cachix cache is used for pulling and pushing artifacts.
+CI (`.github/workflows/ci.yml`) runs two parallel jobs on `x86_64-linux` (Darwin and aarch64 are not exercised in CI): `check` (`nix flake check`, which already builds `packages-default`, `packages-emacs`, `packages-info`, and `options-doc` as flake checks — so a separate `nix build` job would duplicate work) and `test` (`devenv test` — the seven `enterTest` assertions in `devenv.nix`). A workflow-level `concurrency` group cancels superseded runs on PR branches while preserving protected-branch runs so post-merge cache pushes always finish. The `jylhis` cachix cache is used for pulling and pushing artifacts.
 
 ## Common commands
 


### PR DESCRIPTION
## Summary

- Drops the 4-platform matrix from `.github/workflows/ci.yml`. Both `check` and `test` now run only on `ubuntu-latest` / `x86_64-linux`.
- Cuts CI fan-out from 8 jobs (check × 4 + test × 4) to 2. `aarch64-linux`, `x86_64-darwin`, and `aarch64-darwin` are no longer exercised in CI.
- Removes the now-unused `strategy.matrix` block and matrix-templated `name:` / `runs-on:` fields.
- Updates `CLAUDE.md` to match the new CI scope.

`pages.yml` was already Linux-only and is untouched.

The flake still exposes `packages.<system>` for all four systems; this only affects what CI exercises.

## Test plan

- [ ] CI `check` job passes on `ubuntu-latest`
- [ ] CI `test` (devenv) job passes on `ubuntu-latest`
- [ ] No Darwin / aarch64 jobs appear on the PR check list


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoTnGoM29npAQRQzuivJCK)_