### PR TITLE
Add snippet tooling via Tempel

### DIFF
--- a/docs/architecture/modules.mdx
+++ b/docs/architecture/modules.mdx
@@ -31,6 +31,7 @@ init-completion   vertico, marginalia, orderless, consult, corfu, cape
 init-navigation   dired, dirvish, project, windmove, winner
 init-vc           vc, vc-jj, magit, majutsu, magit-todos, forge, diff-hl, smerge, ediff
 init-prog         prog-mode, treesit, eglot, flymake, eldoc, apheleia, compile
+init-snippets     tempel snippets + eglot-tempel LSP expansion
 init-project      project + projection + compile-multi
 init-ai           claude-code-ide, gptel, mcp
 init-shell        eshell, vterm, comint
@@ -89,6 +90,10 @@ The vertico stack on the minibuffer side, corfu + cape on the in-buffer side, pl
 ### `init-prog`
 
 The shared substrate for programming modes: `prog-mode` hooks, `treesit` setup, `eglot`, `flymake`, `eldoc`, `apheleia` for format-on-save, `compile`. Per-language `eglot-ensure` hooks live here so all LSP wiring is in one place; per-language mode settings live in `init-lang-*.el`. When the `rass` binary (rassumfrassum, shipped in the devenv shell) is on `PATH`, `tsx-ts-mode` / `typescript-ts-mode` / `typescript-mode` buffers are routed through it to run `typescript-language-server` alongside whichever of `eslint-lsp` and `tailwindcss-language-server` are also on `PATH`, and Python buffers run the bundled `rass python` preset (basedpyright + ruff) when both binaries are present; any missing prerequisite makes eglot fall back to its built-in single-server lookup, so projects using `pylsp` / `pyright` / unguarded tsserver keep working unchanged. Also provides `jotain-sonarlint` for on-demand SonarLint analysis via the `sonarlint-ls` language server — SonarCloud connected mode is configured per-project via `eglot-workspace-configuration` in `.dir-locals.el`.
+
+### `init-snippets`
+
+Template/snippet expansion via `tempel`, chosen over the built-in `skeleton`/`abbrev` and the heavier `yasnippet` because it shares an author with the corfu/cape/vertico stack and plugs straight into `completion-at-point-functions` — snippet names surface in the corfu popup (added buffer-locally ahead of the cape capfs on `prog-mode`/`text-mode`), and `M-+` (`tempel-complete`) / `M-*` (`tempel-insert`) expand them, with `TAB` / `S-TAB` moving between fields. The curated templates themselves live in `templates/jotain.eld` (keyed by major mode — basic for/while/if/function constructs for Emacs Lisp, Python, Rust, Go, C/C++, and TS/TSX/JS), so adding a snippet never touches Elisp. `eglot-tempel` is configured here too, so Tempel also expands the snippets language servers return (e.g. function-argument placeholders); it is armed the moment eglot loads, before the first connection.
 
 ### `init-project`
 

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -1131,3 +1131,19 @@ Haskell editing session from costing every Emacs start.
 
 Tree-sitter Zig mode (MELPA). Eglot wires zls in init-prog;
 format-on-save runs `zig fmt' through apheleia.
+
+## `init-snippets.el` — Other
+
+### `tempel`
+
+Lightweight template/snippet engine from the corfu/cape author.
+Templates are read from `templates/*.eld' (keyed by major mode);
+`M-+' completes a snippet by name, `M-*' inserts one interactively,
+and once fields are active `TAB'/`S-TAB' move between them.
+
+### `eglot-tempel`
+
+Lets Tempel expand the snippets language servers send back
+(e.g. function-argument placeholders from rust-analyzer / pyright).
+`eglot-tempel-mode' must be enabled before eglot connects, so it is
+armed the moment eglot loads rather than after the first session.

--- a/init.el
+++ b/init.el
@@ -89,6 +89,7 @@
 (require 'init-navigation)   ; Dired + dirvish, project, windmove, winner
 (require 'init-vc)           ; vc + magit + diff-hl + forge
 (require 'init-prog)         ; prog-mode, treesit, eglot, flymake, eldoc, compile
+(require 'init-snippets)     ; tempel snippets + eglot-tempel LSP expansion
 (require 'init-project)      ; project + projection + compile-multi
 (require 'init-ai)           ; claude-code-ide, gptel, mcp
 (require 'init-shell)        ; eshell, vterm, comint

--- a/lisp/init-snippets.el
+++ b/lisp/init-snippets.el
@@ -1,0 +1,57 @@
+;;; init-snippets.el --- Template/snippet expansion via Tempel -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Snippet tooling for basic language constructs (for/while/if/function,
+;; etc.).  We use Tempel rather than the built-in `skeleton'/`abbrev' or
+;; the heavier `yasnippet': Tempel is by the same author as the
+;; corfu/cape/vertico stack this config already runs, so it plugs
+;; straight into `completion-at-point-functions' (snippet names surface
+;; in the corfu popup) and adds TextMate-style tab-stop field navigation
+;; that the built-ins lack.
+;;
+;; The curated templates themselves live in `templates/jotain.eld', keyed
+;; by major mode -- not in this file -- so adding a snippet never means
+;; touching Elisp.
+;;
+;; `eglot-tempel' lives here too: although LSP server config is otherwise
+;; centralised in `init-prog.el', this is purely a snippet-expansion
+;; adapter, so it belongs with the snippet feature it enables.
+
+;;; Code:
+
+;;; @doc Lightweight template/snippet engine from the corfu/cape author.
+;;; Templates are read from `templates/*.eld' (keyed by major mode);
+;;; `M-+' completes a snippet by name, `M-*' inserts one interactively,
+;;; and once fields are active `TAB'/`S-TAB' move between them.
+(use-package tempel
+  :functions (tempel-complete)
+  :custom
+  (tempel-path (expand-file-name "templates/*.eld" user-emacs-directory))
+  :bind
+  (("M-+" . tempel-complete)
+   ("M-*" . tempel-insert)
+   :map tempel-map
+   ("TAB" . tempel-next)
+   ("<backtab>" . tempel-previous))
+  :init
+  ;; Prepend `tempel-complete' to the buffer-local capf list so snippet
+  ;; names appear in the corfu popup ahead of dabbrev/keyword candidates
+  ;; (cf. the cape capfs in `init-completion.el').
+  (defun jotain-tempel-setup-capf ()
+    "Add `tempel-complete' to the front of the buffer-local capfs."
+    (add-hook 'completion-at-point-functions #'tempel-complete -90 t))
+  (add-hook 'prog-mode-hook #'jotain-tempel-setup-capf)
+  (add-hook 'text-mode-hook #'jotain-tempel-setup-capf))
+
+;;; @doc Lets Tempel expand the snippets language servers send back
+;;; (e.g. function-argument placeholders from rust-analyzer / pyright).
+;;; `eglot-tempel-mode' must be enabled before eglot connects, so it is
+;;; armed the moment eglot loads rather than after the first session.
+(use-package eglot-tempel
+  :after eglot
+  :functions (eglot-tempel-mode)
+  :init (with-eval-after-load 'eglot (eglot-tempel-mode 1)))
+
+(provide 'init-snippets)
+;;; init-snippets.el ends here

--- a/lisp/init-snippets.el
+++ b/lisp/init-snippets.el
@@ -25,7 +25,7 @@
 ;;; `M-+' completes a snippet by name, `M-*' inserts one interactively,
 ;;; and once fields are active `TAB'/`S-TAB' move between them.
 (use-package tempel
-  :functions (tempel-complete)
+  :functions (tempel-complete cape-capf-super eglot-completion-at-point eglot-managed-p)
   :custom
   (tempel-path (expand-file-name "templates/*.eld" user-emacs-directory))
   :bind
@@ -37,12 +37,31 @@
   :init
   ;; Prepend `tempel-complete' to the buffer-local capf list so snippet
   ;; names appear in the corfu popup ahead of dabbrev/keyword candidates
-  ;; (cf. the cape capfs in `init-completion.el').
+  ;; (cf. the cape capfs in `init-completion.el').  Outside LSP buffers
+  ;; this only ever shadows the low-value dabbrev/keyword fallbacks.
   (defun jotain-tempel-setup-capf ()
     "Add `tempel-complete' to the front of the buffer-local capfs."
     (add-hook 'completion-at-point-functions #'tempel-complete -90 t))
   (add-hook 'prog-mode-hook #'jotain-tempel-setup-capf)
-  (add-hook 'text-mode-hook #'jotain-tempel-setup-capf))
+  (add-hook 'text-mode-hook #'jotain-tempel-setup-capf)
+  ;; In eglot-managed buffers, prepending `tempel-complete' would hide LSP
+  ;; candidates for prefixes that match a snippet name (f, if, class...).
+  ;; Merge the two into a single capf with `cape-capf-super' so snippet and
+  ;; server candidates share one corfu popup instead of shadowing.
+  (defvar-local jotain-tempel--eglot-merged nil
+    "Non-nil once the merged tempel+eglot capf is installed in this buffer.")
+  (defun jotain-tempel-eglot-capf ()
+    "Merge `tempel-complete' with eglot's capf in managed buffers.
+Idempotent: the buffer-local guard stops `eglot-reconnect' from
+stacking duplicate super-capfs on repeated hook runs."
+    (when (and (eglot-managed-p) (not jotain-tempel--eglot-merged))
+      (setq jotain-tempel--eglot-merged t)
+      (remove-hook 'completion-at-point-functions #'tempel-complete t)
+      (setq-local completion-at-point-functions
+                  (cons (cape-capf-super #'tempel-complete #'eglot-completion-at-point)
+                        (remq #'eglot-completion-at-point
+                              completion-at-point-functions)))))
+  (add-hook 'eglot-managed-mode-hook #'jotain-tempel-eglot-capf))
 
 ;;; @doc Lets Tempel expand the snippets language servers send back
 ;;; (e.g. function-argument placeholders from rust-analyzer / pyright).

--- a/module.nix
+++ b/module.nix
@@ -332,11 +332,14 @@ in
     ++ lib.optional (cfg.client.enable && pkgs.stdenv.isLinux) (lib.hiPrio clientDesktopItem);
 
     # Install the Jotain Emacs configuration into ~/.config/emacs so the
-    # daemon picks up early-init.el, init.el and the lisp/ modules.
+    # daemon picks up early-init.el, init.el, the lisp/ modules, and the
+    # tempel snippet templates (lisp/init-snippets.el resolves
+    # `tempel-path' against user-emacs-directory).
     xdg.configFile = {
       "emacs/early-init.el".source = ./early-init.el;
       "emacs/init.el".source = ./init.el;
       "emacs/lisp".source = ./lisp;
+      "emacs/templates".source = ./templates;
     }
     // lib.optionalAttrs cfg.openrouter.enable {
       # OpenRouter provider for the eca server (lisp/init-ai.el). The key is

--- a/templates/jotain.eld
+++ b/templates/jotain.eld
@@ -11,8 +11,8 @@
 
 prog-mode
 
-(todo (if (derived-mode-p 'emacs-lisp-mode) ";; " comment-start) "TODO: " p)
-(fixme (if (derived-mode-p 'emacs-lisp-mode) ";; " comment-start) "FIXME: " p)
+(todo (if (derived-mode-p 'emacs-lisp-mode) ";; " comment-start) "TODO: " p comment-end)
+(fixme (if (derived-mode-p 'emacs-lisp-mode) ";; " comment-start) "FIXME: " p comment-end)
 
 emacs-lisp-mode
 
@@ -22,7 +22,7 @@ emacs-lisp-mode
 (unless "(unless " p "\n" r> ")")
 (dolist "(dolist (" p " " p ")\n" r> ")")
 
-(python-mode python-ts-mode)
+python-mode python-ts-mode
 
 (for "for " p " in " p ":" n> r>)
 (while "while " p ":" n> r>)
@@ -33,7 +33,7 @@ emacs-lisp-mode
 (try "try:" n> r> n "except " p ":" > n> q)
 (main "if __name__ == \"__main__\":" n> r>)
 
-(rust-mode rust-ts-mode)
+rust-mode rust-ts-mode
 
 (for "for " p " in " p " {" n> r> n "}" >)
 (while "while " p " {" n> r> n "}" >)
@@ -43,7 +43,7 @@ emacs-lisp-mode
 (impl "impl " p " {" n> r> n "}" >)
 (struct "struct " p " {" n> r> n "}" >)
 
-(go-mode go-ts-mode)
+go-mode go-ts-mode
 
 (for "for " p " {" n> r> n "}" >)
 (forr "for " p ", " p " := range " p " {" n> r> n "}" >)
@@ -52,7 +52,7 @@ emacs-lisp-mode
 (switch "switch " p " {" n> r> n "}" >)
 (struct "type " p " struct {" n> r> n "}" >)
 
-(c-mode c-ts-mode)
+c-mode c-ts-mode
 
 (for "for (" p "; " p "; " p ") {" n> r> n "}" >)
 (while "while (" p ") {" n> r> n "}" >)
@@ -61,7 +61,7 @@ emacs-lisp-mode
 (fn p " " p "(" p ") {" n> r> n "}" >)
 (struct "struct " p " {" n> r> n "};" >)
 
-(c++-mode c++-ts-mode)
+c++-mode c++-ts-mode
 
 (for "for (" p "; " p "; " p ") {" n> r> n "}" >)
 (forr "for (auto " p " : " p ") {" n> r> n "}" >)
@@ -71,7 +71,7 @@ emacs-lisp-mode
 (fn p " " p "(" p ") {" n> r> n "}" >)
 (class "class " p " {" n> "public:" n> r> n "};" >)
 
-(typescript-mode typescript-ts-mode tsx-ts-mode js-mode js-ts-mode)
+typescript-mode typescript-ts-mode tsx-ts-mode js-mode js-ts-mode
 
 (for "for (const " p " of " p ") {" n> r> n "}" >)
 (fori "for (let " p " = 0; " p " < " p "; " p "++) {" n> r> n "}" >)

--- a/templates/jotain.eld
+++ b/templates/jotain.eld
@@ -1,0 +1,87 @@
+;; Tempel templates -*- mode: lisp-data; outline-regexp: "[a-z]"; -*-
+;;
+;; Curated, minimal snippets for basic language constructs.  A bare
+;; major-mode symbol is a section header; the (name template...) forms
+;; under it apply to that mode and its derived modes.  Field markers:
+;;   p    tab stop / field           n    newline
+;;   n>   newline + reindent         >    reindent this line
+;;   r>   region or field, reindented
+;; Trigger a snippet by typing its name and completing (M-+), or insert
+;; one interactively with M-*.
+
+prog-mode
+
+(todo (if (derived-mode-p 'emacs-lisp-mode) ";; " comment-start) "TODO: " p)
+(fixme (if (derived-mode-p 'emacs-lisp-mode) ";; " comment-start) "FIXME: " p)
+
+emacs-lisp-mode
+
+(defun "(defun " p " (" p ")\n" r> ")")
+(let "(let ((" p "))\n" r> ")")
+(when "(when " p "\n" r> ")")
+(unless "(unless " p "\n" r> ")")
+(dolist "(dolist (" p " " p ")\n" r> ")")
+
+python-ts-mode
+
+(for "for " p " in " p ":" n> r>)
+(while "while " p ":" n> r>)
+(if "if " p ":" n> r>)
+(ifelse "if " p ":" n> r> n "else:" n> q)
+(def "def " p "(" p "):" n> r>)
+(class "class " p ":" n> r>)
+(try "try:" n> r> n "except " p ":" n> q)
+(main "if __name__ == \"__main__\":" n> r>)
+
+rust-ts-mode
+
+(for "for " p " in " p " {" n> r> n "}" >)
+(while "while " p " {" n> r> n "}" >)
+(if "if " p " {" n> r> n "}" >)
+(fn "fn " p "(" p ") {" n> r> n "}" >)
+(match "match " p " {" n> r> n "}" >)
+(impl "impl " p " {" n> r> n "}" >)
+(struct "struct " p " {" n> r> n "}" >)
+
+go-ts-mode
+
+(for "for " p " {" n> r> n "}" >)
+(forr "for " p ", " p " := range " p " {" n> r> n "}" >)
+(if "if " p " {" n> r> n "}" >)
+(func "func " p "(" p ") " p " {" n> r> n "}" >)
+(switch "switch " p " {" n> r> n "}" >)
+(struct "type " p " struct {" n> r> n "}" >)
+
+c-ts-mode
+
+(for "for (" p "; " p "; " p ") {" n> r> n "}" >)
+(while "while (" p ") {" n> r> n "}" >)
+(if "if (" p ") {" n> r> n "}" >)
+(switch "switch (" p ") {" n> r> n "}" >)
+(fn p " " p "(" p ") {" n> r> n "}" >)
+(struct "struct " p " {" n> r> n "};" >)
+
+c++-ts-mode
+
+(for "for (" p "; " p "; " p ") {" n> r> n "}" >)
+(forr "for (auto " p " : " p ") {" n> r> n "}" >)
+(while "while (" p ") {" n> r> n "}" >)
+(if "if (" p ") {" n> r> n "}" >)
+(switch "switch (" p ") {" n> r> n "}" >)
+(fn p " " p "(" p ") {" n> r> n "}" >)
+(class "class " p " {" n> "public:" n> r> n "};" >)
+
+(typescript-ts-mode tsx-ts-mode js-ts-mode)
+
+(for "for (const " p " of " p ") {" n> r> n "}" >)
+(fori "for (let " p " = 0; " p " < " p "; " p "++) {" n> r> n "}" >)
+(while "while (" p ") {" n> r> n "}" >)
+(if "if (" p ") {" n> r> n "}" >)
+(ifelse "if (" p ") {" n> r> n "} else {" n> q n "}" >)
+(fn "function " p "(" p ") {" n> r> n "}" >)
+(arrow "const " p " = (" p ") => {" n> r> n "}" >)
+(switch "switch (" p ") {" n> r> n "}" >)
+
+;; Local Variables:
+;; mode: lisp-data
+;; End:

--- a/templates/jotain.eld
+++ b/templates/jotain.eld
@@ -22,18 +22,18 @@ emacs-lisp-mode
 (unless "(unless " p "\n" r> ")")
 (dolist "(dolist (" p " " p ")\n" r> ")")
 
-python-ts-mode
+(python-mode python-ts-mode)
 
 (for "for " p " in " p ":" n> r>)
 (while "while " p ":" n> r>)
 (if "if " p ":" n> r>)
-(ifelse "if " p ":" n> r> n "else:" n> q)
+(ifelse "if " p ":" n> r> n "else:" > n> q)
 (def "def " p "(" p "):" n> r>)
 (class "class " p ":" n> r>)
-(try "try:" n> r> n "except " p ":" n> q)
+(try "try:" n> r> n "except " p ":" > n> q)
 (main "if __name__ == \"__main__\":" n> r>)
 
-rust-ts-mode
+(rust-mode rust-ts-mode)
 
 (for "for " p " in " p " {" n> r> n "}" >)
 (while "while " p " {" n> r> n "}" >)
@@ -43,7 +43,7 @@ rust-ts-mode
 (impl "impl " p " {" n> r> n "}" >)
 (struct "struct " p " {" n> r> n "}" >)
 
-go-ts-mode
+(go-mode go-ts-mode)
 
 (for "for " p " {" n> r> n "}" >)
 (forr "for " p ", " p " := range " p " {" n> r> n "}" >)
@@ -52,7 +52,7 @@ go-ts-mode
 (switch "switch " p " {" n> r> n "}" >)
 (struct "type " p " struct {" n> r> n "}" >)
 
-c-ts-mode
+(c-mode c-ts-mode)
 
 (for "for (" p "; " p "; " p ") {" n> r> n "}" >)
 (while "while (" p ") {" n> r> n "}" >)
@@ -61,7 +61,7 @@ c-ts-mode
 (fn p " " p "(" p ") {" n> r> n "}" >)
 (struct "struct " p " {" n> r> n "};" >)
 
-c++-ts-mode
+(c++-mode c++-ts-mode)
 
 (for "for (" p "; " p "; " p ") {" n> r> n "}" >)
 (forr "for (auto " p " : " p ") {" n> r> n "}" >)
@@ -71,13 +71,13 @@ c++-ts-mode
 (fn p " " p "(" p ") {" n> r> n "}" >)
 (class "class " p " {" n> "public:" n> r> n "};" >)
 
-(typescript-ts-mode tsx-ts-mode js-ts-mode)
+(typescript-mode typescript-ts-mode tsx-ts-mode js-mode js-ts-mode)
 
 (for "for (const " p " of " p ") {" n> r> n "}" >)
 (fori "for (let " p " = 0; " p " < " p "; " p "++) {" n> r> n "}" >)
 (while "while (" p ") {" n> r> n "}" >)
 (if "if (" p ") {" n> r> n "}" >)
-(ifelse "if (" p ") {" n> r> n "} else {" n> q n "}" >)
+(ifelse "if (" p ") {" n> r> n "} else {" > n> q n "}" >)
 (fn "function " p "(" p ") {" n> r> n "}" >)
 (arrow "const " p " = (" p ") => {" n> r> n "}" >)
 (switch "switch (" p ") {" n> r> n "}" >)


### PR DESCRIPTION
## What

Adds template/snippet expansion for basic language constructs (for / while / if / function, etc.) per programming language — the config previously had **no** snippet tooling at all.

## Engine choice: Tempel (not built-in skeleton/abbrev, not yasnippet)

The instruction was to prefer built-in tools unless a third party brings significant value. Tempel clears that bar for *this* config specifically:

- It's by **Daniel Mendler** — the same author as `corfu`, `cape`, `vertico`, `consult`, `orderless` that already form the entire completion stack here.
- It plugs straight into `completion-at-point-functions` (where `cape` already registers CAPFs), so snippet names surface in the **corfu popup** as you type.
- It adds **TextMate-style tab-stop field navigation** that built-in `skeleton`/`abbrev` lack.
- It's lightweight (one small package), unlike `yasnippet`.

## Changes

- **`lisp/init-snippets.el`** (new) — `tempel` (`M-+` complete, `M-*` insert, `TAB`/`S-TAB` field nav; `tempel-complete` added buffer-locally ahead of the cape CAPFs on `prog-mode`/`text-mode`) plus **`eglot-tempel`** so the same engine expands LSP server snippets (e.g. function-argument placeholders), armed the moment eglot loads — before the first connection.
- **`templates/jotain.eld`** (new) — a **curated, hand-written** minimal set (no prebuilt collection), keyed by major mode: Emacs Lisp, Python, Rust, Go, C/C++, and TS/TSX/JS. Lives outside `lisp/` so it isn't byte-compiled, and resolves via `user-emacs-directory`.
- **`init.el`** — `(require 'init-snippets)` after `init-prog`.
- **`module.nix`** — ship the `templates/` dir to the Home Manager daemon (`~/.config/emacs/templates`) so deployed daemons get snippets too, not just `just run`.
- **`docs/architecture/modules.mdx`** — load-order entry + module section.

No Nix package wiring needed: `tempel` (ELPA) and `eglot-tempel` (MELPA) are auto-detected by the `nix/use-package.nix` scanner.

## Verification

CI (`nix flake check`) covers the byte-compile (warnings-as-errors) and paren checks — this environment has no Nix/Emacs so they weren't run locally. Manual checks to run after build:

1. Open a Python/Rust buffer, type `for`, confirm it appears in the corfu popup; expand it and confirm `TAB`/`S-TAB` move between fields.
2. With rust-analyzer connected, complete a function and confirm argument placeholders expand as Tempel fields (proves `eglot-tempel-mode` armed before connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAXjueKVxrqGRfLMvjH7SX)_