### PR TITLE
Upgrade Go developer experience: go-ts-mode, gopls tuning, dape, gotest

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,8 +18,6 @@
 - https://www.gnu.org/software/emacs/manual/html_node/elisp/Language-Grammar.html
 - https://github.com/universal-ctags/citre
 - https://github.com/joaotavora/eglot
-- https://github.com/realgud
-- https://github.com/emacs-lsp/dap-mode
 - https://www.emacswiki.org/emacs/FlyMake
 - https://www.gnu.org/software/emacs/manual/html_node/ebrowse/index.html
 - https://github.com/pythonic-emacs/anaconda-mode

--- a/docs/architecture/modules.mdx
+++ b/docs/architecture/modules.mdx
@@ -30,7 +30,7 @@ init-editing      elec-pair, delsel, whitespace, region tools
 init-completion   vertico, marginalia, orderless, consult, corfu, cape
 init-navigation   dired, dirvish, project, windmove, winner
 init-vc           vc, vc-jj, magit, majutsu, magit-todos, forge, diff-hl, smerge, ediff
-init-prog         prog-mode, treesit, eglot, flymake, eldoc, apheleia, compile
+init-prog         prog-mode, treesit, eglot, dape, flymake, eldoc, apheleia, compile
 init-snippets     tempel snippets + eglot-tempel LSP expansion
 init-project      project + projection + compile-multi
 init-ai           claude-code-ide, gptel, mcp
@@ -43,10 +43,11 @@ init-org          org, org-modern, capture templates
 init-lang-nix
 init-lang-rust
 init-lang-python
+init-lang-go
 init-lang-web         TS/TSX/CSS/HTML/JSON
 init-lang-devops      Dockerfile, terraform, just, ansible, bazel
 init-lang-data        yaml, csv, sql, jinja2, gnuplot
-init-lang-systems     Go, C/C++, CMake, Haskell, Zig
+init-lang-systems     C/C++, CMake, Haskell, Zig
 ```
 
 ## Core modules
@@ -89,7 +90,7 @@ The vertico stack on the minibuffer side, corfu + cape on the in-buffer side, pl
 
 ### `init-prog`
 
-The shared substrate for programming modes: `prog-mode` hooks, `treesit` setup, `eglot`, `flymake`, `eldoc`, `apheleia` for format-on-save, `compile`. Per-language `eglot-ensure` hooks live here so all LSP wiring is in one place; per-language mode settings live in `init-lang-*.el`. When the `rass` binary (rassumfrassum, shipped in the devenv shell) is on `PATH`, `tsx-ts-mode` / `typescript-ts-mode` / `typescript-mode` buffers are routed through it to run `typescript-language-server` alongside whichever of `eslint-lsp` and `tailwindcss-language-server` are also on `PATH`, and Python buffers run the bundled `rass python` preset (basedpyright + ruff) when both binaries are present; any missing prerequisite makes eglot fall back to its built-in single-server lookup, so projects using `pylsp` / `pyright` / unguarded tsserver keep working unchanged. Also provides `jotain-sonarlint` for on-demand SonarLint analysis via the `sonarlint-ls` language server — SonarCloud connected mode is configured per-project via `eglot-workspace-configuration` in `.dir-locals.el`.
+The shared substrate for programming modes: `prog-mode` hooks, `treesit` setup, `eglot`, `flymake`, `eldoc`, `apheleia` for format-on-save, `compile`. Per-language `eglot-ensure` hooks live here so all LSP wiring is in one place; per-language mode settings live in `init-lang-*.el`. When the `rass` binary (rassumfrassum, shipped in the devenv shell) is on `PATH`, `tsx-ts-mode` / `typescript-ts-mode` / `typescript-mode` buffers are routed through it to run `typescript-language-server` alongside whichever of `eslint-lsp` and `tailwindcss-language-server` are also on `PATH`, and Python buffers run the bundled `rass python` preset (basedpyright + ruff) when both binaries are present; any missing prerequisite makes eglot fall back to its built-in single-server lookup, so projects using `pylsp` / `pyright` / unguarded tsserver keep working unchanged. Also provides `jotain-sonarlint` for on-demand SonarLint analysis via the `sonarlint-ls` language server — SonarCloud connected mode is configured per-project via `eglot-workspace-configuration` in `.dir-locals.el`. Debugging goes through `dape` (Debug Adapter Protocol, `C-x C-a` prefix); the adapter binaries (e.g. `dlv` for Go, `debugpy` for Python) come from the project/host PATH, same as the LSP servers.
 
 ### `init-snippets`
 
@@ -130,10 +131,11 @@ Each `init-lang-*.el` file pins `:mode` regexes and provides font-lock for a gro
 - **`init-lang-nix`** — `nix-ts-mode`. Formatting via apheleia (which ships a `nixfmt` entry).
 - **`init-lang-rust`** — `rust-ts-mode` (built-in) plus Cargo command wrappers.
 - **`init-lang-python`** — `python-ts-mode` (built-in), the interpreter set to `python3`. The LSP server (pyright/basedpyright/ruff-lsp) comes from the project environment, not from this config.
+- **`init-lang-go`** — `go-ts-mode` / `go-mod-ts-mode` (built-in), gopls workspace settings (staticcheck + inlay-hint sources), `gotest` for test-at-point under the `C-c C-t` prefix. Formatting via apheleia → `goimports`; debugging via dape → `dlv` (both wired in `init-prog`). All Go tooling (`go`, `gopls`, `goimports`, `dlv`) comes from the project/host PATH.
 - **`init-lang-web`** — `typescript-ts-mode`, `tsx-ts-mode`, CSS, HTML, JSON, and related tree-sitter modes.
 - **`init-lang-devops`** — Dockerfile, docker-compose, Terraform (`*.tf`), gitlab-ci, justfile, Ansible, Bazel/Starlark (`BUILD`, `WORKSPACE`, `MODULE.bazel`, `*.bzl`, `.bazelrc`, …). Also exposes the `docker` Magit-style TUI on `C-c d` and a `jotain-docker-backend` defcustom (`'podman` by default, set to `'docker` for classic Docker) that switches the runtime command, compose command, and TRAMP method. Bazel buffers format on save via buildifier (centralised through apheleia in `init-prog`).
 - **`init-lang-data`** — YAML, CSV (with `csv-align-mode`), SQL (`sql-indent`), Jinja2, gnuplot.
-- **`init-lang-systems`** — Go (`go-mode`), C/C++ (`cc-mode`), CMake, Haskell, Zig (`zig-ts-mode`, eglot wires `zls`).
+- **`init-lang-systems`** — C/C++ (`cc-mode`), CMake, Haskell, Zig (`zig-ts-mode`, eglot wires `zls`).
 
 ## Adding a new module
 

--- a/docs/compilation-mode.mdx
+++ b/docs/compilation-mode.mdx
@@ -41,9 +41,14 @@ presets for Go, Python, Haskell, Nix, and Rust:
 
 ```elisp
 (compile-multi-config
- '((go-mode      . (("go test"        . "go test ./...")
+ '((go-ts-mode   . (("go test"         . "go test ./...")
                     ("go test current" . "go test .")
-                    ("go build"       . "go build .")))
+                    ("go build"        . "go build ./...")
+                    ("go run"          . "go run .")
+                    ("go vet"          . "go vet ./...")
+                    ("golangci-lint"   . "golangci-lint run")))
+   (go-mod-ts-mode . (("go mod tidy"     . "go mod tidy")
+                      ("go mod download" . "go mod download")))
    (python-mode  . (("pytest"         . "pytest")
                     ("pytest file"    . "pytest %file-name%")))
    (haskell-mode . (("stack test"     . "stack test")

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -714,6 +714,15 @@ orderless-filtered list of symbols across the LSP workspace.
 Embark integration for consult-eglot — gives every workspace
 symbol an action menu (jump to def, find refs, rename, …).
 
+### `dape`
+
+Debug Adapter Protocol client — the debugging counterpart to
+eglot. Ships adapter configs for dlv (Go), debugpy (Python),
+codelldb (Rust/C/C++), and more; the adapter binary (e.g. `dlv`)
+comes from the project/host PATH, same convention as the LSP
+servers. `C-x C-a` is the prefix (the gud convention); stepping
+commands carry repeat-maps, so `C-x C-a n n n` keeps stepping.
+
 ### `flymake` *(built-in / Nix)*
 
 Built-in inline diagnostic display. Indicator chars (! ? ·) and
@@ -1023,6 +1032,22 @@ get the modern parser without any third-party package. The LSP
 server (pyright/basedpyright/ruff-lsp) comes from the project's
 own environment, not from this config.
 
+## `init-lang-go.el` — Go
+
+### `go-ts-mode` *(built-in / Nix)*
+
+Built-in tree-sitter Go modes: `go-ts-mode` for source files,
+`go-mod-ts-mode` for go.mod. Eglot wires gopls in init-prog;
+format-on-save runs goimports through apheleia; dape drives dlv
+for debugging. All Go tooling (go, gopls, goimports, dlv) comes
+from the project/host PATH, not from this config.
+
+### `gotest`
+
+Run the Go test or benchmark at point, the current file's
+tests, or the whole project, with compilation-mode error jumping.
+Bound under the mode-local `C-c C-t` prefix in Go buffers.
+
 ## `init-lang-web.el` — Web (TypeScript, JS, CSS, HTML)
 
 ### `typescript-ts-mode` *(built-in / Nix)*
@@ -1134,12 +1159,7 @@ covers `.j2`, `.jinja`, and `.jinja2`.
 Major mode for gnuplot script files (`.plt`). Useful when an
 analysis pipeline emits its own plotting scripts.
 
-## `init-lang-systems.el` — Systems (Go, C/C++, Haskell, Zig)
-
-### `go-mode`
-
-Go major mode. Eglot wires gopls in init-prog so all language
-servers are configured in one place.
+## `init-lang-systems.el` — Systems (C/C++, Haskell, Zig)
 
 ### `cc-mode` *(built-in / Nix)*
 

--- a/init.el
+++ b/init.el
@@ -98,16 +98,17 @@
 (require 'init-writing)      ; jinx, markdown-mode, denote, pdf-tools
 (require 'init-org)          ; org, org-modern, capture templates
 
-;; Languages. The big three (Nix, Rust, Python) each have their own
-;; file; less-used modes are grouped by concern so init.el doesn't
-;; grow one line per MELPA package.
+;; Languages. The big languages (Nix, Rust, Python, Go) each have
+;; their own file; less-used modes are grouped by concern so init.el
+;; doesn't grow one line per MELPA package.
 (require 'init-lang-nix)
 (require 'init-lang-rust)
 (require 'init-lang-python)
+(require 'init-lang-go)
 (require 'init-lang-web)       ; TS/TSX/CSS/HTML/JSON/web-mode
 (require 'init-lang-devops)    ; Dockerfile, terraform, just, ansible
 (require 'init-lang-data)      ; yaml, csv, sql, jinja2, gnuplot
-(require 'init-lang-systems)   ; Go, C/C++, CMake, Haskell
+(require 'init-lang-systems)   ; C/C++, CMake, Meson, Haskell, Zig
 
 (provide 'init)
 ;;; init.el ends here

--- a/lisp/init-keys.el
+++ b/lisp/init-keys.el
@@ -116,6 +116,7 @@ Region active → deactivate it.  Otherwise call regular
     "C-c C-'"   "claude-code-ide"
     "C-c M-x"   "consult-mode-command"
     ;; C-x namespace.
+    "C-x C-a"   "dape (debug)"
     "C-x g"     "magit-status"
     "C-x M-g"   "magit-dispatch"
     "C-x j"     "rotate-window-split"

--- a/lisp/init-lang-go.el
+++ b/lisp/init-lang-go.el
@@ -1,0 +1,80 @@
+;;; init-lang-go.el --- Go language support -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Go modes (built-in tree-sitter variants) plus test-at-point via
+;; gotest.  The eglot hook is registered in `init-prog'; format-on-save
+;; flows through apheleia -> goimports and debugging through dape ->
+;; dlv, both configured in `init-prog'.
+;;
+;; Per the convention for language tooling, no Go binaries ship with
+;; this config.  Expected on the project/host PATH: go, gopls (LSP),
+;; goimports (formatting), dlv (debugging), and optionally
+;; golangci-lint (compile-multi entry).
+
+;;; Code:
+
+;; gopls workspace settings.  Buffer-local in a mode hook instead of
+;; `setq-default' so no other language's workspace configuration is
+;; clobbered and a project .dir-locals.el
+;; `eglot-workspace-configuration' entry still overrides it cleanly.
+(defvar eglot-workspace-configuration) ; defined in eglot.el
+
+(defun jotain-go--eglot-workspace-config ()
+  "Conservative gopls defaults: staticcheck plus inlay-hint sources.
+gopls only emits inlay hints when the hint kinds are enabled in
+workspace configuration; `eglot-inlay-hints-mode' (armed for Go in
+init-prog) then displays them."
+  (setq-local eglot-workspace-configuration
+              '(:gopls (:staticcheck t
+                        :usePlaceholders t
+                        :hints (:parameterNames t
+                                :assignVariableTypes t
+                                :compositeLiteralFields t
+                                :compositeLiteralTypes t
+                                :constantValues t
+                                :functionTypeParameters t
+                                :rangeVariableTypes t)))))
+
+;;; @doc Built-in tree-sitter Go modes: `go-ts-mode` for source files,
+;;; `go-mod-ts-mode` for go.mod. Eglot wires gopls in init-prog;
+;;; format-on-save runs goimports through apheleia; dape drives dlv
+;;; for debugging. All Go tooling (go, gopls, goimports, dlv) comes
+;;; from the project/host PATH, not from this config.
+(use-package go-ts-mode
+  :ensure nil
+  :mode (("\\.go\\'" . go-ts-mode)
+         ("/go\\.mod\\'" . go-mod-ts-mode))
+  :hook ((go-ts-mode . jotain-go--eglot-workspace-config)
+         (go-mod-ts-mode . jotain-go--eglot-workspace-config))
+  :custom
+  ;; gofmt indents with tabs; a step of 8 (the default) matches the
+  ;; default `tab-width' so one indent level renders as exactly one tab.
+  (go-ts-mode-indent-offset 8))
+
+;; go.work: Emacs 31 adds `go-work-ts-mode'; on Emacs 30 fall back to
+;; `go-mod-ts-mode', whose gomod grammar handles the near-identical
+;; syntax.  This runs after treesit-auto (loaded in init-prog), so the
+;; entry prepends ahead of the go-work-ts-mode entry treesit-auto
+;; registers even on Emacs 30.
+(add-to-list 'auto-mode-alist
+             (cons "/go\\.work\\'"
+                   (if (fboundp 'go-work-ts-mode)
+                       'go-work-ts-mode
+                     'go-mod-ts-mode)))
+
+;;; @doc Run the Go test or benchmark at point, the current file's
+;;; tests, or the whole project, with compilation-mode error jumping.
+;;; Bound under the mode-local `C-c C-t` prefix in Go buffers.
+(use-package gotest
+  :after go-ts-mode
+  :bind (:map go-ts-mode-map
+              ("C-c C-t t" . go-test-current-test)
+              ("C-c C-t f" . go-test-current-file)
+              ("C-c C-t p" . go-test-current-project)
+              ("C-c C-t b" . go-test-current-benchmark)
+              ("C-c C-t c" . go-test-current-coverage)
+              ("C-c C-t r" . go-run)))
+
+(provide 'init-lang-go)
+;;; init-lang-go.el ends here

--- a/lisp/init-lang-go.el
+++ b/lisp/init-lang-go.el
@@ -46,7 +46,10 @@ init-prog) then displays them."
   :mode (("\\.go\\'" . go-ts-mode)
          ("/go\\.mod\\'" . go-mod-ts-mode))
   :hook ((go-ts-mode . jotain-go--eglot-workspace-config)
-         (go-mod-ts-mode . jotain-go--eglot-workspace-config))
+         (go-mod-ts-mode . jotain-go--eglot-workspace-config)
+         ;; Emacs 31 mode; on 30 the hook variable is created but
+         ;; never runs (go.work falls back to go-mod-ts-mode below).
+         (go-work-ts-mode . jotain-go--eglot-workspace-config))
   :custom
   ;; gofmt indents with tabs; a step of 8 (the default) matches the
   ;; default `tab-width' so one indent level renders as exactly one tab.

--- a/lisp/init-lang-systems.el
+++ b/lisp/init-lang-systems.el
@@ -1,21 +1,16 @@
-;;; init-lang-systems.el --- Systems language modes: Go, C/C++, CMake, Meson, Haskell, Zig -*- lexical-binding: t; -*-
+;;; init-lang-systems.el --- Systems language modes: C/C++, CMake, Meson, Haskell, Zig -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 
-;; Compiled/systems-programming modes. Go and cc-mode are built in
-;; (ensure nil); cmake-mode, meson-mode, haskell-mode, and zig-ts-mode
-;; come from MELPA.
+;; Compiled/systems-programming modes. cc-mode is built in (ensure
+;; nil); cmake-mode, meson-mode, haskell-mode, and zig-ts-mode come
+;; from MELPA. Go has grown into its own file, `init-lang-go.el'.
 ;;
-;; eglot wiring for go + rust + zig is in `init-prog.el'. If you add
-;; hooks for more servers, keep them there so all LSP wiring is in one
+;; eglot wiring for rust + zig is in `init-prog.el'. If you add hooks
+;; for more servers, keep them there so all LSP wiring is in one
 ;; place.
 
 ;;; Code:
-
-;;; @doc Go major mode. Eglot wires gopls in init-prog so all language
-;;; servers are configured in one place.
-(use-package go-mode
-  :defer t)
 
 ;;; @doc Built-in C/C++ mode with a Stroustrup style bias. The header
 ;;; extensions below default to C++ — Jotain assumes that's the

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -109,7 +109,7 @@ These servers may evaluate project JavaScript configuration files."
   ;; Per-language modules register modes only; auto-start lives here.
   :hook
   ((dockerfile-mode
-    go-mode go-ts-mode
+    go-mode go-ts-mode go-mod-ts-mode go-work-ts-mode
     nix-ts-mode
     python-mode python-ts-mode
     rust-mode rust-ts-mode
@@ -167,7 +167,8 @@ These servers may evaluate project JavaScript configuration files."
   ;; Server overrides — most languages don't need an entry, eglot has
   ;; sensible defaults. Add only when you want a specific server name.
   (add-to-list 'eglot-server-programs
-               '((go-mode go-ts-mode) . ("gopls")))
+               '((go-mode go-ts-mode go-mod-ts-mode go-work-ts-mode)
+                 . ("gopls")))
   (add-to-list 'eglot-server-programs
                '(dockerfile-mode . ("docker-langserver" "--stdio")))
 
@@ -216,6 +217,29 @@ These servers may evaluate project JavaScript configuration files."
 (use-package consult-eglot-embark
   :after (consult eglot embark)
   :demand t)
+
+;;;; Debugging — dape (Debug Adapter Protocol)
+
+;;; @doc Debug Adapter Protocol client — the debugging counterpart to
+;;; eglot. Ships adapter configs for dlv (Go), debugpy (Python),
+;;; codelldb (Rust/C/C++), and more; the adapter binary (e.g. `dlv`)
+;;; comes from the project/host PATH, same convention as the LSP
+;;; servers. `C-x C-a` is the prefix (the gud convention); stepping
+;;; commands carry repeat-maps, so `C-x C-a n n n` keeps stepping.
+(use-package dape
+  :bind-keymap ("C-x C-a" . dape-global-map)
+  :custom
+  (dape-buffer-window-arrangement 'right)
+  (dape-default-breakpoints-file (jotain-var-file "dape-breakpoints"))
+  :config
+  ;; Restore the previous session's breakpoints on first use; persist
+  ;; them at exit, but only when dape actually got loaded — neither
+  ;; function is autoloaded, and this keeps startup free of dape.
+  (dape-breakpoint-load)
+  (add-hook 'kill-emacs-hook
+            (lambda ()
+              (when (featurep 'dape)
+                (dape-breakpoint-save)))))
 
 ;;;; SonarLint (SonarCloud connected mode)
 
@@ -390,6 +414,11 @@ outside a project."
   (add-to-list 'apheleia-formatters
                '(zig-fmt . ("zig" "fmt" "--stdin")))
   (add-to-list 'apheleia-mode-alist '(zig-ts-mode . zig-fmt))
+  ;; Apheleia ships gofmt/goimports/gofumpt formatters but maps Go
+  ;; modes to plain gofmt; prepend a goimports mapping (gofmt plus
+  ;; import management) to shadow it.  The binary comes from the
+  ;; project/host PATH, like gopls and dlv.
+  (add-to-list 'apheleia-mode-alist '(go-ts-mode . goimports))
   ;; buildifier reads from stdin; `-path' lets it infer the Starlark
   ;; dialect (BUILD vs WORKSPACE vs .bzl).  Mapping the `bazel-mode'
   ;; parent covers every derived Starlark-family mode (build/workspace/

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -233,13 +233,10 @@ These servers may evaluate project JavaScript configuration files."
   (dape-default-breakpoints-file (jotain-var-file "dape-breakpoints"))
   :config
   ;; Restore the previous session's breakpoints on first use; persist
-  ;; them at exit, but only when dape actually got loaded — neither
-  ;; function is autoloaded, and this keeps startup free of dape.
+  ;; them at exit. Both run in :config, so a session that never loads
+  ;; dape never touches the breakpoints file.
   (dape-breakpoint-load)
-  (add-hook 'kill-emacs-hook
-            (lambda ()
-              (when (featurep 'dape)
-                (dape-breakpoint-save)))))
+  (add-hook 'kill-emacs-hook #'dape-breakpoint-save))
 
 ;;;; SonarLint (SonarCloud connected mode)
 

--- a/lisp/init-project.el
+++ b/lisp/init-project.el
@@ -114,9 +114,14 @@ projects sharing a basename across different roots stay distinct."
   :commands (compile-multi)
   :custom
   (compile-multi-config
-   '((go-mode      . (("go test"        . "go test ./...")
+   '((go-ts-mode   . (("go test"         . "go test ./...")
                       ("go test current" . "go test .")
-                      ("go build"       . "go build .")))
+                      ("go build"        . "go build ./...")
+                      ("go run"          . "go run .")
+                      ("go vet"          . "go vet ./...")
+                      ("golangci-lint"   . "golangci-lint run")))
+     (go-mod-ts-mode . (("go mod tidy"     . "go mod tidy")
+                        ("go mod download" . "go mod download")))
      (python-mode  . (("pytest"         . "pytest")
                       ("pytest file"    . "pytest %file-name%")))
      (haskell-mode . (("stack test"     . "stack test")

--- a/nix/packages-doc.nix
+++ b/nix/packages-doc.nix
@@ -111,6 +111,10 @@ let
       title = "Python";
     }
     {
+      file = "init-lang-go.el";
+      title = "Go";
+    }
+    {
       file = "init-lang-web.el";
       title = "Web (TypeScript, JS, CSS, HTML)";
     }
@@ -124,7 +128,7 @@ let
     }
     {
       file = "init-lang-systems.el";
-      title = "Systems (Go, C/C++, Haskell, Zig)";
+      title = "Systems (C/C++, Haskell, Zig)";
     }
   ];
 


### PR DESCRIPTION
## Summary

Go support was a bare MELPA `go-mode` with no tree-sitter pin, no formatter mapping, no gopls settings (inlay hints were armed in init-prog but gopls never emitted them), no test runner, no debugger, and compile-multi entries keyed on a mode Go buffers would stop using. This PR brings Go up to the big-language convention (Nix/Rust/Python) and adds a config-wide debugger.

### New `lisp/init-lang-go.el`
- Built-in `go-ts-mode` (`.go`) / `go-mod-ts-mode` (`go.mod`) pinned via `:mode`, mirroring init-lang-rust/python; the MELPA `go-mode` block is dropped from init-lang-systems.el.
- `go.work` falls back to `go-mod-ts-mode` on Emacs 30 (`fboundp` guard for Emacs 31's `go-work-ts-mode`), masking the broken `go-work-ts-mode` entry treesit-auto registers on 30.
- Buffer-local gopls workspace settings (staticcheck, usePlaceholders, all inlay-hint sources) set in a mode hook — this is what makes the already-armed `eglot-inlay-hints-mode` actually show hints, and `.dir-locals.el` still overrides per-project.
- `gotest` for test/benchmark-at-point under the mode-local `C-c C-t` prefix.

### `lisp/init-prog.el`
- Eglot hook + gopls server entry extended to `go-mod-ts-mode`/`go-work-ts-mode` so gopls also manages module files.
- `go-ts-mode` mapped to apheleia's built-in `goimports` (shadowing its plain-`gofmt` default) — format-on-save now organizes imports too.
- **New: `dape`** as the cross-language Debug Adapter Protocol client (`C-x C-a` prefix, gud convention). Right-side debug windows, breakpoints persisted under `var/`, restored on first use. Adapter binaries (`dlv` for Go, debugpy, codelldb, …) come from the project/host PATH — same convention as the LSP servers. Stepping commands carry repeat-maps, and `repeat-mode` is already on.

### Supporting changes
- `lisp/init-project.el`: compile-multi keyed on `go-ts-mode` (was stale `go-mode`) with expanded entries (test/build/run/vet/golangci-lint) plus `go-mod-ts-mode` entries (tidy/download).
- `lisp/init-keys.el`: which-key label for the `C-x C-a` prefix.
- `nix/packages-doc.nix`: `init-lang-go.el` added to the module order; systems title updated.
- Docs: `modules.mdx`, `compilation-mode.mdx`, regenerated `package-reference.mdx`; superseded dap-mode/realgud TODO links removed.

No Nix dev-shell changes: per the repo convention, `go`/`gopls`/`goimports`/`dlv`/`golangci-lint` come from the project's own environment (documented in the new module's Commentary).

## Verification

- `check-parens` clean on all touched elisp files; `init-lang-go.el` byte-compiles with zero warnings (Emacs 29 locally; `dape`/`gotest` resolve via the use-package scanner in the flake check env).
- `package-reference.mdx` regenerated with a byte-exact port of the generator (validated identical against HEAD's checked-in file before applying the change), so `packages-doc-in-sync` should pass.
- Nix was unavailable in this environment, so `just check` runs in CI — please treat the CI result as authoritative for treefmt/statix/elisp-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBehWv68JC9pZ2RDJGoCaF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBehWv68JC9pZ2RDJGoCaF)_