### PR TITLE
Clarify font-scale customization docs

### DIFF
--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -83,7 +83,8 @@ and the result is a face-attribute soup."
 (defcustom jotain-font-scale 1.0
   "Multiplier applied to every height in the font preference lists.
 Increase above 1.0 on large or high-density displays where the
-default sizes feel small (e.g. set 1.25 in custom.el for 4K)."
+default sizes feel small (for example, set it to 1.25 in your
+machine-local config)."
   :type 'float
   :group 'jotain-ui)
 


### PR DESCRIPTION
### Motivation
- The `jotain-font-scale` docstring pointed users to set the value in `custom.el` even though `init.el` intentionally treats `custom-file` as write-only and never loads it, so persisted Customize changes would not affect startup behavior.

### Description
- Update the `jotain-font-scale` docstring in `lisp/init-ui.el` to remove the misleading `custom.el` guidance and instead refer users to machine-local configuration, without changing runtime behavior or the repo's declarative startup policy.

### Testing
- Attempted to run `just check-elisp` but it failed in this environment because the `just` command is not installed, so no automated Elisp checks were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5a039ed483269301141aa363eb48)