### PR TITLE
Guard missing Jylhis theme package

### DIFF
--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -47,7 +47,9 @@ and the result is a face-attribute soup."
     (unless noninteractive
       (load-theme jotain-theme-light t t)
       (load-theme jotain-theme-dark  t t))
-  (message "jylhis-themes is unavailable; keeping Emacs default theme"))
+  (setq jotain-theme-light 'modus-operandi
+        jotain-theme-dark 'modus-vivendi)
+  (message "jylhis-themes is unavailable; falling back to Modus themes"))
 
 ;;; @doc Flips between `jotain-theme-light` and `jotain-theme-dark`
 ;;; following the system appearance — works on macOS, GNOME, and

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -47,8 +47,8 @@ and the result is a face-attribute soup."
     (unless noninteractive
       (load-theme jotain-theme-light t t)
       (load-theme jotain-theme-dark  t t))
-  (setq jotain-theme-light 'modus-operandi
-        jotain-theme-dark 'modus-vivendi)
+  (setopt jotain-theme-light 'modus-operandi
+          jotain-theme-dark 'modus-vivendi)
   (message "jylhis-themes is unavailable; falling back to Modus themes"))
 
 ;;; @doc Flips between `jotain-theme-light` and `jotain-theme-dark`

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -40,14 +40,14 @@ and the result is a face-attribute soup."
 
 ;; Register the Jylhis theme directory on custom-theme-load-path.
 ;; The package ships jylhis-themes.el as the entry point for this.
-(require 'jylhis-themes)
-
-;; Pre-load both themes so auto-dark can flip between them without
-;; re-evaluating the .el files on every appearance change.  Guarded
-;; against batch mode where custom-theme-load-path may be incomplete.
-(unless noninteractive
-  (load-theme jotain-theme-light t t)
-  (load-theme jotain-theme-dark  t t))
+(if (require 'jylhis-themes nil t)
+    ;; Pre-load both themes so auto-dark can flip between them without
+    ;; re-evaluating the .el files on every appearance change.  Guarded
+    ;; against batch mode where custom-theme-load-path may be incomplete.
+    (unless noninteractive
+      (load-theme jotain-theme-light t t)
+      (load-theme jotain-theme-dark  t t))
+  (message "jylhis-themes is unavailable; keeping Emacs default theme"))
 
 ;;; @doc Flips between `jotain-theme-light` and `jotain-theme-dark`
 ;;; following the system appearance — works on macOS, GNOME, and


### PR DESCRIPTION
### Motivation
- The UI module unconditionally called `(require 'jylhis-themes)` in `lisp/init-ui.el`, which aborts Emacs startup for source checkouts or non-Nix paths where the `jylhis-themes` package is not on `load-path`.

### Description
- Modify `lisp/init-ui.el` to use `(require 'jylhis-themes nil t)` and only preload `jotain-theme-light`/`jotain-theme-dark` when the feature is available, otherwise emit a clear message and keep Emacs' default theme.

### Testing
- Attempted to run `just check-elisp` in the execution environment but the `just` helper is not available, so the automated Elisp check could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d563899608326b14fa2cc0710dd3d)