### PR TITLE
Unify terminal setup around Ghostty via ghostel

### DIFF
--- a/docs/architecture/modules.mdx
+++ b/docs/architecture/modules.mdx
@@ -23,7 +23,8 @@ Jotain's Elisp configuration is split across `lisp/init-*.el`, one file per conc
 ```
 init-core         GC, encoding, var/ paths, sane file-handling defaults
 init-keys         Global keymap and window-split helpers
-init-ui           Theme, modeline, fonts, frame tweaks, icons, kkp, clipetty
+init-ui           Theme, modeline, fonts, frame tweaks, icons
+init-tabs         Workspace tabs via tab-bar-mode
 init-help         helpful + built-in help tweaks
 init-docs         Register the bundled jotain.info with C-h i
 init-editing      elec-pair, delsel, whitespace, region tools
@@ -34,7 +35,8 @@ init-prog         prog-mode, treesit, eglot, flymake, eldoc, apheleia, compile
 init-snippets     tempel snippets + eglot-tempel LSP expansion
 init-project      project + projection + compile-multi
 init-ai           claude-code-ide, gptel, mcp
-init-shell        eshell, vterm, comint
+init-shell        eshell, comint, ielm
+init-terminal     ghostel terminal + tty integration (kkp, clipetty)
 init-systems      sops, logview, auth-source-1password
 init-tracking     keyfreq, wakatime, activity-watch
 init-writing      jinx, markdown-mode, denote, pdf-tools
@@ -61,7 +63,7 @@ Global bindings only — per-package bindings live in the relevant `use-package`
 
 ### `init-ui`
 
-Appearance. Uses `modus-operandi-tinted` and `modus-vivendi-tinted` (user-customisable via `jotain-theme-light` / `jotain-theme-dark`), with `auto-dark-mode` flipping between them based on the system appearance. Installs `doom-modeline`, picks the first available font from `jotain-font-preferences` (JetBrains Mono Nerd Font → Iosevka Nerd Font → DejaVu Sans Mono), enables `display-line-numbers`, `pixel-scroll-precision-mode`, `hl-line-mode`, `show-paren-mode`, built-in `which-key`, `nerd-icons` integrations for dired/ibuffer/corfu/marginalia, `hl-todo`, `breadcrumb`, `pulsar`, `rainbow-delimiters`, `indent-bars`. Also enables `global-kkp-mode` (Kitty Keyboard Protocol) and `clipetty` for OSC 52 clipboard support through SSH + tmux.
+Appearance. Uses `modus-operandi-tinted` and `modus-vivendi-tinted` (user-customisable via `jotain-theme-light` / `jotain-theme-dark`), with `auto-dark-mode` flipping between them based on the system appearance. Installs `doom-modeline`, picks the first available font from `jotain-font-preferences` (JetBrains Mono Nerd Font → Iosevka Nerd Font → DejaVu Sans Mono), enables `display-line-numbers`, `pixel-scroll-precision-mode`, `hl-line-mode`, `show-paren-mode`, built-in `which-key`, `nerd-icons` integrations for dired/ibuffer/corfu/marginalia, `hl-todo`, `breadcrumb`, `pulsar`, `rainbow-delimiters`, `indent-bars`.
 
 ### `init-help`
 
@@ -105,7 +107,11 @@ AI assistants. `claude-code-ide` on `C-c C-'` for agentic multi-file edits via t
 
 ### `init-shell`
 
-`eshell`, `vterm`, and `comint` together — shells have their own input handling, history, prompts, and rendering, so grouping them lets the rules be coordinated in one place.
+`eshell`, `comint`, and `ielm` together — shells and REPLs have their own input handling, history, prompts, and rendering, so grouping them lets the rules be coordinated in one place. The true PTY terminal emulator lives in `init-terminal`.
+
+### `init-terminal`
+
+Both directions of terminal support. Inside Emacs: `ghostel`, a terminal emulator powered by libghostty-vt (the VT engine behind Ghostty) through a native dynamic module — real PTY for tmux/ncurses programs, plus automatic shell integration (OSC 7 directory tracking, OSC 133 prompt navigation) and OSC 52 clipboard. The Nix package builds the module from source and ships it in the package directory; in a source checkout the module is downloaded into the writable `elpa/` dir on first `M-x ghostel`. Emacs inside a terminal: `global-kkp-mode` (Kitty Keyboard Protocol), `clipetty` (OSC 52 clipboard through SSH + tmux), `xterm-mouse-mode`, and `tty-tip-mode` on Emacs 31+ — all no-ops in GUI frames. Ghostel's buffers advertise `TERM=xterm-ghostty`, the same dialect the outer Ghostty terminal uses; the `xterm-ghostty → xterm-256color` alias that supports both lives in `early-init.el` because terminal initialisation runs before `init.el`.
 
 ### `init-systems`
 

--- a/docs/configuration/init.mdx
+++ b/docs/configuration/init.mdx
@@ -47,6 +47,7 @@ Nix (or the devenv shell in development) provides most packages via `load-path`,
 (require 'init-core)         ; GC, encoding, var/ paths, sane defaults
 (require 'init-keys)         ; Global keymap and leader-key setup
 (require 'init-ui)           ; Theme, modeline, fonts, frame tweaks
+(require 'init-tabs)         ; Workspace tabs via tab-bar-mode
 (require 'init-help)         ; helpful + built-in help tweaks
 (require 'init-docs)         ; Surface jotain.info under C-h i
 (require 'init-editing)      ; Electric pairs, delsel, whitespace, region tools
@@ -54,9 +55,11 @@ Nix (or the devenv shell in development) provides most packages via `load-path`,
 (require 'init-navigation)   ; Dired + dirvish, project, windmove, winner
 (require 'init-vc)           ; vc + magit + diff-hl + forge
 (require 'init-prog)         ; prog-mode, treesit, eglot, flymake, eldoc, compile
+(require 'init-snippets)     ; tempel snippets + eglot-tempel LSP expansion
 (require 'init-project)      ; project + projection + compile-multi
 (require 'init-ai)           ; claude-code-ide, gptel, mcp
-(require 'init-shell)        ; eshell, vterm, comint
+(require 'init-shell)        ; eshell, comint, ielm
+(require 'init-terminal)     ; ghostel terminal + tty integration (kkp, clipetty)
 (require 'init-systems)      ; sops, logview, auth-source-1password
 (require 'init-tracking)     ; keyfreq, wakatime, activity-watch
 (require 'init-writing)      ; jinx, markdown-mode, denote, pdf-tools

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -237,18 +237,6 @@ Vertical indent guides for code, treesit-aware so the bars
 follow real syntactic indentation. Toggle via
 `jotain-indent-bars-enabled'.
 
-### `kkp`
-
-Kitty Keyboard Protocol — lets terminal Emacs distinguish
-C-i/TAB, C-m/RET, C-[/ESC, and pass Shift-modified function
-keys through. No-op in GUI frames, so safe to enable
-unconditionally.
-
-### `clipetty`
-
-OSC 52 clipboard integration. Yank/kill in terminal Emacs
-reaches the system clipboard even through ssh + tmux.
-
 ## `init-tabs.el` — Workspace tabs
 
 ### `tab-bar` *(built-in / Nix)*
@@ -866,12 +854,6 @@ Built-in Lisp-driven shell — works the same on every platform
 and is the right tool for Emacs-flavoured pipelines (commands
 as Elisp functions, no subprocess for builtins).
 
-### `vterm`
-
-Real terminal emulator (libvterm). Use this when you need a
-tmux session, ncurses programs, or anything that wants a true
-PTY — eshell can't do those.
-
 ### `comint` *(built-in / Nix)*
 
 Built-in REPL substrate (used by python, ielm, sql, etc.).
@@ -882,6 +864,30 @@ The settings here apply to every comint-derived buffer.
 Built-in Emacs Lisp REPL. Emacs 31+ can persist input history
 across sessions like comint/shell already do; point it at a file
 under `var/'. Guarded so the config loads on Emacs 30.
+
+## `init-terminal.el` — Terminal support
+
+### `ghostel`
+
+Terminal emulator powered by libghostty-vt (the Ghostty VT
+engine) via a native dynamic module.  Replaces vterm: real PTY for
+tmux/ncurses/TUI programs, plus shell integration (OSC 7 directory
+tracking, OSC 133 prompt jumping) injected automatically for
+bash/zsh/fish.  The Nix package builds the module from source and
+ships it in the package directory; in a source checkout the module
+is downloaded into the writable elpa/ dir on first `M-x ghostel'.
+
+### `kkp`
+
+Kitty Keyboard Protocol — lets terminal Emacs distinguish
+C-i/TAB, C-m/RET, C-[/ESC, and pass Shift-modified function
+keys through. No-op in GUI frames, so safe to enable
+unconditionally.
+
+### `clipetty`
+
+OSC 52 clipboard integration. Yank/kill in terminal Emacs
+reaches the system clipboard even through ssh + tmux.
 
 ## `init-systems.el` — Sysadmin tools
 

--- a/early-init.el
+++ b/early-init.el
@@ -129,6 +129,9 @@
 ;; term/xterm-ghostty.el. Aliasing to xterm-256color makes term/xterm.el
 ;; load instead, which restores modifyOtherKeys + 24-bit colour. Must be
 ;; set here because tty-run-terminal-initialization fires before init.el.
+;; The rest of the terminal story (the ghostel terminal emulator, kkp,
+;; clipetty) lives in lisp/init-terminal.el; ghostel's buffers also use
+;; TERM=xterm-ghostty, so this alias covers nested `emacs -nw' there.
 (add-to-list 'term-file-aliases '("xterm-ghostty" . "xterm-256color"))
 
 (provide 'early-init)

--- a/init.el
+++ b/init.el
@@ -92,7 +92,8 @@
 (require 'init-snippets)     ; tempel snippets + eglot-tempel LSP expansion
 (require 'init-project)      ; project + projection + compile-multi
 (require 'init-ai)           ; claude-code-ide, gptel, mcp
-(require 'init-shell)        ; eshell, vterm, comint
+(require 'init-shell)        ; eshell, comint, ielm
+(require 'init-terminal)     ; ghostel terminal + tty integration (kkp, clipetty)
 (require 'init-systems)      ; sops, logview, auth-source-1password
 (require 'init-tracking)     ; keyfreq, wakatime, activity-watch
 (require 'init-writing)      ; jinx, markdown-mode, denote, pdf-tools

--- a/lisp/init-shell.el
+++ b/lisp/init-shell.el
@@ -1,4 +1,4 @@
-;;; init-shell.el --- Eshell, vterm, comint -*- lexical-binding: t; -*-
+;;; init-shell.el --- Eshell, comint, ielm -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 
@@ -6,6 +6,9 @@
 ;; have their own input handling, history, prompts, and rendering. Group
 ;; them together so the rules ("how should the prompt look", "how does
 ;; history search work") can be coordinated.
+;;
+;; The ghostel terminal emulator (a true PTY, unlike these Lisp-driven
+;; shells and REPLs) lives in init-terminal.el.
 
 ;;; Code:
 
@@ -21,15 +24,6 @@
   (eshell-scroll-to-bottom-on-input 'all)
   (eshell-error-if-no-glob t)
   (eshell-destroy-buffer-when-process-dies t))
-
-;;; @doc Real terminal emulator (libvterm). Use this when you need a
-;;; tmux session, ncurses programs, or anything that wants a true
-;;; PTY — eshell can't do those.
-(use-package vterm
-  :commands (vterm vterm-other-window)
-  :custom
-  (vterm-max-scrollback 10000)
-  (vterm-buffer-name-string "vterm: %s"))
 
 ;;; @doc Built-in REPL substrate (used by python, ielm, sql, etc.).
 ;;; The settings here apply to every comint-derived buffer.

--- a/lisp/init-terminal.el
+++ b/lisp/init-terminal.el
@@ -1,0 +1,72 @@
+;;; init-terminal.el --- Ghostel terminal + tty integration -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Both directions of terminal support live here:
+;;
+;; - A terminal *inside* Emacs: ghostel, powered by libghostty-vt
+;;   (Ghostty's VT engine) through a native dynamic module.
+;; - Emacs *inside* a terminal: kkp (Kitty Keyboard Protocol), clipetty
+;;   (OSC 52 clipboard), xterm-mouse, tty-tip.  All no-ops in GUI frames.
+;;
+;; The two meet in the middle: ghostel's terminal advertises
+;; TERM=xterm-ghostty with Kitty-keyboard and OSC 52 support, which is
+;; exactly what kkp and clipetty speak — so a nested `emacs -nw' inside
+;; a ghostel buffer gets full key fidelity and clipboard access.
+;;
+;; The xterm-ghostty → xterm-256color TERM alias stays in early-init.el
+;; because `tty-run-terminal-initialization' fires before init.el loads.
+
+;;; Code:
+
+;;;; Terminal emulator inside Emacs
+
+;;; @doc Terminal emulator powered by libghostty-vt (the Ghostty VT
+;;; engine) via a native dynamic module.  Replaces vterm: real PTY for
+;;; tmux/ncurses/TUI programs, plus shell integration (OSC 7 directory
+;;; tracking, OSC 133 prompt jumping) injected automatically for
+;;; bash/zsh/fish.  The Nix package builds the module from source and
+;;; ships it in the package directory; in a source checkout the module
+;;; is downloaded into the writable elpa/ dir on first `M-x ghostel'.
+(use-package ghostel
+  :commands (ghostel ghostel-project ghostel-other)
+  :custom
+  ;; `ghostel-module-directory' stays nil (= package directory): that
+  ;; is where nixpkgs ships the module, and a present module is only
+  ;; loaded, never re-written, so the read-only store is safe.
+  ;; Auto-install fires only when the module is missing — i.e. only on
+  ;; the source-checkout/MELPA path where elpa/ is writable.
+  (ghostel-module-auto-install 'download)
+  ;; Unified clipboard story with clipetty below: programs inside the
+  ;; terminal reach the system clipboard via OSC 52.
+  (ghostel-enable-osc52 t))
+
+;;;; Terminal compatibility (no-ops in GUI)
+
+;;; @doc Kitty Keyboard Protocol — lets terminal Emacs distinguish
+;;; C-i/TAB, C-m/RET, C-[/ESC, and pass Shift-modified function
+;;; keys through. No-op in GUI frames, so safe to enable
+;;; unconditionally.
+(use-package kkp
+  :functions (global-kkp-mode)
+  :config (global-kkp-mode 1))
+
+;;; @doc OSC 52 clipboard integration. Yank/kill in terminal Emacs
+;;; reaches the system clipboard even through ssh + tmux.
+(use-package clipetty
+  :diminish
+  :hook (after-init . global-clipetty-mode))
+
+(defun jotain-terminal--tty-setup ()
+  "Per-frame tty setup hook."
+  (xterm-mouse-mode 1))
+(add-hook 'tty-setup-hook #'jotain-terminal--tty-setup)
+
+;;; @doc Emacs 31+: bring tooltips (help-echo, button hints) to terminal
+;;; frames, which previously had none. No-op in GUI. Guarded with
+;;; `fboundp' so the config still loads on Emacs 30.
+(when (fboundp 'tty-tip-mode)
+  (tty-tip-mode 1))
+
+(provide 'init-terminal)
+;;; init-terminal.el ends here

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -332,32 +332,5 @@ availability on the right display."
   :custom (indent-bars-treesit-support t)
   :hook (prog-mode . jotain-ui--maybe-indent-bars))
 
-;;;; Terminal compatibility (no-ops in GUI)
-
-;;; @doc Kitty Keyboard Protocol — lets terminal Emacs distinguish
-;;; C-i/TAB, C-m/RET, C-[/ESC, and pass Shift-modified function
-;;; keys through. No-op in GUI frames, so safe to enable
-;;; unconditionally.
-(use-package kkp
-  :functions (global-kkp-mode)
-  :config (global-kkp-mode 1))
-
-;;; @doc OSC 52 clipboard integration. Yank/kill in terminal Emacs
-;;; reaches the system clipboard even through ssh + tmux.
-(use-package clipetty
-  :diminish
-  :hook (after-init . global-clipetty-mode))
-
-(defun jotain-ui--tty-setup ()
-  "Per-frame tty setup hook."
-  (xterm-mouse-mode 1))
-(add-hook 'tty-setup-hook #'jotain-ui--tty-setup)
-
-;;; @doc Emacs 31+: bring tooltips (help-echo, button hints) to terminal
-;;; frames, which previously had none. No-op in GUI. Guarded with
-;;; `fboundp' so the config still loads on Emacs 30.
-(when (fboundp 'tty-tip-mode)
-  (tty-tip-mode 1))
-
 (provide 'init-ui)
 ;;; init-ui.el ends here

--- a/nix/packages-doc.nix
+++ b/nix/packages-doc.nix
@@ -83,6 +83,10 @@ let
       title = "Shells";
     }
     {
+      file = "init-terminal.el";
+      title = "Terminal support";
+    }
+    {
       file = "init-systems.el";
       title = "Sysadmin tools";
     }


### PR DESCRIPTION
## Summary

Replaces vterm with **[ghostel](https://github.com/dakra/ghostel)** — a terminal emulator powered by libghostty-vt, the VT engine behind Ghostty — and unifies all terminal support into a new `lisp/init-terminal.el`.

Terminal config was previously split with no shared story: TTY compatibility (kkp, clipetty, xterm-mouse, tty-tip) at the bottom of `init-ui.el`, vterm in `init-shell.el`, and the `xterm-ghostty` alias in `early-init.el`. Ghostel is a superset of vterm (true PTY, plus OSC 7 directory tracking, OSC 133 prompt navigation, Kitty keyboard/graphics protocols, OSC 52 clipboard, TRAMP support) and its buffers advertise `TERM=xterm-ghostty` — the same dialect the outer Ghostty terminal uses, so the whole stack speaks one language and a nested `emacs -nw` inside a ghostel buffer gets full key fidelity via kkp.

## Changes

- **New `lisp/init-terminal.el`** — both directions of terminal support: ghostel (with `ghostel-enable-osc52 t` for a unified clipboard story with clipetty), plus the TTY block moved from `init-ui.el` (helper renamed `jotain-ui--tty-setup` → `jotain-terminal--tty-setup`).
- **`lisp/init-shell.el`** — vterm removed; keeps eshell/comint/ielm with a pointer to init-terminal.
- **`early-init.el`** — the `xterm-ghostty → xterm-256color` alias stays (must run before `tty-run-terminal-initialization`) with a cross-reference comment.
- **Nix: zero packaging work.** The pinned nixpkgs ships `emacsPackages.ghostel` as a manual package that zig-builds the native module from source and installs it in the package directory, where ghostel's loader finds it with no runtime download (manual packages shadow the elisp-only MELPA auto-build; verified in `pkgs/top-level/emacs-packages.nix`). The use-package scanner picks it up automatically. In a source checkout the module auto-downloads into the writable `elpa/` dir on first `M-x ghostel` (`ghostel-module-auto-install 'download`).
- **Docs** — `nix/packages-doc.nix` gets an `init-terminal.el` moduleOrder entry; `package-reference.mdx` regenerated; `modules.mdx`/`init.mdx` updated (also syncing the previously missing `init-tabs`/`init-snippets` entries in the load-order listings).

## Verification

- Regenerated `package-reference.mdx` with a byte-exact replica of the generator (validated against the committed artifact from HEAD sources before regenerating), so the `packages-doc-in-sync` check should pass.
- Paren-balance checked on all touched elisp; verified `ghostel-enable-osc52`, `ghostel-module-auto-install`, and the autoloaded `ghostel`/`ghostel-project`/`ghostel-other` commands all exist at the exact commit nixpkgs pins (`cd32af7`).
- Nix is unavailable in this environment, so `nix flake check` (byte-compile with warnings-as-errors, packages-doc-in-sync, builds) runs in CI — watching for the result.
- Manual follow-up for a machine with the built distribution: `M-x ghostel` should open a shell with no module-download prompt; OSC 52 test: `printf '\e]52;c;%s\a' "$(echo hi | base64)"` inside the terminal, then yank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bBQRj8zjSsPSxQXNgzA1A

---
_Generated by [Claude Code](https://claude.ai/code/session_011bBQRj8zjSsPSxQXNgzA1A)_