### PR TITLE
Fix project tab parameter lookup

### DIFF
--- a/lisp/init-tabs.el
+++ b/lisp/init-tabs.el
@@ -53,9 +53,11 @@ that share a basename across different roots get distinct tabs."
                (funcall orig dir))
       (tab-bar-new-tab)
       (tab-bar-rename-tab name)
-      (let ((current (assq 'current-tab (tab-bar-tabs))))
+      (let ((current (cl-find-if (lambda (tab)
+                                   (alist-get 'current-tab tab))
+                                 (tab-bar-tabs))))
         (when current
-          (push (cons 'jotain-tabs-project-dir dir-key) (cdr current))))
+          (setf (alist-get 'jotain-tabs-project-dir current) dir-key)))
       (funcall orig dir))))
 
 (advice-add 'project-switch-project :around


### PR DESCRIPTION
### Motivation
- Ensure the `jotain-tabs-project-dir` tab parameter is actually stored on the newly created tab so project switches reuse existing project tabs instead of creating duplicate tabs.

### Description
- Replace the incorrect top-level `(assq 'current-tab (tab-bar-tabs))` lookup with a `cl-find-if` over `(tab-bar-tabs)` to locate the tab alist whose `current-tab` entry is set, and write the project key using `(setf (alist-get 'jotain-tabs-project-dir current) dir-key)`.

### Testing
- Attempted to run `just check-elisp`, but the command failed in this environment because `just` is not installed, so no automated Elisp checks were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5a02b58883268a6b1cdbe11f165f)