### PR TITLE
Resolve standalone nixpkgs via root lock input

### DIFF
--- a/emacs-jylhis.nix
+++ b/emacs-jylhis.nix
@@ -10,7 +10,8 @@
       (
         let
           lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-          n = lock.nodes.nixpkgs.locked;
+          nixpkgsNode = lock.nodes.root.inputs.nixpkgs;
+          n = lock.nodes.${nixpkgsNode}.locked;
         in
         fetchTarball {
           url = "https://github.com/${n.owner}/${n.repo}/archive/${n.rev}.tar.gz";

--- a/emacs.nix
+++ b/emacs.nix
@@ -40,7 +40,8 @@
       (
         let
           lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-          n = lock.nodes.nixpkgs.locked;
+          nixpkgsNode = lock.nodes.root.inputs.nixpkgs;
+          n = lock.nodes.${nixpkgsNode}.locked;
         in
         fetchTarball {
           url = "https://github.com/${n.owner}/${n.repo}/archive/${n.rev}.tar.gz";
@@ -220,7 +221,8 @@ let
   # Verify after any change to defaults:
   #     nix-instantiate --eval --strict -E \
   #       'let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  #            n = lock.nodes.nixpkgs.locked;
+  #            nixpkgsNode = lock.nodes.root.inputs.nixpkgs;
+  #            n = lock.nodes.${nixpkgsNode}.locked;
   #            ov = lock.nodes.emacs-overlay.locked;
   #            nixpkgs = fetchTarball { url = "https://github.com/${n.owner}/${n.repo}/archive/${n.rev}.tar.gz"; sha256 = n.narHash; };
   #            overlay = fetchTarball { url = "https://github.com/${ov.owner}/${ov.repo}/archive/${ov.rev}.tar.gz"; sha256 = ov.narHash; };


### PR DESCRIPTION
### Motivation
- Standalone Nix entrypoints (`emacs.nix` and `emacs-jylhis.nix`) previously read `lock.nodes.nixpkgs` directly, which can point to a transitive flake input and weaken supply-chain provenance. 
- The change ensures standalone builds consistently resolve the repository root's `nixpkgs` input so the pinned root lock entry is used for fetches.

### Description
- Change `emacs.nix` to resolve the root nixpkgs node via `nixpkgsNode = lock.nodes.root.inputs.nixpkgs; n = lock.nodes.${nixpkgsNode}.locked;` instead of `lock.nodes.nixpkgs.locked` for the default `pkgs` import. 
- Apply the same root-resolved nixpkgs lookup to `emacs-jylhis.nix` so it no longer follows a transitive flake input's `nixpkgs`. 
- Update the cache-parity verification snippet in `emacs.nix` to use the same root-resolved lookup pattern.

### Testing
- ✅ Ran a Python validation that parsed `flake.lock` and confirmed `root.inputs.nixpkgs` is present and both `emacs.nix` and `emacs-jylhis.nix` use `nixpkgsNode = lock.nodes.root.inputs.nixpkgs;` with `n = lock.nodes.${nixpkgsNode}.locked;`. 
- ✅ Ran repository checks to verify diffs and that the modified files contain the intended replacements. 
- ⚠️ `just check-elisp` and `nix-instantiate --parse emacs.nix` were not run due to missing tooling in the environment (reported as environment limitations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d300c548c8326acda8e69ebf4f320)