### PR TITLE
Stop persisting kill/search rings in savehist to prevent secret leakage

### DIFF
--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -269,24 +269,8 @@ freezes — start, reproduce, stop."
   :ensure nil
   :custom
   (savehist-file (jotain-var-file "savehist.el"))
-  (savehist-additional-variables '(kill-ring search-ring regexp-search-ring))
   :config
-  (savehist-mode 1)
-
-  ;; Strip text properties from every ring savehist persists, so the
-  ;; savehist file doesn't bloat with face/font-lock metadata from
-  ;; whatever buffer the strings were copied out of. Named so the hook
-  ;; can be removed cleanly when the config is re-evaluated.
-  (defun jotain-core--savehist-strip-properties ()
-    "Strip text properties from persisted rings before serialization."
-    (dolist (ring '(kill-ring search-ring regexp-search-ring))
-      (set ring (mapcar (lambda (entry)
-                          (if (stringp entry)
-                              (substring-no-properties entry)
-                            entry))
-                        (symbol-value ring)))))
-
-  (add-hook 'savehist-save-hook #'jotain-core--savehist-strip-properties))
+  (savehist-mode 1))
 
 ;;; @doc Built-in bookmark store. State file is themed under var/ so it
 ;;; joins the rest of Jotain's persistent state.


### PR DESCRIPTION
### Motivation
- Persisting `kill-ring`, `search-ring`, and `regexp-search-ring` to the `savehist` file can silently write copied secrets and search terms to disk in cleartext, exposing API keys, passwords, or plaintext SOPS content.
- The prior mitigation only stripped text properties and did not redact, encrypt, truncate, or otherwise harden sensitive contents, so a safer default is to avoid persisting those rings at all.

### Description
- Removed `savehist-additional-variables` entries for `kill-ring`, `search-ring`, and `regexp-search-ring` from `lisp/init-core.el` so those rings are no longer serialized to `var/savehist.el`.
- Deleted the prior `savehist` hook and helper that stripped text properties from ring entries because ring persistence is no longer enabled.
- Kept `savehist` enabled for normal minibuffer history via `savehist-mode` so usual history persistence remains unchanged.

### Testing
- Attempted to run `just check-elisp` in the environment but it failed because `just` is not installed, so no automated Elisp checks completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4bd0e4f48326b008a9eb366217dc)