### PR TITLE
Harden .git parsing in git stats

### DIFF
--- a/lisp/init-vc.el
+++ b/lisp/init-vc.el
@@ -206,6 +206,13 @@ Each value is a plist (:changes N :commits M :ts TIMESTAMP :busy BOOL).")
 (defvar jotain-git-stats--timer nil
   "Idle timer that walks the cache and invalidates stale entries.")
 
+(defcustom jotain-git-stats-max-dotgit-bytes 4096
+  "Maximum number of bytes read from a regular `.git' file.
+Worktree indirection files are tiny; larger files are treated as
+untrusted and ignored by `jotain-git-stats--git-dir'."
+  :type 'integer
+  :group 'jotain-vc)
+
 (defun jotain-git-stats--entry (root)
   "Return the cache plist for ROOT, creating a zeroed one if missing."
   (or (gethash root jotain-git-stats--cache)
@@ -221,16 +228,20 @@ Each value is a plist (:changes N :commits M :ts TIMESTAMP :busy BOOL).")
   "Resolve the git-dir for ROOT.
 Handles both normal repos (`.git' is a directory) and worktrees
 (`.git' is a regular file holding `gitdir: <path>'). Returns nil
-when ROOT is not under git control."
+when ROOT is not under git control or parsing fails."
   (let ((dotgit (expand-file-name ".git" root)))
     (cond
      ((file-directory-p dotgit) dotgit)
      ((file-regular-p dotgit)
-      (with-temp-buffer
-        (insert-file-contents dotgit)
-        (goto-char (point-min))
-        (when (re-search-forward "^gitdir: \\(.+\\)$" nil t)
-          (expand-file-name (string-trim (match-string 1)) root))))
+      (condition-case nil
+          (with-temp-buffer
+            (insert-file-contents dotgit nil 0 jotain-git-stats-max-dotgit-bytes)
+            (goto-char (point-min))
+            (when (re-search-forward "^gitdir: \\(.+\\)$" nil t)
+              (let ((git-dir (expand-file-name (string-trim (match-string 1)) root)))
+                (unless (file-remote-p git-dir)
+                  git-dir))))
+        (file-error nil)))
      (t nil))))
 
 (defun jotain-git-stats--git-busy-p (root)


### PR DESCRIPTION
### Motivation
- The modeline `jotain-git-stats` path could synchronously read an attacker-controlled regular `.git` file with `insert-file-contents` and then feed the parsed value into `file-exists-p`, which risked unbounded I/O, uncaught `file-error` during redisplay, or triggering file-name-handler probes for remote/magic paths.
- The intent is to stop untrusted or large `.git` files from causing availability or unexpected remote I/O while preserving accurate behavior for normal repos and small worktree indirection files.

### Description
- Add a configurable cap `jotain-git-stats-max-dotgit-bytes` (default `4096`) to limit how many bytes are read from a regular `.git` worktree indirection file.
- Change `jotain-git-stats--git-dir` to read the `.git` file with the byte limit via `insert-file-contents` and to wrap parsing in `condition-case` so `file-error` is safely handled and returns nil on failure.
- Reject remote/magic `gitdir` targets by checking `file-remote-p` and returning nil for remote paths so the modeline does not trigger remote file-name-handler probes.
- Preserve the existing behavior for normal repositories where `.git` is a directory and otherwise return nil when parsing fails.

### Testing
- Attempted to run `just check-elisp`, but `just` is not installed in the current environment so the check could not be executed (failure: missing tool).
- Inspected the modified file and verified the patch (`lisp/init-vc.el`) contains the new `defcustom` and the hardened `jotain-git-stats--git-dir` implementation via a line-range diff inspection.
- No ERT/byte-compile jobs were run in this environment due to missing tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1731c7aaa08326a4a34178570672d8)