### PR TITLE
Add Bazel/Starlark support

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -62,6 +62,11 @@ in
     meson
     ninja
 
+    # Bazel/Starlark formatter.  bazel-mode (C-c C-f) and apheleia
+    # format-on-save shell out to buildifier for BUILD/WORKSPACE/.bzl
+    # buffers.
+    buildifier
+
     # SonarLint language server for in-editor code quality analysis.
     # Start in Emacs with M-x jotain-sonarlint.
     sonarlint-ls

--- a/docs/architecture/modules.mdx
+++ b/docs/architecture/modules.mdx
@@ -43,7 +43,7 @@ init-lang-nix
 init-lang-rust
 init-lang-python
 init-lang-web         TS/TSX/CSS/HTML/JSON
-init-lang-devops      Dockerfile, terraform, just, ansible
+init-lang-devops      Dockerfile, terraform, just, ansible, bazel
 init-lang-data        yaml, csv, sql, jinja2, gnuplot
 init-lang-systems     Go, C/C++, CMake, Haskell, Zig
 ```
@@ -126,7 +126,7 @@ Each `init-lang-*.el` file pins `:mode` regexes and provides font-lock for a gro
 - **`init-lang-rust`** — `rust-ts-mode` (built-in) plus Cargo command wrappers.
 - **`init-lang-python`** — `python-ts-mode` (built-in), the interpreter set to `python3`. The LSP server (pyright/basedpyright/ruff-lsp) comes from the project environment, not from this config.
 - **`init-lang-web`** — `typescript-ts-mode`, `tsx-ts-mode`, CSS, HTML, JSON, and related tree-sitter modes.
-- **`init-lang-devops`** — Dockerfile, docker-compose, Terraform (`*.tf`), gitlab-ci, justfile, Ansible. Also exposes the `docker` Magit-style TUI on `C-c d` and a `jotain-docker-backend` defcustom (`'podman` by default, set to `'docker` for classic Docker) that switches the runtime command, compose command, and TRAMP method.
+- **`init-lang-devops`** — Dockerfile, docker-compose, Terraform (`*.tf`), gitlab-ci, justfile, Ansible, Bazel/Starlark (`BUILD`, `WORKSPACE`, `MODULE.bazel`, `*.bzl`, `.bazelrc`, …). Also exposes the `docker` Magit-style TUI on `C-c d` and a `jotain-docker-backend` defcustom (`'podman` by default, set to `'docker` for classic Docker) that switches the runtime command, compose command, and TRAMP method. Bazel buffers format on save via buildifier (centralised through apheleia in `init-prog`).
 - **`init-lang-data`** — YAML, CSV (with `csv-align-mode`), SQL (`sql-indent`), Jinja2, gnuplot.
 - **`init-lang-systems`** — Go (`go-mode`), C/C++ (`cc-mode`), CMake, Haskell, Zig (`zig-ts-mode`, eglot wires `zls`).
 

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -1061,6 +1061,14 @@ commands.
 Ansible minor mode layered on top of yaml-mode for playbook
 files. Adds module-name completion and Jinja2 highlighting.
 
+### `bazel`
+
+Bazel/Starlark support — major modes for `BUILD`, `WORKSPACE`,
+`MODULE.bazel`, `REPO.bazel`, `*.bzl`, `.bazelrc`, `.bazelignore`
+and `.bazeliskrc` (auto-mode-alist comes from the package's own
+autoloads). `C-c C-f` runs buildifier; format-on-save for the
+Starlark-family buffers is wired through apheleia in init-prog.
+
 ## `init-lang-data.el` — Data formats
 
 ### `yaml-mode`

--- a/lisp/init-lang-devops.el
+++ b/lisp/init-lang-devops.el
@@ -93,5 +93,13 @@ inside a running container."
 (use-package ansible
   :defer t)
 
+;;; @doc Bazel/Starlark support — major modes for `BUILD`, `WORKSPACE`,
+;;; `MODULE.bazel`, `REPO.bazel`, `*.bzl`, `.bazelrc`, `.bazelignore`
+;;; and `.bazeliskrc` (auto-mode-alist comes from the package's own
+;;; autoloads). `C-c C-f` runs buildifier; format-on-save for the
+;;; Starlark-family buffers is wired through apheleia in init-prog.
+(use-package bazel
+  :defer t)
+
 (provide 'init-lang-devops)
 ;;; init-lang-devops.el ends here

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -377,6 +377,14 @@ outside a project."
   (add-to-list 'apheleia-formatters
                '(zig-fmt . ("zig" "fmt" "--stdin")))
   (add-to-list 'apheleia-mode-alist '(zig-ts-mode . zig-fmt))
+  ;; buildifier reads from stdin; `-path' lets it infer the Starlark
+  ;; dialect (BUILD vs WORKSPACE vs .bzl).  Mapping the `bazel-mode'
+  ;; parent covers every derived Starlark-family mode (build/workspace/
+  ;; module/repo/starlark) while leaving the conf-derived bazelrc /
+  ;; bazeliskrc / bazelignore modes untouched.
+  (add-to-list 'apheleia-formatters
+               '(buildifier . ("buildifier" "-path" filepath)))
+  (add-to-list 'apheleia-mode-alist '(bazel-mode . buildifier))
   (apheleia-global-mode 1)
   (put 'apheleia-mode 'safe-local-variable #'booleanp))
 

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -383,7 +383,7 @@ outside a project."
   ;; module/repo/starlark) while leaving the conf-derived bazelrc /
   ;; bazeliskrc / bazelignore modes untouched.
   (add-to-list 'apheleia-formatters
-               '(buildifier . ("buildifier" "-path" filepath)))
+               '(buildifier . ("buildifier" "-path" (or filepath "BUILD"))))
   (add-to-list 'apheleia-mode-alist '(bazel-mode . buildifier))
   (apheleia-global-mode 1)
   (put 'apheleia-mode 'safe-local-variable #'booleanp))


### PR DESCRIPTION
## What

Adds Emacs support for Bazel/Starlark files, following the existing `init-lang-devops` conventions.

## Changes

- **`lisp/init-lang-devops.el`** — new `(use-package bazel …)` block (Google's `emacs-bazel-mode`, on MELPA). Provides major modes for `BUILD` / `BUILD.bazel`, `WORKSPACE`, `MODULE.bazel`, `REPO.bazel`, `*.bzl`, `.bazelrc`, `.bazelignore`, `.bazeliskrc`. The package ships its own `###autoload` cookies for `auto-mode-alist`, so a deferred block suffices — same pattern as `just-mode` / `ansible`. `C-c C-f` runs buildifier.
- **`lisp/init-prog.el`** — format-on-save wired through `apheleia` (the repo's centralised formatter convention), `buildifier -path <file>` so it infers the Starlark dialect from the filename. Mapping the `bazel-mode` parent covers every derived Starlark-family mode (build/workspace/module/repo/starlark) while leaving the conf-derived `bazelrc` / `bazeliskrc` / `bazelignore` modes untouched.
- **`devenv.nix`** — add `buildifier` to the dev shell so the formatter resolves on `PATH` (mirrors how `meson` is provided for `meson-format`).
- **Docs** — updated `docs/architecture/modules.mdx` and regenerated `docs/configuration/package-reference.mdx` (keeps the `packages-doc-in-sync` flake check green).

## Notes

- No tree-sitter grammar change needed — `bazel.el` is not tree-sitter based, so the `mk-overlay` grammar subset is unaffected.
- No eglot/LSP hook added, consistent with `terraform-mode` (no widely-packaged Starlark LSP in the default toolchain). Easy to add later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01En1iJu1jpCsBVtbcS5TUyA)_