### PR TITLE
Harden Pages workflow against non-main manual dispatch deployments

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,8 +26,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -35,6 +33,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/main'
     name: Build docs
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -66,10 +65,14 @@ jobs:
           path: site
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     name: Deploy
     needs: build
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
### Motivation
- Prevent a manually-triggered `workflow_dispatch` from building and publishing documentation from an arbitrary branch and reduce the scope of privileged workflow permissions.

### Description
- Add `if: github.ref == 'refs/heads/main'` to both the `build` and `deploy` jobs in `.github/workflows/pages.yml` so only `main` can execute the privileged build/deploy path.
- Reduce workflow-level `permissions` to `contents: read` and move `pages: write` and `id-token: write` to the `deploy` job only to follow least-privilege principles.

### Testing
- Verified the workflow diff with `git diff -- .github/workflows/pages.yml` and committed the change successfully.
- Attempted to run the repository check `just check-elisp`, but it could not run in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d555f59d48326a85e999a3c88ea67)