### PR TITLE
Use upstream SonarLint package attr in module

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -75,7 +75,7 @@ let
       direnv # envrc
       coreutils # gls, used by dirvish-listing-switches on darwin
     ]
-    ++ lib.optional cfg.sonarlint.enable pkgs.sonarlintLs
+    ++ lib.optional cfg.sonarlint.enable pkgs.sonarlint-ls
     ++ lib.optional cfg.dockerfileLsp.enable pkgs.dockerfile-language-server;
 
   # Colour-emoji fallback for the `emoji' / `symbol' fontsets wired in


### PR DESCRIPTION
### Motivation
- Prevent Nix/Home Manager evaluation failures when `services.jotain.sonarlint.enable` is set by avoiding a reference to an overlay-only alias that may not be present in the module-level `pkgs`.

### Description
- Replace the overlay-only `pkgs.sonarlintLs` reference with the upstream `pkgs.sonarlint-ls` attribute in `module.nix` so `runtimeDeps` does not require this repository's overlay to be applied.

### Testing
- Confirmed the change with `git diff -- module.nix`, searched for occurrences with `rg -n 'sonarlint' module.nix`, and inspected the modified lines with `nl -ba module.nix | sed -n '68,86p'`; no Nix evaluation was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d56395fbc8326b7dd21be5a21d92a)