### PR TITLE
Add rsync to Jotain runtime path

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -84,6 +84,7 @@ let
       direnv # envrc
       coreutils # gls, used by dirvish-listing-switches on darwin
       pkgsWithOverlay.eca # eca-emacs server; prevents runtime download fallback
+      rsync # dired-rsync (C-c C-r)
     ]
     ++ lib.optional cfg.sonarlint.enable pkgs.sonarlint-ls
     ++ lib.optional cfg.dockerfileLsp.enable pkgs.dockerfile-language-server;


### PR DESCRIPTION
### Motivation
- Ensure `dired-rsync` (bound to `C-c C-r`) can execute in daemon/launchd/Nix wrapper contexts by provisioning the `rsync` binary in the wrapper `PATH`.

### Description
- Add `rsync` to `runtimeDeps` in `module.nix` so the wrapper `runtimePath` includes `rsync` (minimal change, one-line addition).

### Testing
- Attempted to run the automated Elisp checks via `just check-elisp`, but the command failed in this environment with `just: command not found`, and the change was verified via `git diff` and committed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5a0434348326b9e806791fe75833)