### PR TITLE
Docs: align cache-parity references to pkgs.emacs (emacs31 → emacs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ There's also an `emacs-smoke` script (defined in `devenv.nix`) that byte-compile
 
 ### Nix build layer — cache-parity invariant
 
-**This is the most important invariant in the repo:** every default in `emacs.nix`'s argument list must match the corresponding default in upstream nixpkgs `make-emacs.nix` (and the explicit args `emacs-overlay` passes to its prebuilt attrs). When that holds, `import ./emacs.nix {}` produces the **exact same store path** as `pkgs.emacs31`, and the `git`/`unstable`/`igc` variants the store paths of `pkgs.emacs-git`/`emacs-unstable`/`emacs-igc`, so every default-rev build is a binary-cache hit (Hydra for mainline, `nix-community.cachix.org` for the overlay variants, plus the `jylhis` cachix cache) and nothing is rebuilt from source.
+**This is the most important invariant in the repo:** every default in `emacs.nix`'s argument list must match the corresponding default in upstream nixpkgs `make-emacs.nix` (and the explicit args `emacs-overlay` passes to its prebuilt attrs). When that holds, `import ./emacs.nix {}` produces the **exact same store path** as `pkgs.emacs`, and the `git`/`unstable`/`igc` variants the store paths of `pkgs.emacs-git`/`emacs-unstable`/`emacs-igc`, so every default-rev build is a binary-cache hit (Hydra for mainline, `nix-community.cachix.org` for the overlay variants, plus the `jylhis` cachix cache) and nothing is rebuilt from source.
 
-The base package map: `mainline` (default) is nixpkgs `emacs31` (release branch); `git`/`unstable`/`igc` come from [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay), wired in as a flake input alongside `nixpkgs`; `macport` is nixpkgs' `emacs-macport` alias (→ `emacs30-macport`, the jdtsmith/emacs-mac fork — emacs-overlay does not ship a macport). Only custom `rev` pins and the Darwin patch flags go through `overrideAttrs` and *intentionally* bust the cache. Any edit to `emacs.nix` that touches the `basePackage.override { … }` block must preserve parity for the mainline variant (and ideally the overlay variants). Verify with:
+The base package map: `mainline` (default) is nixpkgs' default `pkgs.emacs` attribute (currently the Emacs 30 release); `git`/`unstable`/`igc` come from [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay), wired in as a flake input alongside `nixpkgs`; `macport` is nixpkgs' `emacs-macport` alias (→ `emacs30-macport`, the jdtsmith/emacs-mac fork — emacs-overlay does not ship a macport). Only custom `rev` pins and the Darwin patch flags go through `overrideAttrs` and *intentionally* bust the cache. Any edit to `emacs.nix` that touches the `basePackage.override { … }` block must preserve parity for the mainline variant (and ideally the overlay variants). Verify with:
 
 ```
 nix-instantiate --eval --strict -E '
@@ -78,7 +78,7 @@ nix-instantiate --eval --strict -E '
       overlay = fetchTarball { url = "https://github.com/${ov.owner}/${ov.repo}/archive/${ov.rev}.tar.gz"; sha256 = ov.narHash; };
       pkgs = import nixpkgs { overlays = [ (import overlay) ]; };
   in {
-    mainline = (import ./emacs.nix {}).outPath == pkgs.emacs31.outPath;
+    mainline = (import ./emacs.nix {}).outPath == pkgs.emacs.outPath;
     git      = (import ./emacs.nix { variant = "git"; }).outPath == pkgs.emacs-git.outPath;
     unstable = (import ./emacs.nix { variant = "unstable"; }).outPath == pkgs.emacs-unstable.outPath;
     igc      = (import ./emacs.nix { variant = "igc"; }).outPath == pkgs.emacs-igc.outPath;

--- a/docs/architecture/nix-build.mdx
+++ b/docs/architecture/nix-build.mdx
@@ -11,11 +11,11 @@ Jotain uses Nix for reproducible Emacs builds with fine-grained control over com
 
 ### emacs.nix
 
-The core build expression. It selects a base package per variant — nixpkgs' `emacs31` for the default `mainline`, emacs-overlay's `emacs-git`/`emacs-unstable`/`emacs-igc` for the git-based variants, and nixpkgs' `emacs-macport` alias for macport — and calls `.override { ... }` with every upstream build flag exposed as a file-level argument. The [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay) is added in `flake.nix`/`devenv.nix` to supply the git-based variants.
+The core build expression. It selects a base package per variant — nixpkgs' default `emacs` attribute for the default `mainline`, emacs-overlay's `emacs-git`/`emacs-unstable`/`emacs-igc` for the git-based variants, and nixpkgs' `emacs-macport` alias for macport — and calls `.override { ... }` with every upstream build flag exposed as a file-level argument. The [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay) is added in `flake.nix`/`devenv.nix` to supply the git-based variants.
 
 Supported:
 
-- **Source variants**: `mainline` (nixpkgs `emacs31`, the Emacs 31 release branch, default), `git` (emacs-overlay's `emacs-git`, current master), `unstable` (`emacs-unstable`, latest tagged release), `macport` (`emacs-macport` → nixpkgs `emacs30-macport`, jdtsmith/emacs-mac fork), `igc` (`emacs-igc`, the feature/igc3 Memory Pool System incremental GC branch).
+- **Source variants**: `mainline` (nixpkgs' default `emacs` attribute, currently the Emacs 30 release, default), `git` (emacs-overlay's `emacs-git`, current master), `unstable` (`emacs-unstable`, latest tagged release), `macport` (`emacs-macport` → nixpkgs `emacs30-macport`, jdtsmith/emacs-mac fork), `igc` (`emacs-igc`, the feature/igc3 Memory Pool System incremental GC branch).
 - **GUI toolkits**: GTK3, pgtk (pure GTK for Wayland), NS (Cocoa/NeXTstep on macOS), Motif, Athena, X11, or no GUI at all (`noGui = true`).
 - **Compilation**: native compilation (libgccjit AOT, default when the build platform can execute the host), compressed install, C sources for `find-function-C-source`, `srcRepo` (run autoreconf on git-based sources).
 - **Image formats**: WebP (default), Cairo (X11 default), optionally ImageMagick.
@@ -31,7 +31,7 @@ import ./emacs.nix {}                  # mainline
 import ./emacs.nix { noGui = true; }   # any standard override
 ```
 
-produces the *exact* store path of `pkgs.emacs31(.override { ... })` — and `variant = "git"`/`"unstable"`/`"igc"` the store paths of the matching emacs-overlay attrs — so the Hydra, `nix-community.cachix.org`, and project `jylhis` binary caches hit and nothing recompiles from source. Only custom `rev` pins and the Darwin patch flags are expected to diverge — those paths run through `overrideAttrs` and intentionally bust the cache.
+produces the *exact* store path of `pkgs.emacs(.override { ... })` — and `variant = "git"`/`"unstable"`/`"igc"` the store paths of the matching emacs-overlay attrs — so the Hydra, `nix-community.cachix.org`, and project `jylhis` binary caches hit and nothing recompiles from source. Only custom `rev` pins and the Darwin patch flags are expected to diverge — those paths run through `overrideAttrs` and intentionally bust the cache.
 
 Verify after any change to defaults:
 
@@ -50,7 +50,7 @@ nix-instantiate --eval --strict -E '
       };
       pkgs = import nixpkgs { overlays = [ (import overlay) ]; };
   in {
-    mainline = (import ./emacs.nix {}).outPath == pkgs.emacs31.outPath;
+    mainline = (import ./emacs.nix {}).outPath == pkgs.emacs.outPath;
     git      = (import ./emacs.nix { variant = "git"; }).outPath == pkgs.emacs-git.outPath;
     unstable = (import ./emacs.nix { variant = "unstable"; }).outPath == pkgs.emacs-unstable.outPath;
     igc      = (import ./emacs.nix { variant = "igc"; }).outPath == pkgs.emacs-igc.outPath;

--- a/docs/architecture/overview.mdx
+++ b/docs/architecture/overview.mdx
@@ -45,7 +45,7 @@ The Elisp configuration is split into three parts:
 
 The Nix layer provides reproducible Emacs builds:
 
-1. **`emacs.nix`** — wraps nixpkgs' `emacs31` (default), the git-based attrs from [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay) (`git`/`unstable`/`igc`), or `pkgs.emacs-macport` with the full set of build flags exposed as arguments. A cache-parity invariant guarantees that `import ./emacs.nix {}` produces the same store path as `pkgs.emacs31` (and each overlay variant the matching overlay attr), so default-rev builds are cache hits against Hydra and `nix-community.cachix.org`. Only custom `rev` pins and Darwin patches run through `overrideAttrs` and intentionally rebuild from source.
+1. **`emacs.nix`** — wraps nixpkgs' default `emacs` attribute (default), the git-based attrs from [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay) (`git`/`unstable`/`igc`), or `pkgs.emacs-macport` with the full set of build flags exposed as arguments. A cache-parity invariant guarantees that `import ./emacs.nix {}` produces the same store path as `pkgs.emacs` (and each overlay variant the matching overlay attr), so default-rev builds are cache hits against Hydra and `nix-community.cachix.org`. Only custom `rev` pins and Darwin patches run through `overrideAttrs` and intentionally rebuild from source.
 
 2. **`emacs-jylhis.nix`** — builds the pinned `github:jylhis/emacs` Meson fork. The flake exposes it as a non-default opt-in backend so consumer flakes can install the same Jotain setup on the fork without changing the stable default.
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -23,7 +23,7 @@ The default build targets the current system and includes every tree-sitter gram
 just build
 ```
 
-This runs `nix-build --argstr system <current-system> default.nix`, which wraps `emacs.nix` with `emacsPackagesFor ... withPackages` to add `treesit-grammars.with-all-grammars`. For the plain Emacs 31 mainline build (the `emacs.nix` default), the store path is bit-for-bit identical to nixpkgs' `pkgs.emacs31`, so the official binary cache is hit and nothing recompiles from source; the git-based variants are likewise cache hits from [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay)'s `nix-community.cachix.org`.
+This runs `nix-build --argstr system <current-system> default.nix`, which wraps `emacs.nix` with `emacsPackagesFor ... withPackages` to add `treesit-grammars.with-all-grammars`. For the plain mainline build (the `emacs.nix` default), the store path is bit-for-bit identical to nixpkgs' default `pkgs.emacs`, so the official binary cache is hit and nothing recompiles from source; the git-based variants are likewise cache hits from [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay)'s `nix-community.cachix.org`.
 
 ### Build Variants
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -10,7 +10,7 @@ description: Jotain — a custom GNU Emacs configuration built from scratch
 The project includes:
 
 - A modular Emacs Lisp configuration organised by concern (`lisp/init-*.el`)
-- A Nix expression (`emacs.nix`) for building GNU Emacs from source, with every upstream build flag exposed and `pkgs.emacs31` (nixpkgs) binary-cache parity as an invariant; git-based variants come from [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay)
+- A Nix expression (`emacs.nix`) for building GNU Emacs from source, with every upstream build flag exposed and `pkgs.emacs` (nixpkgs) binary-cache parity as an invariant; git-based variants come from [`nix-community/emacs-overlay`](https://github.com/nix-community/emacs-overlay)
 - A distribution wrapper (`default.nix`) that ships Emacs together with all ~275 tree-sitter grammars from nixpkgs
 - A development shell (`devenv.nix`) that provides the same Emacs to developers and tools
 - A home-manager service (`module.nix`) for running Jotain as a user daemon with `emacsclient`
@@ -20,7 +20,7 @@ The project includes:
 
 Jotain takes a different approach from framework-based Emacs configurations like Doom or Spacemacs. Instead of layering on top of an opinionated framework, Jotain is built from scratch with:
 
-- **Nix-based builds** — reproducible Emacs from source with precise control over compile options, and binary-cache parity with `pkgs.emacs31` (nixpkgs) for the default configuration.
+- **Nix-based builds** — reproducible Emacs from source with precise control over compile options, and binary-cache parity with `pkgs.emacs` (nixpkgs) for the default configuration.
 - **Modular Elisp** — one file per concern (`init-ui.el`, `init-completion.el`, `init-vc.el`, …). A package that only exists to enhance a built-in (e.g. `dirvish` → `dired`, `magit` → `vc`) lives in the same file as the built-in it enhances — there is no "builtins.el" / "third-party.el" split.
 - **Modern Emacs** — targets Emacs 30+ (`emacs "30.1"`), with native compilation, tree-sitter modes, lexical binding throughout, and `use-package` built-in.
 - **`setopt` by default** — user options (`defcustom`) are set via `setopt` so `:set` callbacks and type validation actually run.

--- a/emacs.nix
+++ b/emacs.nix
@@ -4,7 +4,7 @@
 # tree-sitter grammars, use default.nix instead.
 #
 # Base packages per variant:
-#   * mainline — pkgs.emacs31 from nixpkgs (release branch, Hydra-cached)
+#   * mainline — pkgs.emacs from nixpkgs (default Emacs attr, Hydra-cached)
 #   * git/unstable/igc — pkgs.emacs-git / emacs-unstable / emacs-igc from
 #     nix-community/emacs-overlay (cached on nix-community.cachix.org)
 #   * macport — pkgs.emacs-macport, nixpkgs' alias for emacs30-macport
@@ -72,7 +72,7 @@
       },
 
   # ── Source variant ────────────────────────────────────────────────
-  #   "mainline"  — nixpkgs emacs31 release branch (default, binary-cached)
+  #   "mainline"  — nixpkgs default emacs attr (default, binary-cached)
   #   "git"       — bleeding-edge master from git.savannah.gnu.org
   #   "unstable"  — latest release tag built from git source (srcRepo)
   #   "macport"   — jdtsmith/emacs-mac fork (Darwin only)
@@ -109,7 +109,7 @@
   # --with-native-compilation (libgccjit AOT)
   withCompressInstall ? true, # --with-compress-install (gzip .el files)
   withCsrc ? true, # install C sources for find-function-C-source
-  # Every base is a git checkout these days: nixpkgs fetches emacs31 and
+  # Every base is a git checkout these days: nixpkgs fetches emacs and
   # emacs30-macport via fetchgit/fetchFromGitHub (srcRepo defaults to
   # true in make-emacs.nix and nixpkgs does not override it), and
   # emacs-overlay passes srcRepo = true for git/unstable/igc.
@@ -189,7 +189,7 @@ let
   };
 
   # ── Base package per variant ─────────────────────────────────────
-  #   * mainline — nixpkgs emacs31 (release branch, Hydra-cached)
+  #   * mainline — nixpkgs default emacs attr (Hydra-cached)
   #   * git/unstable/igc — emacs-overlay's prebuilt attrs (cached on
   #     nix-community.cachix.org; emacs-igc already carries
   #     --with-mps=yes and the mps buildInput)
@@ -217,7 +217,7 @@ let
   #     import ./emacs.nix {}                  # mainline variant
   #     import ./emacs.nix { noGui = true; }   # any standard override
   #
-  # produces the *exact* store path of `pkgs.emacs31(.override { ... })`
+  # produces the *exact* store path of `pkgs.emacs(.override { ... })`
   # — and variant "git"/"unstable"/"igc" the store path of the matching
   # emacs-overlay attr — so binary caches (Hydra, nix-community.cachix.org,
   # jylhis) hit and we never rebuild Emacs from source. Only custom rev
@@ -236,7 +236,7 @@ let
   #            nixpkgs = fetchTarball { url = "https://github.com/${n.owner}/${n.repo}/archive/${n.rev}.tar.gz"; sha256 = n.narHash; };
   #            overlay = fetchTarball { url = "https://github.com/${ov.owner}/${ov.repo}/archive/${ov.rev}.tar.gz"; sha256 = ov.narHash; };
   #            pkgs = import nixpkgs { overlays = [ (import overlay) ]; };
-  #        in (import ./emacs.nix {}).outPath == pkgs.emacs31.outPath'
+  #        in (import ./emacs.nix {}).outPath == pkgs.emacs.outPath'
   overridden = basePackage.override {
     inherit
       noGui

--- a/flake.nix
+++ b/flake.nix
@@ -13,8 +13,8 @@
     };
     # Supplies the git-based variants used by emacs.nix: emacs-git
     # (master), emacs-unstable (latest release tag), emacs-igc
-    # (feature/igc3). The default mainline build uses nixpkgs' emacs31
-    # and does not need the overlay.
+    # (feature/igc3). The default mainline build uses nixpkgs' default
+    # emacs attribute and does not need the overlay.
     emacs-overlay = {
       url = "github:nix-community/emacs-overlay";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## Summary

`nix flake check` already passes fully on `main` (all 20 checks on x86_64-linux, including byte-compile-as-errors and the jylhis-emacs fork build). While verifying, I found that the **documented cache-parity verification snippet was broken**: the pinned nixpkgs no longer exposes `pkgs.emacs31` (renamed to the default `pkgs.emacs` / `pkgs.emacs30`), so running the snippet errored with `attribute 'emacs31' missing` instead of returning the parity booleans.

`emacs.nix` already selects `pkgs.emacs` as the mainline base package (`basePackage` falls through to `pkgs.emacs`), but the surrounding comments, `CLAUDE.md`, `flake.nix`, and the `docs/*.mdx` pages still referenced the removed `pkgs.emacs31`.

## Changes

Documentation / comment only — rename the stale `pkgs.emacs31` references to `pkgs.emacs` so the documented verification procedure runs again and the prose matches the actual base-package selection:

- `CLAUDE.md` — cache-parity invariant prose + verification snippet
- `emacs.nix` — header/base-package/invariant comments + the inline verify snippet
- `flake.nix` — emacs-overlay input comment
- `docs/architecture/nix-build.mdx`, `docs/architecture/overview.mdx`, `docs/introduction.mdx`, `docs/installation.mdx`

No override args or base-package logic is touched, so build outputs are unchanged. Historical `journal/` entries and `plan.md` are intentionally left as-is.

## Scope note

This is the **docs/parity-check fixup only** option agreed with the maintainer. The actual cache-parity drift remains in place: with the current pin, `import ./emacs.nix {}` and `pkgs.emacs` (plus the git/unstable/igc variants) produce different store paths, so the snippet now runs but reports `false` for all variants. Restoring true parity (re-aligning the `.override` defaults to the current `make-emacs.nix`) is deliberately out of scope here.

## Verification

- The documented snippet now evaluates without error (returns `{ mainline = false; git = false; unstable = false; igc = false; }` rather than throwing `attribute 'emacs31' missing`).
- `nix flake check --no-build` → `all checks passed!`
- `formatting`, `statix`, `deadnix` checks all build green (treefmt: 0 files changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sxwkg121DfoR36yzVJ7rcv)_