### PR TITLE
Pin ECA server in modules

### DIFF
--- a/module-system.nix
+++ b/module-system.nix
@@ -112,6 +112,7 @@ in
       selectedPackage
       editorScript
       visualScript
+      pkgsWithOverlay.eca
     ];
     # Colour-emoji fallback for the `emoji' / `symbol' fontsets wired
     # in lisp/init-ui.el.  Skipped on Darwin: macOS provides Apple

--- a/module.nix
+++ b/module.nix
@@ -82,6 +82,7 @@ let
       git # magit, vc
       direnv # envrc
       coreutils # gls, used by dirvish-listing-switches on darwin
+      pkgsWithOverlay.eca # eca-emacs server; prevents runtime download fallback
     ]
     ++ lib.optional cfg.sonarlint.enable pkgs.sonarlintLs
     ++ lib.optional cfg.dockerfileLsp.enable pkgs.dockerfile-language-server;


### PR DESCRIPTION
### Motivation
- Prevent eca-emacs from falling back to downloading and running an unpinned `eca` server by ensuring the Nix-provided `eca` binary is available on the runtime PATH used by wrapped Emacs sessions and on system installations.

### Description
- Add `pkgsWithOverlay.eca` to `runtimeDeps` in `module.nix` so the Emacs wrapper's `runtimePath` (and thus daemon/wrapped sessions) include the pinned server, and add `pkgsWithOverlay.eca` to `environment.systemPackages` in `module-system.nix` so NixOS/nix-darwin installations expose the same Nix-controlled binary.

### Testing
- Ran `git diff --check` and a targeted Python assertion that verifies both `module.nix` and `module-system.nix` reference `pkgsWithOverlay.eca`, and both checks passed; `just check-elisp` and `nix flake check` were not executed because `just` and `nix` are not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d2f1a909c8326a12802762dbab422)