### PR TITLE
Restrict Cachix writer token to push events in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
       - uses: cachix/install-nix-action@v31
 
       - uses: cachix/cachix-action@v17
+        if: github.event_name == 'pull_request'
+        with:
+          name: jylhis
+
+      - uses: cachix/cachix-action@v17
+        if: github.event_name == 'push'
         with:
           name: jylhis
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -86,6 +92,13 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - uses: cachix/cachix-action@v17
+        if: github.event_name == 'pull_request'
+        with:
+          name: jylhis
+          extraPullNames: devenv
+
+      - uses: cachix/cachix-action@v17
+        if: github.event_name == 'push'
         with:
           name: jylhis
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of `CACHIX_AUTH_TOKEN` to workflows that run repository-controlled code on `pull_request` events, which could enable cache-poisoning or credential exfiltration.

### Description
- Split the `cachix/cachix-action` invocation in `.github/workflows/ci.yml` into event-specific steps for both the `check` and `test` jobs so `pull_request` runs only get pull-only configuration and `push` runs receive the writer `authToken`.
- Add `if: github.event_name == 'pull_request'` branches that configure the cache for pulls (`name: jylhis`) and `if: github.event_name == 'push'` branches that include `authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}` and preserve `extraPullNames` where previously present.
- This change preserves pull-only cache access for PRs while ensuring the writer token is only presented in trusted push contexts.

### Testing
- Ran repository queries and file inspections with `rg` to confirm occurrences of `CACHIX_AUTH_TOKEN`, `cachix-action`, and `devenv test`, and the searches succeeded.
- Displayed and inspected the modified workflow with `sed -n '1,260p' .github/workflows/ci.yml` and `nl -ba .github/workflows/ci.yml | sed -n '45,130p'` to validate the inserted `if:` guards, and both commands succeeded.
- Verified the diff with `git diff -- .github/workflows/ci.yml` and committed the change with `git commit -m "Restrict Cachix auth to push events in CI"`, and the commit succeeded.
- Created a PR titled "Restrict Cachix writer token usage to trusted CI pushes" containing the change and validation notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022e2eeb788326a922f3a4f981112e)