### PR TITLE
Add native devenv.sh integration (devenv.el + init-devenv)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -120,15 +120,14 @@ compile-native:
 #       --eval '(native-compile-async (list "{{config_dir}}/early-init.el" "{{config_dir}}/init.el" "{{config_dir}}/lisp") (quote recursively))' \
 #       --eval '(while (or comp-files-queue (> (comp-async-runnings) 0)) (sleep-for 1))'
 
-# [DISABLED] Run ERT tests under test/ if any exist.
+# Run the ERT tests under test/ via the flake check (the dev shell has
+# no emacs; the check builds one). Direct equivalent once Emacs is back
+# in the shell:
+#   emacs --batch -L lisp -L test -l ert -l test/devenv-test.el \
+#       -f ert-run-tests-batch-and-exit
 [group('check')]
 test:
-    @echo "just test is disabled — emacs is not in the devenv shell."
-    @echo "(There is no test/ directory yet; re-enable alongside Emacs.)"
-# Original:
-#   emacs --batch -L lisp -L test -l ert \
-#       $(find test -name 'test-*.el' -exec echo -l {} \;) \
-#       -f ert-run-tests-batch-and-exit
+    nix build .#checks.{{system}}.elisp-test --no-link --print-build-logs
 
 
 # Wrapper init files live in bench/ — kept on disk for when re-enabled.

--- a/docs/architecture/modules.mdx
+++ b/docs/architecture/modules.mdx
@@ -33,6 +33,7 @@ init-vc           vc, vc-jj, magit, majutsu, magit-todos, forge, diff-hl, smerge
 init-prog         prog-mode, treesit, eglot, flymake, eldoc, apheleia, compile
 init-snippets     tempel snippets + eglot-tempel LSP expansion
 init-project      project + projection + compile-multi
+init-devenv       devenv.sh: tasks, processes, env, LSP, MCP
 init-ai           claude-code-ide, gptel, mcp
 init-shell        eshell, vterm, comint
 init-systems      sops, logview, auth-source-1password
@@ -98,6 +99,10 @@ Template/snippet expansion via `tempel`, chosen over the built-in `skeleton`/`ab
 ### `init-project`
 
 Two complementary project command systems: `projection` (`.dir-locals.el`-backed commands exposed via `C-x P`, auto-detected from Makefiles/justfiles/Cargo.toml/etc) and `compile-multi` (per-major-mode named compile commands like "go test", "pytest file", "nix flake check"). They overlap but neither fully covers the other.
+
+### `init-devenv`
+
+Wiring for the in-repo [devenv.sh](https://devenv.sh) integration library `lisp/devenv.el` — the one file under `lisp/` that is *not* an `init-*` module: it is a standalone, reusable package (own `devenv-` namespace, no `jotain-` dependencies) that this module merely binds into the configuration. `C-c v` opens a transient with task and script runners (completing-read over `devenv tasks list --json` / `devenv eval scripts`), `devenv test`/`build`/`update`/`gc` through compilation-mode with Nix-trace error matching, a tabulated process dashboard over the devenv process manager (`devenv up`/`down`, per-process start/stop/restart/logs), environment introspection (`devenv eval`/`info`/`search`), and `devenv-reload` (invalidates caches, refreshes the environment through envrc, offers `eglot-reconnect`). `devenv.nix` buffers are routed to the bundled `devenv lsp` server while `nil` keeps serving other Nix files. `devenv-mcp-setup` registers the project's `devenv mcp` stdio server with mcp.el for gptel tool use. Environment loading stays with envrc (see `init-prog`); the library's optional native loader (`devenv-env-global-mode`) exists for devenv projects without direnv and skips envrc-managed projects. See [devenv integration](/usage/devenv) for the user guide.
 
 ### `init-ai`
 

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -840,8 +840,12 @@ reconnect eglot servers so they see the new environment.
 devenv.nix buffers are routed to the bundled `devenv lsp` server
 while `nil` keeps serving other Nix files, and `devenv-mcp-setup`
 registers the project's `devenv mcp` server with mcp.el so gptel
-can call its tools. Everything degrades to a clean error when the
-`devenv` binary is not on PATH.
+can call its tools. `devenv-allow`/`devenv-revoke` manage devenv
+2.1's auto-activation trust database, which also gates the native
+env loader, and `devenv-modeline-mode` (enabled here) shows the
+per-buffer status — devenv[on]/[off]/[!] — in the mode line.
+Everything degrades to a clean error when the `devenv` binary is
+not on PATH.
 
 ## `init-ai.el` — AI assistants
 

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -825,6 +825,24 @@ command type — purely visual, but a useful at-a-glance hint.
 Embark actions on compile-multi entries (run, copy, edit
 command line). Mirrors the projection embark integration.
 
+## `init-devenv.el` — devenv.sh integration
+
+### `devenv` *(built-in / Nix)*
+
+Native devenv.sh integration (the in-repo `lisp/devenv.el`
+library). `C-c v` opens a transient with task and script runners,
+`devenv test`/`build` through compilation-mode with Nix error
+matching, a process-manager dashboard (start/stop/restart/logs),
+and environment introspection (`devenv eval`/`info`/`search`).
+`devenv-reload` refreshes the project environment through envrc
+(the direnv substrate configured in init-prog) and offers to
+reconnect eglot servers so they see the new environment.
+devenv.nix buffers are routed to the bundled `devenv lsp` server
+while `nil` keeps serving other Nix files, and `devenv-mcp-setup`
+registers the project's `devenv mcp` server with mcp.el so gptel
+can call its tools. Everything degrades to a clean error when the
+`devenv` binary is not on PATH.
+
 ## `init-ai.el` — AI assistants
 
 ### `claude-code-ide` *(built-in / Nix)*

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,7 +41,8 @@
           {
             "group": "Usage",
             "pages": [
-              "usage/launching"
+              "usage/launching",
+              "usage/devenv"
             ]
           },
           {

--- a/docs/jotain.texi
+++ b/docs/jotain.texi
@@ -60,6 +60,7 @@ Configuration
 Usage
 
 * Launching Emacs::             One-shot, daemon + client, quick edit.
+* Devenv Integration::          Tasks, processes, env, LSP, MCP.
 
 Guides
 
@@ -118,6 +119,10 @@ Appendix
 @node Launching Emacs
 @chapter Launching Emacs
 @include usage-launching.texi
+
+@node Devenv Integration
+@chapter Devenv Integration
+@include usage-devenv.texi
 
 @node Finding Information in Emacs
 @chapter Finding Information in Emacs

--- a/docs/keybindings.mdx
+++ b/docs/keybindings.mdx
@@ -33,6 +33,7 @@ following:
 | `C-c o` | **combobulate** prefix | structural editing dispatch |
 | `C-c r` | **eglot-refactor** prefix | `r r` rename, `r f` format, `r a` actions, `r o` organize-imports, `r q` quickfix |
 | `C-c t` | toggle-theme | `auto-dark-toggle-appearance` |
+| `C-c v` | devenv | `devenv` transient — tasks, scripts, processes, env |
 | `C-c RET` | gptel-send | `gptel-send` |
 | `C-c M-RET` | gptel-menu | `gptel-menu` |
 | `C-c M-x` | consult-mode-command | `consult-mode-command` |

--- a/docs/usage/devenv.mdx
+++ b/docs/usage/devenv.mdx
@@ -29,6 +29,8 @@ so devenv's TUI stays out of the machine-readable output.
 | `i` / `/` / `:` | `devenv-info` / `devenv-search` / `devenv-eval` | Introspection: environment summary, package/option search, evaluate any config attribute to pretty-printed JSON |
 | `r` | `devenv-reload` | Refresh the environment (below) |
 | `e` | `devenv-env-global-mode` | Toggle the native environment loader (below) |
+| `m` | `devenv-modeline-mode` | Toggle the mode-line status segment (below) |
+| `a` / `x` | `devenv-allow` / `devenv-revoke` | Trust / untrust the project for auto-activation (below) |
 | `M` | `devenv-mcp-setup` | Register the project's MCP server with mcp.el |
 | `U` / `G` | `devenv-update` / `devenv-gc` | Update `devenv.lock` inputs / garbage-collect old generations |
 | `$` | `devenv-show-log` | Every CLI invocation is recorded in `*devenv log*` |
@@ -69,6 +71,38 @@ predicate skips any project with a `.envrc`, so it can never
 double-manage a buffer envrc owns. While a fetch is in flight,
 `eglot-ensure` is deferred and replayed once the environment lands, so
 language servers never start with the wrong `PATH`.
+
+## Auto-activation trust (`devenv allow` / `revoke`)
+
+devenv 2.1+ gates shell auto-activation behind a per-project trust
+database (`~/.local/share/devenv/allowed`), managed with `devenv
+allow` and `devenv revoke`. The integration honours the same
+contract: the native loader (`devenv-env-global-mode`) consults the
+internal `devenv hook-should-activate` check and **never evaluates an
+untrusted devenv.nix automatically** — exactly like the zsh/fish/nu
+shell hooks. `devenv-allow` (`C-c v a`) trusts the project and
+immediately activates the loader in its buffers; `devenv-revoke`
+(`C-c v x`) untrusts it and drops the native environment. On devenv
+versions without the trust model (< 2.1) the loader behaves as
+before. Note that the direnv/envrc path has its own consent gate
+(`envrc-allow` → `direnv allow`), independent of devenv's database.
+
+## Mode-line status
+
+`devenv-modeline-mode` (global, enabled by `init-devenv` at startup)
+adds a status segment to the mode line for buffers inside a devenv
+project:
+
+- **`devenv[on]`** — the buffer's environment carries the devenv
+  shell (loaded by envrc/direnv or the native loader; detected via
+  `DEVENV_PROFILE`).
+- **`devenv[off]`** — devenv project, environment not loaded.
+- **`devenv[!]`** — auto-activation trust denied; run `devenv-allow`.
+
+Outside devenv projects the segment is empty. `mouse-1` on the
+segment opens the `devenv` transient. The redisplay path is
+subprocess-free: trust is probed once per project in the background
+from `find-file-hook` and cached.
 
 ## LSP for devenv.nix
 

--- a/docs/usage/devenv.mdx
+++ b/docs/usage/devenv.mdx
@@ -1,0 +1,100 @@
+---
+title: devenv integration
+description: Run tasks, manage processes, and introspect devenv.sh environments from Emacs
+---
+
+# devenv integration
+
+Jotain ships a native integration with [devenv](https://devenv.sh), the
+Nix-based developer environment tool. The library lives in
+`lisp/devenv.el` (standalone and reusable — no Jotain dependencies) and
+is wired in by `init-devenv.el`. Everything is driven through the
+`devenv` CLI and degrades to a clean error when the binary is not on
+`PATH`. devenv 2.1+ is recommended; every invocation sets `AI_AGENT=1`
+so devenv's TUI stays out of the machine-readable output.
+
+## Entry point: `C-c v`
+
+`C-c v` (or `M-x devenv`) opens a transient covering the whole surface:
+
+| Key | Command | What it does |
+| --- | --- | --- |
+| `t` | `devenv-task-run` | Pick a task (annotated from `devenv tasks list --json`) and run it; prefix arg selects the dependency mode (`before`/`single`/`after`/`all`) |
+| `s` | `devenv-script-run` | Pick a script defined in `devenv.nix` (annotated with its description) and run it |
+| `T` | `devenv-test` | `devenv test` (enterTest, with processes started/stopped around it) |
+| `b` | `devenv-build` | `devenv build`, optionally for specific attributes |
+| `u` / `d` | `devenv-up` / `devenv-down` | Start/stop the project's processes; `up` streams into a live buffer (or detaches, see `devenv-up-detached`); prefix arg picks a subset |
+| `p` | `devenv-processes` | Process dashboard (below) |
+| `l` | `devenv-processes-logs` | Tail one process's logs |
+| `i` / `/` / `:` | `devenv-info` / `devenv-search` / `devenv-eval` | Introspection: environment summary, package/option search, evaluate any config attribute to pretty-printed JSON |
+| `r` | `devenv-reload` | Refresh the environment (below) |
+| `e` | `devenv-env-global-mode` | Toggle the native environment loader (below) |
+| `M` | `devenv-mcp-setup` | Register the project's MCP server with mcp.el |
+| `U` / `G` | `devenv-update` / `devenv-gc` | Update `devenv.lock` inputs / garbage-collect old generations |
+| `$` | `devenv-show-log` | Every CLI invocation is recorded in `*devenv log*` |
+
+The `-c` (`--clean`) and `-r` (`--refresh-eval-cache`) infixes apply to
+`devenv-test` and `devenv-build`.
+
+Long-running commands (test, build, tasks, update, gc) run in
+compilation buffers with Nix trace matching, so `M-g M-n` jumps to the
+`file.nix:LINE:COL` locations in evaluation errors.
+
+## Process dashboard
+
+`devenv-processes` opens a tabulated view of the devenv process
+manager. Keys: `s` start, `k` stop, `r` restart, `l`/`RET` logs, `u`
+up, `d` down, `g` refresh. Data comes from `devenv processes list`
+(JSON when available, plain table on older devenv), fetched
+asynchronously so the UI never blocks.
+
+## Environment loading and reload
+
+Environment loading stays with **envrc + direnv** (see `init-prog`):
+`.envrc` says `use devenv`, so every project buffer already carries the
+devenv shell environment buffer-locally — eglot servers, apheleia
+formatters, `M-x compile`, and vterm all see devenv-provided tools with
+no extra configuration.
+
+After changing `devenv.nix`, run `devenv-reload` (`C-c v r`). It
+invalidates the library's caches, refreshes the environment through
+`envrc-reload-all`, and — because eglot snapshots the environment when
+a server starts — offers to `eglot-reconnect` every server serving the
+project so language servers pick up new `PATH` entries.
+
+For devenv projects **without** direnv, `devenv-env-global-mode` is an
+optional native loader: it fetches `devenv print-dev-env --json`
+asynchronously and applies it buffer-locally, envrc-style. Its
+predicate skips any project with a `.envrc`, so it can never
+double-manage a buffer envrc owns. While a fetch is in flight,
+`eglot-ensure` is deferred and replayed once the environment lands, so
+language servers never start with the wrong `PATH`.
+
+## LSP for devenv.nix
+
+devenv 2.0+ ships `devenv lsp`, a bundled nixd preconfigured with the
+project's devenv module options (completion, hover docs for
+`devenv.nix` options). `init-devenv` routes `devenv.nix` and
+`devenv.local.nix` buffers to it while `nil` keeps serving every other
+Nix file — the routing entry delegates non-devenv buffers to whatever
+contact was registered before it.
+
+## MCP server for the AI stack
+
+devenv 2.0+ ships `devenv mcp`, a stdio MCP server exposing nixpkgs
+package search, devenv option search, and process control
+(list/status/logs/start/stop/restart). `devenv-mcp-setup` (`C-c v M`)
+registers it with [mcp.el](https://github.com/lizqwerscott/mcp.el)
+under a per-project name (`devenv-<project>`); start it from
+`M-x mcp-hub` and run `M-x gptel-mcp-connect` to hand its tools to
+gptel. `devenv-mcp-remove` unregisters it.
+
+## Customization
+
+The `devenv` customization group covers the executable name
+(`devenv-executable`), the quiet-mode environment
+(`devenv-extra-env`), global CLI flags (`devenv-global-arguments`),
+cache TTL and command timeout, detached `up`
+(`devenv-up-detached`), variables the native loader never applies
+(`devenv-env-ignored-variables`), and the dashboard's log line count
+(`devenv-processes-log-lines`).

--- a/init.el
+++ b/init.el
@@ -91,6 +91,7 @@
 (require 'init-prog)         ; prog-mode, treesit, eglot, flymake, eldoc, compile
 (require 'init-snippets)     ; tempel snippets + eglot-tempel LSP expansion
 (require 'init-project)      ; project + projection + compile-multi
+(require 'init-devenv)       ; devenv.sh: tasks, processes, env, LSP, MCP
 (require 'init-ai)           ; claude-code-ide, gptel, mcp
 (require 'init-shell)        ; eshell, vterm, comint
 (require 'init-systems)      ; sops, logview, auth-source-1password

--- a/lisp/devenv.el
+++ b/lisp/devenv.el
@@ -358,10 +358,13 @@ time and exists for tests."
   "Drop cached results for ROOT, or all roots when ROOT is nil."
   (if (null root)
       (clrhash devenv--cache)
-    (maphash (lambda (key _value)
-               (when (equal (car key) root)
-                 (remhash key devenv--cache)))
-             devenv--cache)))
+    (let (stale)
+      (maphash (lambda (key _value)
+                 (when (equal (car key) root)
+                   (push key stale)))
+               devenv--cache)
+      (dolist (key stale)
+        (remhash key devenv--cache)))))
 
 (defun devenv-version (root)
   "Return the devenv version string active in ROOT, or nil."
@@ -911,7 +914,10 @@ reconnect any eglot servers so they see the new environment."
   (let ((root (devenv--root-or-error)))
     (devenv--cache-invalidate root)
     (cond
+     ;; `envrc-reload-all' can be fboundp via its autoload before the
+     ;; package is loaded, so also require the mode variable to exist.
      ((and (fboundp 'envrc-reload-all)
+           (boundp 'envrc-mode)
            (seq-some (lambda (buffer)
                        (buffer-local-value 'envrc-mode buffer))
                      (devenv--project-buffers root)))
@@ -1156,6 +1162,12 @@ at the front of the list.  Call after eglot is loaded."
   (format "devenv-%s"
           (file-name-nondirectory (directory-file-name root))))
 
+(defun devenv--mcp-command (root)
+  "Return the sh -c command string that starts `devenv mcp' in ROOT."
+  (format "cd %s && exec %s mcp"
+          (shell-quote-argument root)
+          (shell-quote-argument devenv-executable)))
+
 ;;;###autoload
 (defun devenv-mcp-setup ()
   "Register the current project's `devenv mcp' server with mcp.el.
@@ -1171,10 +1183,7 @@ clients: start the server from the `mcp-hub' dashboard, then
   (let* ((root (devenv--root-or-error))
          (name (devenv--mcp-server-name root))
          (spec (list :command "sh"
-                     :args (list "-c"
-                                 (format "cd %s && exec %s mcp"
-                                         (shell-quote-argument root)
-                                         devenv-executable)))))
+                     :args (list "-c" (devenv--mcp-command root)))))
     (setf (alist-get name mcp-hub-servers nil nil #'equal) spec)
     (message "devenv: registered MCP server %S — start it from M-x \
 mcp-hub, then M-x gptel-mcp-connect exposes its tools to gptel"

--- a/lisp/devenv.el
+++ b/lisp/devenv.el
@@ -90,6 +90,10 @@
 (defvar mcp-hub-servers)
 (defvar envrc-mode)
 
+;; Defined later in this file; declared for forward references.
+(defvar devenv-env-global-mode)
+(defvar devenv-env-mode)
+
 ;;;; Customization
 
 (defgroup devenv nil
@@ -376,6 +380,84 @@ time and exists for tests."
            (when (string-match "devenv \\([0-9][0-9.]*\\)" out)
              (match-string 1 out)))
        (error nil)))))
+
+;;;; Auto-activation trust (devenv allow / revoke)
+
+;; devenv 2.1+ gates auto-activation behind a trust database
+;; (~/.local/share/devenv/allowed, managed by `devenv allow' and
+;; `devenv revoke').  The shell hook consults it via the internal
+;; `devenv hook-should-activate' subcommand: exit 0 with the project
+;; path on stdout when trusted, exit 2 when a project exists but is
+;; not trusted, exit 0 with no output when there is no project.  The
+;; native environment loader below honours the same contract so Emacs
+;; never evaluates an untrusted devenv.nix automatically.
+
+(defun devenv--activation-state (exit output)
+  "Map hook-should-activate EXIT code and OUTPUT to a trust state.
+Returns `allowed', `blocked', `no-project', or `unsupported' (a
+devenv without the trust model, e.g. 1.x — treated as permitted
+to preserve that version's behaviour)."
+  (cond
+   ((and (eql exit 0) (not (string-blank-p (or output "")))) 'allowed)
+   ((eql exit 2) 'blocked)
+   ((eql exit 0) 'no-project)
+   (t 'unsupported)))
+
+(defun devenv--activation-permits-p (state)
+  "Return non-nil when trust STATE permits automatic env loading."
+  (memq state '(allowed unsupported)))
+
+(defun devenv--trust-state (root)
+  "Return ROOT's auto-activation trust state (cached).
+See `devenv--activation-state' for the possible values."
+  (devenv--cached
+   root 'trust
+   (lambda ()
+     (if (not (executable-find devenv-executable))
+         'unsupported
+       (let ((default-directory root)
+             (process-environment (append devenv-extra-env
+                                          process-environment)))
+         (with-temp-buffer
+           (let ((exit (ignore-errors
+                         (apply #'call-process devenv-executable
+                                nil '(t nil) nil
+                                (append devenv-global-arguments
+                                        '("hook-should-activate"))))))
+             (devenv--activation-state exit (buffer-string)))))))))
+
+;;;###autoload
+(defun devenv-allow ()
+  "Trust the current project for devenv auto-activation.
+Runs `devenv allow' (recording the project in devenv's trust
+database), then activates the native environment loader in the
+project's buffers when `devenv-env-global-mode' is enabled."
+  (interactive)
+  (let ((root (devenv--root-or-error)))
+    (devenv--call root "allow")
+    (devenv--cache-invalidate root)
+    (when devenv-env-global-mode
+      (dolist (buffer (devenv--project-buffers root))
+        (with-current-buffer buffer
+          (unless devenv-env-mode
+            (devenv-env--turn-on)))))
+    (devenv-modeline--refresh-root root)
+    (message "devenv: allowed %s" (abbreviate-file-name root))))
+
+;;;###autoload
+(defun devenv-revoke ()
+  "Revoke devenv auto-activation trust for the current project.
+Runs `devenv revoke' and drops the native environment from any
+buffer `devenv-env-mode' was managing."
+  (interactive)
+  (let ((root (devenv--root-or-error)))
+    (devenv--call root "revoke")
+    (devenv--cache-invalidate root)
+    (dolist (buffer (devenv-env--buffers root))
+      (with-current-buffer buffer
+        (devenv-env-mode -1)))
+    (devenv-modeline--refresh-root root)
+    (message "devenv: revoked %s" (abbreviate-file-name root))))
 
 ;;;; Introspection: eval, info, search
 
@@ -928,6 +1010,7 @@ reconnect any eglot servers so they see the new environment."
       (devenv-env--refresh root))
      (t
       (message "devenv: introspection cache cleared")))
+    (devenv-modeline--refresh-root root)
     (devenv--offer-eglot-reconnect root)))
 
 ;;;; Native environment loader (opt-in; envrc is the default substrate)
@@ -979,7 +1062,8 @@ variable, skipping names in IGNORED (defaults to
       (setq-local process-environment
                   (append pairs (default-value 'process-environment)))
       (when-let* ((path (devenv-env--path-from-pairs pairs)))
-        (setq-local exec-path path)))))
+        (setq-local exec-path path))
+      (devenv-modeline--update buffer 'no-probe))))
 
 (defun devenv-env--cached-pairs (root)
   "Return cached environment pairs for ROOT, or nil."
@@ -1063,14 +1147,18 @@ without direnv."
   "Enable `devenv-env-mode' when this buffer should manage its env.
 The buffer must sit inside a devenv project that direnv does not
 already cover (no .envrc anywhere above), with the devenv binary
-available.  Never activates in the minibuffer or remote buffers."
-  (when (and (not (minibufferp))
-             (not (file-remote-p default-directory))
-             (executable-find devenv-executable)
-             (devenv-project-root)
-             (not (locate-dominating-file default-directory ".envrc"))
-             (not (bound-and-true-p envrc-mode)))
-    (devenv-env-mode 1)))
+available, and the project must be trusted for auto-activation
+\(`devenv allow'; see `devenv-allow').  Never activates in the
+minibuffer or remote buffers."
+  (let ((root (and (not (minibufferp))
+                   (not (file-remote-p default-directory))
+                   (executable-find devenv-executable)
+                   (devenv-project-root))))
+    (when (and root
+               (not (locate-dominating-file default-directory ".envrc"))
+               (not (bound-and-true-p envrc-mode))
+               (devenv--activation-permits-p (devenv--trust-state root)))
+      (devenv-env-mode 1))))
 
 (defun devenv-env--around-eglot-ensure (orig-fun &rest args)
   "Defer ORIG-FUN (`eglot-ensure', ARGS) while the env is loading.
@@ -1090,6 +1178,156 @@ environment.  Deferred buffers replay once the env is applied."
       (advice-add 'eglot-ensure :around
                   #'devenv-env--around-eglot-ensure)
     (advice-remove 'eglot-ensure #'devenv-env--around-eglot-ensure)))
+
+;;;; Modeline status
+
+(defface devenv-modeline-active-face
+  '((t :inherit success))
+  "Face for the modeline segment when the devenv env is active.")
+
+(defface devenv-modeline-inactive-face
+  '((t :inherit shadow))
+  "Face for the modeline segment when the devenv env is not loaded.")
+
+(defface devenv-modeline-blocked-face
+  '((t :inherit warning))
+  "Face for the modeline segment when auto-activation is blocked.")
+
+(defvar-local devenv-modeline--state nil
+  "Cached devenv modeline state for this buffer.
+Nil when not yet computed; otherwise `none' (not a devenv
+project), `active', `inactive', or `blocked'.")
+
+(defvar devenv-modeline--map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [mode-line mouse-1] #'devenv)
+    map)
+  "Keymap for the devenv modeline segment; mouse-1 opens the menu.")
+
+(defun devenv-modeline--compute-state (root active trust-state)
+  "Return the modeline state for a buffer.
+ROOT is the devenv project root or nil, ACTIVE non-nil when the
+buffer's environment already carries the devenv shell, and
+TRUST-STATE the cached `devenv--activation-state' value (or
+nil when unknown)."
+  (cond ((null root) 'none)
+        (active 'active)
+        ((eq trust-state 'blocked) 'blocked)
+        (t 'inactive)))
+
+(defun devenv-modeline--format (state)
+  "Return the mode-line string for modeline STATE."
+  (pcase state
+    ('active
+     (propertize " devenv[on]"
+                 'face 'devenv-modeline-active-face
+                 'help-echo "devenv environment active\nmouse-1: devenv menu"
+                 'mouse-face 'mode-line-highlight
+                 'local-map devenv-modeline--map))
+    ('inactive
+     (propertize " devenv[off]"
+                 'face 'devenv-modeline-inactive-face
+                 'help-echo "devenv project, environment not loaded\n\
+mouse-1: devenv menu"
+                 'mouse-face 'mode-line-highlight
+                 'local-map devenv-modeline--map))
+    ('blocked
+     (propertize " devenv[!]"
+                 'face 'devenv-modeline-blocked-face
+                 'help-echo "devenv project not trusted — M-x devenv-allow\n\
+mouse-1: devenv menu"
+                 'mouse-face 'mode-line-highlight
+                 'local-map devenv-modeline--map))
+    (_ "")))
+
+(defun devenv-modeline--cached-trust (root)
+  "Return ROOT's trust state from the cache, or nil when unknown.
+Never runs devenv: modeline code must stay subprocess-free on
+the synchronous path."
+  (cdr (gethash (cons root 'trust) devenv--cache)))
+
+(defvar devenv-modeline--probing (make-hash-table :test #'equal)
+  "Roots whose trust state is being resolved in the background.")
+
+(defun devenv-modeline--probe-trust (root)
+  "Resolve ROOT's trust state asynchronously, then refresh buffers."
+  (unless (gethash root devenv-modeline--probing)
+    (puthash root t devenv-modeline--probing)
+    (devenv--run root '("hook-should-activate")
+                 (lambda (exit output)
+                   (remhash root devenv-modeline--probing)
+                   (puthash (cons root 'trust)
+                            (cons (float-time)
+                                  (devenv--activation-state exit output))
+                            devenv--cache)
+                   (devenv-modeline--refresh-root root))
+                 "trust-probe")))
+
+(defun devenv-modeline--update (&optional buffer no-probe)
+  "Recompute the devenv modeline state for BUFFER.
+Unless NO-PROBE, kick an asynchronous trust probe when the state
+is unknown so blocked projects eventually show devenv[!]."
+  (with-current-buffer (or buffer (current-buffer))
+    (let ((root (devenv-project-root)))
+      (setq devenv-modeline--state
+            (devenv-modeline--compute-state
+             root
+             (and root (getenv "DEVENV_PROFILE"))
+             (and root (devenv-modeline--cached-trust root))))
+      (when (and root (not no-probe)
+                 (eq devenv-modeline--state 'inactive)
+                 (null (devenv-modeline--cached-trust root))
+                 (executable-find devenv-executable))
+        (devenv-modeline--probe-trust root))
+      devenv-modeline--state)))
+
+(defun devenv-modeline--refresh-root (root)
+  "Recompute the modeline state of every buffer under ROOT."
+  (when (bound-and-true-p devenv-modeline-mode)
+    (dolist (buffer (devenv--project-buffers root))
+      (devenv-modeline--update buffer 'no-probe))
+    (force-mode-line-update t)))
+
+(defun devenv-modeline--segment ()
+  "Return the devenv status string for the current buffer.
+Computes the state lazily on first render; the redisplay path
+never runs subprocesses (probes happen from `find-file-hook')."
+  (unless devenv-modeline--state
+    (devenv-modeline--update nil 'no-probe))
+  (devenv-modeline--format devenv-modeline--state))
+
+(defun devenv-modeline--on-find-file ()
+  "Compute this buffer's modeline state, probing trust if needed."
+  (devenv-modeline--update))
+
+(defconst devenv-modeline--construct
+  '(devenv-modeline-mode (:eval (devenv-modeline--segment)))
+  "Mode-line construct injected into `mode-line-misc-info'.")
+
+;;;###autoload
+(define-minor-mode devenv-modeline-mode
+  "Show the devenv environment status in the mode line.
+Displays devenv[on] when the buffer's environment carries the
+devenv shell (loaded by envrc/direnv or `devenv-env-mode'),
+devenv[off] in a devenv project whose environment is not loaded,
+and devenv[!] when auto-activation trust has been denied (run
+\\[devenv-allow] to trust the project).  Outside devenv projects
+the segment is empty."
+  :global t
+  (if devenv-modeline-mode
+      (progn
+        (add-to-list 'mode-line-misc-info devenv-modeline--construct t)
+        (add-hook 'find-file-hook #'devenv-modeline--on-find-file)
+        (add-hook 'dired-mode-hook #'devenv-modeline--on-find-file)
+        ;; Invalidate so already-open buffers recompute lazily.
+        (dolist (buffer (buffer-list))
+          (with-current-buffer buffer
+            (setq devenv-modeline--state nil))))
+    (setq mode-line-misc-info
+          (delete devenv-modeline--construct mode-line-misc-info))
+    (remove-hook 'find-file-hook #'devenv-modeline--on-find-file)
+    (remove-hook 'dired-mode-hook #'devenv-modeline--on-find-file))
+  (force-mode-line-update t))
 
 ;;;; Eglot: serve devenv.nix with `devenv lsp'
 
@@ -1224,8 +1462,11 @@ mcp-hub, then M-x gptel-mcp-connect exposes its tools to gptel"
     ("$" "Show invocation log" devenv-show-log)]]
   ["Environment"
    [("r" "Reload environment" devenv-reload)
-    ("e" "Native env loader (global)" devenv-env-global-mode)]
-   [("M" "Register MCP server" devenv-mcp-setup)]]
+    ("e" "Native env loader (global)" devenv-env-global-mode)
+    ("m" "Modeline status (global)" devenv-modeline-mode)]
+   [("a" "Allow auto-activation" devenv-allow)
+    ("x" "Revoke auto-activation" devenv-revoke)
+    ("M" "Register MCP server" devenv-mcp-setup)]]
   ["Maintenance"
    [("U" "Update inputs (devenv.lock)" devenv-update)
     ("G" "Garbage-collect generations" devenv-gc)]]

--- a/lisp/devenv.el
+++ b/lisp/devenv.el
@@ -1,0 +1,1228 @@
+;;; devenv.el --- devenv.sh integration: tasks, processes, env, LSP, MCP -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Markus Jylhänkangas
+
+;; Author: Markus Jylhänkangas <markus@jylhis.com>
+;; Maintainer: Markus Jylhänkangas <markus@jylhis.com>
+;; URL: https://github.com/Jylhis/jotain
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "30.1") (transient "0.7.4"))
+;; Keywords: processes, tools, unix
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Native Emacs integration for devenv <https://devenv.sh>, the
+;; Nix-based developer environment tool.  Everything is driven through
+;; the `devenv' CLI (2.x recommended; older versions degrade
+;; gracefully):
+;;
+;;   `devenv'                  Transient entry point with all commands.
+;;   `devenv-task-run'         Pick and run a task (`devenv tasks run').
+;;   `devenv-script-run'       Pick and run a script from the config.
+;;   `devenv-test'             `devenv test' in a compilation buffer.
+;;   `devenv-build'            `devenv build' in a compilation buffer.
+;;   `devenv-up' / `devenv-down'
+;;                             Start/stop the project's processes.
+;;   `devenv-processes'        Tabulated dashboard over the process
+;;                             manager (start/stop/restart/logs).
+;;   `devenv-info' / `devenv-search' / `devenv-eval'
+;;                             Introspection of the environment.
+;;   `devenv-reload'           Refresh the environment (delegates to
+;;                             envrc when it manages the project) and
+;;                             offer to reconnect eglot servers.
+;;   `devenv-env-global-mode'  Optional native environment loader for
+;;                             devenv projects without direnv: applies
+;;                             `devenv print-dev-env --json' buffer-
+;;                             locally, envrc-style.
+;;   `devenv-eglot-setup'      Route devenv.nix buffers to the bundled
+;;                             `devenv lsp' server (a nixd preloaded
+;;                             with the project's devenv options) while
+;;                             other Nix buffers keep their server.
+;;   `devenv-mcp-setup'        Register the project's `devenv mcp'
+;;                             stdio server with mcp.el so gptel and
+;;                             friends can call its tools.
+;;
+;; Environment loading: with direnv, the recommended substrate is
+;; envrc.el plus `use devenv' in .envrc — this library detects that
+;; and stays out of the way.  `devenv-env-global-mode' exists for
+;; devenv projects without direnv; its predicate skips any project
+;; that has a .envrc, so the two loaders can never double-manage a
+;; buffer.  Buffer-local values propagate to temp buffers through
+;; inheritenv when that package is installed (envrc depends on it).
+;;
+;; All subprocess invocations set AI_AGENT=1 (see `devenv-extra-env'),
+;; which puts devenv 2.1+ into quiet mode: the TUI is suppressed and
+;; stdout stays machine-readable.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'subr-x)
+(require 'seq)
+(require 'json)
+(require 'compile)
+(require 'ansi-color)
+(require 'tabulated-list)
+(require 'transient)
+
+;; Soft dependencies — only called when the feature is loaded.
+(declare-function envrc-reload-all "envrc" ())
+(declare-function eglot-reconnect "eglot" (server &optional interactive))
+(declare-function eglot-current-server "eglot" ())
+(declare-function eglot-managed-p "eglot" ())
+(declare-function eglot-ensure "eglot" ())
+(defvar eglot-server-programs)
+(defvar mcp-hub-servers)
+(defvar envrc-mode)
+
+;;;; Customization
+
+(defgroup devenv nil
+  "Integration with devenv.sh developer environments."
+  :group 'tools
+  :prefix "devenv-")
+
+(defcustom devenv-executable "devenv"
+  "Name or path of the devenv executable."
+  :type 'string)
+
+(defcustom devenv-extra-env '("AI_AGENT=1")
+  "Environment strings prepended to every devenv subprocess.
+The default AI_AGENT=1 switches devenv 2.1+ into quiet mode so
+the progress TUI never interleaves with machine-readable output."
+  :type '(repeat string))
+
+(defcustom devenv-global-arguments '("-q")
+  "Arguments inserted after the executable in every invocation."
+  :type '(repeat string))
+
+(defcustom devenv-cache-ttl 30
+  "Seconds to keep cached introspection results (tasks, scripts)."
+  :type 'natnum)
+
+(defcustom devenv-command-timeout 60
+  "Seconds to wait for a synchronous devenv command before giving up."
+  :type 'natnum)
+
+(defcustom devenv-up-detached nil
+  "When non-nil, `devenv-up' starts processes detached (devenv up -d).
+Otherwise processes run attached in a live output buffer."
+  :type 'boolean)
+
+(defcustom devenv-env-ignored-variables '("PS1" "SHLVL" "TERM" "HOME")
+  "Variables from `devenv print-dev-env' never applied to buffers."
+  :type '(repeat string))
+
+(defcustom devenv-env-lighter " devenv"
+  "Mode-line lighter for `devenv-env-mode'."
+  :type 'string)
+
+(defcustom devenv-processes-log-lines 200
+  "Number of log lines fetched by `devenv-processes-logs'."
+  :type 'natnum)
+
+;;;; Project root and executable discovery
+
+(defun devenv-project-root (&optional dir)
+  "Return the devenv project root at or above DIR, else nil.
+The root is the closest directory containing devenv.nix.  DIR
+defaults to `default-directory'.  Remote directories are not
+supported and return nil."
+  (let ((dir (or dir default-directory)))
+    (unless (file-remote-p dir)
+      (when-let* ((root (locate-dominating-file dir "devenv.nix")))
+        (expand-file-name root)))))
+
+(defun devenv--ensure-executable ()
+  "Signal a `user-error' unless the devenv executable is on PATH.
+Return the resolved executable path."
+  (or (executable-find devenv-executable)
+      (user-error "Cannot find `%s' on PATH; install devenv or set \
+`devenv-executable'" devenv-executable)))
+
+(defun devenv--root-or-error (&optional dir)
+  "Return the devenv project root covering DIR or signal `user-error'."
+  (or (devenv-project-root dir)
+      (user-error "No devenv.nix found above %s"
+                  (abbreviate-file-name (or dir default-directory)))))
+
+;;;; Logging
+
+(defvar devenv-log-buffer-name "*devenv log*"
+  "Name of the buffer recording every devenv CLI invocation.")
+
+(defun devenv--log (root argv exit output)
+  "Append an invocation record to `devenv-log-buffer-name'.
+ROOT is the project directory, ARGV the full command list, EXIT
+the numeric exit status (or a symbol while still running), and
+OUTPUT the captured text (truncated for display)."
+  (with-current-buffer (get-buffer-create devenv-log-buffer-name)
+    (unless (derived-mode-p 'special-mode)
+      (special-mode))
+    (let ((inhibit-read-only t))
+      (goto-char (point-max))
+      (insert (format "\n[%s] %s\n$ %s\n=> %s\n"
+                      (format-time-string "%F %T")
+                      (abbreviate-file-name root)
+                      (mapconcat #'identity argv " ")
+                      exit))
+      (when (and output (not (string-empty-p output)))
+        (insert (if (> (length output) 4000)
+                    (concat (substring output 0 4000) "…[truncated]\n")
+                  output))
+        (unless (string-suffix-p "\n" output)
+          (insert "\n"))))))
+
+(defun devenv-show-log ()
+  "Display the devenv invocation log buffer."
+  (interactive)
+  (display-buffer (get-buffer-create devenv-log-buffer-name)))
+
+;;;; Subprocess plumbing
+
+(defun devenv--command (args &optional global-args)
+  "Return the full argv for a devenv invocation with ARGS.
+GLOBAL-ARGS are extra global flags (e.g. from the transient)
+inserted between `devenv-global-arguments' and ARGS."
+  (cons devenv-executable
+        (append devenv-global-arguments global-args args)))
+
+(defun devenv--shell-command (argv)
+  "Return ARGV quoted for the shell as a single command string."
+  (mapconcat #'shell-quote-argument argv " "))
+
+(defun devenv--first-line (string)
+  "Return the first non-empty line of STRING, or the empty string."
+  (or (seq-find (lambda (line) (not (string-blank-p line)))
+                (split-string (or string "") "\n"))
+      ""))
+
+(defun devenv--call (root &rest args)
+  "Run devenv with ARGS synchronously in ROOT; return stdout.
+Waits at most `devenv-command-timeout' seconds.  A non-zero exit
+signals a `user-error' carrying the first stderr line."
+  (devenv--ensure-executable)
+  (let* ((default-directory root)
+         (process-environment (append devenv-extra-env process-environment))
+         (argv (devenv--command args))
+         (stdout (generate-new-buffer " *devenv-stdout*"))
+         (stderr (generate-new-buffer " *devenv-stderr*")))
+    (unwind-protect
+        (let ((proc (make-process
+                     :name "devenv" :buffer stdout :stderr stderr
+                     :command argv :noquery t :connection-type 'pipe
+                     :sentinel #'ignore)))
+          ;; The pipe process wrapping STDERR must not prompt either.
+          (when-let* ((err-proc (get-buffer-process stderr)))
+            (set-process-query-on-exit-flag err-proc nil))
+          (with-timeout (devenv-command-timeout
+                         (delete-process proc)
+                         (devenv--log root argv 'timeout nil)
+                         (user-error "devenv timed out after %ss: %s"
+                                     devenv-command-timeout
+                                     (devenv--shell-command argv)))
+            (while (process-live-p proc)
+              (accept-process-output proc 0.1)))
+          ;; Let the stderr pipe drain before reading it.
+          (accept-process-output nil 0.05)
+          (let ((exit (process-exit-status proc))
+                (out (with-current-buffer stdout (buffer-string)))
+                (err (with-current-buffer stderr (buffer-string))))
+            (devenv--log root argv exit (if (string-empty-p err) out err))
+            (unless (zerop exit)
+              (user-error "devenv failed (%d): %s" exit
+                          (devenv--first-line err)))
+            out))
+      (kill-buffer stdout)
+      (kill-buffer stderr))))
+
+(defun devenv--json-parse (string)
+  "Parse JSON STRING with the conventions used across this library.
+Objects become alists, arrays become lists, null/false become
+nil.  Signals on malformed input."
+  (json-parse-string string
+                     :object-type 'alist
+                     :array-type 'list
+                     :null-object nil
+                     :false-object nil))
+
+(defun devenv--call-json (root &rest args)
+  "Run devenv with ARGS in ROOT and parse the stdout as JSON."
+  (let ((out (apply #'devenv--call root args)))
+    (condition-case err
+        (devenv--json-parse out)
+      (error (user-error "devenv returned unparseable JSON (%s): %s"
+                         (error-message-string err)
+                         (devenv--first-line out))))))
+
+(defun devenv--run (root args callback &optional name)
+  "Run devenv with ARGS asynchronously in ROOT.
+CALLBACK receives (EXIT-CODE OUTPUT) when the process finishes.
+NAME labels the process.  If `make-process' itself fails,
+CALLBACK still runs (with exit code 127) so callers never
+deadlock waiting for a result."
+  (devenv--ensure-executable)
+  (let* ((default-directory root)
+         (process-environment (append devenv-extra-env process-environment))
+         (argv (devenv--command args))
+         (buffer (generate-new-buffer
+                  (format " *devenv-%s*" (or name "async")))))
+    (condition-case nil
+        (make-process
+         :name (format "devenv-%s" (or name "async"))
+         :buffer buffer :command argv :noquery t :connection-type 'pipe
+         :sentinel
+         (lambda (proc _event)
+           (when (memq (process-status proc) '(exit signal))
+             (let* ((buf (process-buffer proc))
+                    (exit (process-exit-status proc))
+                    (output (if (buffer-live-p buf)
+                                (with-current-buffer buf (buffer-string))
+                              "")))
+               (devenv--log root argv exit output)
+               (when (buffer-live-p buf) (kill-buffer buf))
+               (funcall callback exit output)))))
+      (error
+       (when (buffer-live-p buffer) (kill-buffer buffer))
+       (funcall callback 127 "")))))
+
+(defvar devenv-compilation-error-regexp-alist-alist
+  '((devenv-nix-trace
+     "\\bat \\(/[^ :\n]+\\.nix\\):\\([0-9]+\\):\\([0-9]+\\)" 1 2 3)
+    (devenv-nix-error "^error: " nil nil nil 2))
+  "Error matchers for `devenv-compilation-mode' (Nix eval traces).")
+
+(defvar devenv-compilation-error-regexp-alist
+  '(devenv-nix-trace devenv-nix-error)
+  "Active error matchers for `devenv-compilation-mode'.")
+
+(define-compilation-mode devenv-compilation-mode "devenv"
+  "Compilation mode for devenv commands with Nix trace matching.")
+
+(defun devenv--compile (root args &optional global-args)
+  "Run devenv ARGS in ROOT through `compilation-start'.
+GLOBAL-ARGS are global CLI flags inserted before the subcommand.
+Return the compilation buffer."
+  (devenv--ensure-executable)
+  (let* ((default-directory root)
+         (compilation-environment devenv-extra-env)
+         (argv (devenv--command args global-args))
+         (command (devenv--shell-command argv)))
+    (devenv--log root argv 'compile nil)
+    (compilation-start
+     command #'devenv-compilation-mode
+     (lambda (_mode)
+       (format "*devenv %s: %s*"
+               (car args)
+               (file-name-nondirectory (directory-file-name root)))))))
+
+;;;; Cache
+
+(defvar devenv--cache (make-hash-table :test #'equal)
+  "Cache of introspection results keyed by (ROOT . KEY).
+Values are (TIMESTAMP . VALUE) conses; see `devenv-cache-ttl'.")
+
+(defun devenv--cache-fresh-p (entry &optional now)
+  "Return non-nil when cache ENTRY is younger than `devenv-cache-ttl'.
+ENTRY is a (TIMESTAMP . VALUE) cons; NOW defaults to the current
+time and exists for tests."
+  (and entry
+       (< (- (or now (float-time)) (car entry)) devenv-cache-ttl)))
+
+(defun devenv--cached (root key fetch-fn)
+  "Return the cached value for (ROOT . KEY), refreshing via FETCH-FN."
+  (let* ((cache-key (cons root key))
+         (entry (gethash cache-key devenv--cache)))
+    (if (devenv--cache-fresh-p entry)
+        (cdr entry)
+      (let ((value (funcall fetch-fn)))
+        (puthash cache-key (cons (float-time) value) devenv--cache)
+        value))))
+
+(defun devenv--cache-invalidate (&optional root)
+  "Drop cached results for ROOT, or all roots when ROOT is nil."
+  (if (null root)
+      (clrhash devenv--cache)
+    (maphash (lambda (key _value)
+               (when (equal (car key) root)
+                 (remhash key devenv--cache)))
+             devenv--cache)))
+
+(defun devenv-version (root)
+  "Return the devenv version string active in ROOT, or nil."
+  (devenv--cached
+   root 'version
+   (lambda ()
+     (condition-case nil
+         (let ((out (devenv--call root "version")))
+           (when (string-match "devenv \\([0-9][0-9.]*\\)" out)
+             (match-string 1 out)))
+       (error nil)))))
+
+;;;; Introspection: eval, info, search
+
+(defun devenv--eval-attr (root attr)
+  "Evaluate config ATTR in ROOT via `devenv eval'; return parsed JSON.
+When the output is a single-key object keyed by ATTR itself the
+value is unwrapped, so callers always get the attribute's value."
+  (let ((parsed (devenv--call-json root "eval" attr)))
+    (if (and (consp parsed)
+             (null (cdr parsed))
+             (consp (car parsed))
+             (equal (symbol-name (caar parsed)) attr))
+        (cdar parsed)
+      parsed)))
+
+(defvar devenv-eval-history nil
+  "Minibuffer history for `devenv-eval'.")
+
+;;;###autoload
+(defun devenv-eval (attr)
+  "Evaluate devenv config attribute ATTR and show it as pretty JSON."
+  (interactive
+   (list (read-string "devenv eval attribute: " nil 'devenv-eval-history)))
+  (let* ((root (devenv--root-or-error))
+         (out (devenv--call root "eval" attr))
+         (buffer (get-buffer-create (format "*devenv eval: %s*" attr))))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert out)
+        (ignore-errors (json-pretty-print-buffer))
+        (if (fboundp 'js-json-mode) (js-json-mode) (fundamental-mode))
+        (view-mode 1)))
+    (display-buffer buffer)))
+
+(defun devenv--show-output (buffer-name output)
+  "Display OUTPUT (ANSI-colored) in a fresh buffer named BUFFER-NAME."
+  (let ((buffer (get-buffer-create buffer-name)))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (ansi-color-apply output))
+        (goto-char (point-min))
+        (special-mode)))
+    (display-buffer buffer)))
+
+;;;###autoload
+(defun devenv-info ()
+  "Show `devenv info' for the current project."
+  (interactive)
+  (let ((root (devenv--root-or-error)))
+    (devenv--show-output
+     (format "*devenv info: %s*"
+             (file-name-nondirectory (directory-file-name root)))
+     (devenv--call root "info"))))
+
+;;;###autoload
+(defun devenv-search (query)
+  "Search nixpkgs packages and devenv options for QUERY."
+  (interactive "sdevenv search: ")
+  (let ((root (devenv--root-or-error)))
+    (devenv--show-output (format "*devenv search: %s*" query)
+                         (devenv--call root "search" query))))
+
+;;;; Tasks
+
+(defun devenv--tasks-parse (parsed)
+  "Normalize PARSED `devenv tasks list --json' output.
+Return an alist of (NAME . DESCRIPTION) with NAME a string and
+DESCRIPTION a string or nil.  Accepts either a list of task
+objects with `name'/`description' fields or an object mapping
+task names to their definitions."
+  (cond
+   ;; List of task objects: ({name: "a:b", description: …} …)
+   ((and (listp parsed)
+         (cl-every #'listp parsed)
+         (cl-some (lambda (entry) (and (listp entry) (assq 'name entry)))
+                  parsed))
+    (mapcar (lambda (entry)
+              (cons (format "%s" (alist-get 'name entry))
+                    (alist-get 'description entry)))
+            parsed))
+   ;; Object keyed by task name: ((a:b . (…)) …)
+   ((and (consp parsed) (consp (car parsed)) (symbolp (caar parsed)))
+    (mapcar (lambda (entry)
+              (cons (symbol-name (car entry))
+                    (when (listp (cdr entry))
+                      (alist-get 'description (cdr entry)))))
+            parsed))
+   (t nil)))
+
+(defun devenv--tasks (root)
+  "Return the (NAME . DESCRIPTION) task alist for ROOT (cached)."
+  (devenv--cached
+   root 'tasks
+   (lambda ()
+     (devenv--tasks-parse
+      (devenv--call-json root "tasks" "list" "--json")))))
+
+(defconst devenv-task-run-modes '("before" "single" "after" "all")
+  "Valid values for the -m flag of `devenv tasks run'.")
+
+;;;###autoload
+(defun devenv-task-run (task &optional mode)
+  "Run TASK via `devenv tasks run' in a compilation buffer.
+Interactively, complete over the project's tasks; with a prefix
+argument also prompt for the dependency MODE (devenv 2.1 default
+is `before', which runs the task's dependencies first)."
+  (interactive
+   (let* ((root (devenv--root-or-error))
+          (tasks (or (devenv--tasks root)
+                     (user-error "No tasks defined in this devenv \
+configuration")))
+          (completion-extra-properties
+           (list :annotation-function
+                 (lambda (name)
+                   (when-let* ((desc (cdr (assoc name tasks))))
+                     (concat "  " desc))))))
+     (list (completing-read "Run task: " tasks nil t)
+           (when current-prefix-arg
+             (completing-read "Dependency mode: " devenv-task-run-modes
+                              nil t nil nil "before")))))
+  (devenv--compile (devenv--root-or-error)
+                   (append (list "tasks" "run" task)
+                           (when mode (list "-m" mode)))))
+
+;;;; Scripts
+
+(defun devenv--scripts (root)
+  "Return the (NAME . DESCRIPTION) script alist for ROOT (cached)."
+  (devenv--cached
+   root 'scripts
+   (lambda ()
+     (let ((parsed (ignore-errors (devenv--eval-attr root "scripts"))))
+       (when (and (consp parsed) (consp (car parsed)))
+         (mapcar (lambda (entry)
+                   (cons (symbol-name (car entry))
+                         (when (listp (cdr entry))
+                           (let ((desc (alist-get 'description
+                                                  (cdr entry))))
+                             (unless (member desc '(nil "")) desc)))))
+                 parsed))))))
+
+;;;###autoload
+(defun devenv-script-run (script)
+  "Run SCRIPT (defined in devenv.nix) in a compilation buffer.
+When the buffer's environment already carries DEVENV_PROFILE
+\(direnv/envrc has loaded the shell), the script is on PATH and
+runs directly; otherwise it goes through `devenv shell'."
+  (interactive
+   (let* ((root (devenv--root-or-error))
+          (scripts (or (devenv--scripts root)
+                       (user-error "No scripts defined in this devenv \
+configuration")))
+          (completion-extra-properties
+           (list :annotation-function
+                 (lambda (name)
+                   (when-let* ((desc (cdr (assoc name scripts))))
+                     (concat "  " desc))))))
+     (list (completing-read "Run script: " scripts nil t))))
+  (let ((root (devenv--root-or-error)))
+    (if (getenv "DEVENV_PROFILE")
+        (let ((default-directory root))
+          (compilation-start (shell-quote-argument script)
+                             #'devenv-compilation-mode))
+      (devenv--compile root (list "shell" script)))))
+
+;;;; Build, test, maintenance
+
+;;;###autoload
+(defun devenv-test (&optional args)
+  "Run `devenv test' in a compilation buffer.
+ARGS are extra global CLI flags (supplied by the transient)."
+  (interactive (list (transient-args 'devenv)))
+  (devenv--compile (devenv--root-or-error) '("test") args))
+
+;;;###autoload
+(defun devenv-build (&optional attrs args)
+  "Run `devenv build' in a compilation buffer.
+ATTRS is a space-separated string of attributes to build (empty
+builds the whole shell).  ARGS are extra global CLI flags."
+  (interactive (list (read-string "Attributes (empty for all): ")
+                     (transient-args 'devenv)))
+  (devenv--compile (devenv--root-or-error)
+                   (cons "build" (split-string (or attrs "") nil t))
+                   args))
+
+;;;###autoload
+(defun devenv-update ()
+  "Run `devenv update' (refresh devenv.lock) in a compilation buffer."
+  (interactive)
+  (devenv--compile (devenv--root-or-error) '("update")))
+
+;;;###autoload
+(defun devenv-gc ()
+  "Run `devenv gc' (delete unused environment generations)."
+  (interactive)
+  (devenv--compile (devenv--root-or-error) '("gc")))
+
+;;;; Processes: up/down and log buffers
+
+(define-derived-mode devenv-log-mode special-mode "devenv-log"
+  "Major mode for live devenv process output buffers."
+  (setq-local window-point-insertion-type t))
+
+(defun devenv--insert-filter (proc string)
+  "Insert STRING into PROC's buffer with ANSI colors applied."
+  (when (buffer-live-p (process-buffer proc))
+    (with-current-buffer (process-buffer proc)
+      (let ((inhibit-read-only t))
+        (save-excursion
+          (goto-char (point-max))
+          (insert (ansi-color-apply string)))))))
+
+(defun devenv--up-buffer-name (root)
+  "Return the attached `devenv up' buffer name for ROOT."
+  (format "*devenv up: %s*"
+          (file-name-nondirectory (directory-file-name root))))
+
+;;;###autoload
+(defun devenv-up (&optional select)
+  "Start the project's processes with `devenv up'.
+With prefix argument SELECT, choose a subset of the defined
+processes.  Runs detached when `devenv-up-detached' is non-nil,
+otherwise attached in a live `devenv-log-mode' buffer."
+  (interactive "P")
+  (let* ((root (devenv--root-or-error))
+         (procs (when select
+                  (let ((defined (devenv--processes-defined root)))
+                    (unless defined
+                      (user-error "No processes defined in devenv.nix"))
+                    (completing-read-multiple "Processes: " defined nil t))))
+         (args (append '("up") procs)))
+    (if devenv-up-detached
+        (devenv--run root (append args '("-d"))
+                     (lambda (exit _output)
+                       (if (zerop exit)
+                           (message "devenv up: started (detached)")
+                         (message "devenv up failed; see %s"
+                                  devenv-log-buffer-name)))
+                     "up")
+      (let* ((default-directory root)
+             (process-environment (append devenv-extra-env
+                                          process-environment))
+             (buffer (get-buffer-create (devenv--up-buffer-name root))))
+        (when (get-buffer-process buffer)
+          (user-error "devenv up already running in %s"
+                      (buffer-name buffer)))
+        (with-current-buffer buffer
+          (let ((inhibit-read-only t)) (erase-buffer))
+          (devenv-log-mode))
+        (make-process
+         :name "devenv-up" :buffer buffer
+         :command (devenv--command args)
+         :noquery t :connection-type 'pipe
+         :filter #'devenv--insert-filter
+         :sentinel (lambda (proc event)
+                     (devenv--insert-filter
+                      proc (format "\n[devenv up %s]"
+                                   (string-trim event)))))
+        (display-buffer buffer)))))
+
+;;;###autoload
+(defun devenv-down ()
+  "Stop the project's running processes with `devenv down'."
+  (interactive)
+  (let ((root (devenv--root-or-error)))
+    ;; Interrupt an attached `devenv up' first so it can shut down.
+    (when-let* ((buffer (get-buffer (devenv--up-buffer-name root)))
+                (proc (get-buffer-process buffer)))
+      (interrupt-process proc))
+    (devenv--run root '("down")
+                 (lambda (exit _output)
+                   (if (zerop exit)
+                       (message "devenv down: processes stopped")
+                     (message "devenv down failed; see %s"
+                              devenv-log-buffer-name))
+                   (devenv-processes--maybe-refresh root))
+                 "down")))
+
+(defun devenv--processes-defined (root)
+  "Return the names of processes defined in ROOT's devenv.nix."
+  (devenv--cached
+   root 'processes-def
+   (lambda ()
+     (let ((parsed (ignore-errors (devenv--eval-attr root "processes"))))
+       (when (and (consp parsed) (consp (car parsed)))
+         (mapcar (lambda (entry) (symbol-name (car entry))) parsed))))))
+
+;;;###autoload
+(defun devenv-processes-logs (name)
+  "Show recent log output of managed process NAME."
+  (interactive
+   (list (completing-read
+          "Process logs: "
+          (or (devenv--processes-defined (devenv--root-or-error)) '())
+          nil nil)))
+  (let* ((root (devenv--root-or-error))
+         (out (devenv--call root "processes" "logs" name
+                            "-n" (number-to-string
+                                  devenv-processes-log-lines)))
+         (buffer (get-buffer-create (format "*devenv logs: %s*" name))))
+    (with-current-buffer buffer
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (ansi-color-apply out))
+        (goto-char (point-max)))
+      (devenv-log-mode))
+    (display-buffer buffer)))
+
+;;;; Process dashboard
+
+(defvar-local devenv-processes--root nil
+  "Project root shown by this `devenv-processes-mode' buffer.")
+
+(defun devenv-processes--parse-json (parsed)
+  "Normalize PARSED `devenv processes list --json' output.
+Return a list of (NAME STATUS DETAIL) string triples.  Accepts
+a list of process objects or an object keyed by process name."
+  (cl-flet ((field (alist key)
+              (let ((value (alist-get key alist)))
+                (if value (format "%s" value) ""))))
+    (cond
+     ((and (listp parsed)
+           (cl-every #'listp parsed)
+           (cl-some (lambda (entry) (and (listp entry) (assq 'name entry)))
+                    parsed))
+      (mapcar (lambda (entry)
+                (list (field entry 'name)
+                      (field entry 'status)
+                      (string-trim
+                       (concat (field entry 'pid) " "
+                               (field entry 'exit_code)))))
+              parsed))
+     ((and (consp parsed) (consp (car parsed)) (symbolp (caar parsed)))
+      (mapcar (lambda (entry)
+                (let ((props (if (listp (cdr entry)) (cdr entry) nil)))
+                  (list (symbol-name (car entry))
+                        (field props 'status)
+                        (string-trim
+                         (concat (field props 'pid) " "
+                                 (field props 'exit_code))))))
+              parsed))
+     (t nil))))
+
+(defun devenv-processes--parse-table (output)
+  "Parse plain-text `devenv processes list' OUTPUT into triples.
+Columns are split on runs of two or more spaces; header and rule
+lines are skipped.  Return (NAME STATUS DETAIL) string triples."
+  (let (rows)
+    (dolist (line (split-string (ansi-color-filter-apply output) "\n" t))
+      (let ((cols (split-string (string-trim line) "[ \t][ \t]+" t)))
+        (when (and cols
+                   (not (string-match-p "\\`\\(NAME\\'\\|[─═-]+\\'\\)"
+                                        (car cols))))
+          (push (list (nth 0 cols)
+                      (or (nth 1 cols) "")
+                      (mapconcat #'identity (cddr cols) " "))
+                rows))))
+    (nreverse rows)))
+
+(defun devenv-processes--entries (triples)
+  "Convert (NAME STATUS DETAIL) TRIPLES to `tabulated-list-entries'."
+  (mapcar (lambda (row)
+            (list (nth 0 row)
+                  (vector (nth 0 row) (nth 1 row) (nth 2 row))))
+          triples))
+
+(defun devenv-processes--display (buffer triples)
+  "Fill dashboard BUFFER with TRIPLES and redraw it."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq tabulated-list-entries (devenv-processes--entries triples))
+      (tabulated-list-print t)
+      (unless triples
+        (let ((inhibit-read-only t))
+          (save-excursion
+            (goto-char (point-max))
+            (insert "No running processes — press u (devenv up) to \
+start them.")))))))
+
+(defun devenv-processes--refresh ()
+  "Asynchronously refresh the current dashboard buffer."
+  (let ((buffer (current-buffer))
+        (root devenv-processes--root))
+    (devenv--run
+     root '("processes" "list" "--json")
+     (lambda (exit output)
+       (if (zerop exit)
+           (devenv-processes--display
+            buffer
+            (devenv-processes--parse-json
+             (ignore-errors (devenv--json-parse output))))
+         ;; Older devenv without --json: fall back to the plain table.
+         (devenv--run
+          root '("processes" "list")
+          (lambda (exit2 output2)
+            (devenv-processes--display
+             buffer (when (zerop exit2)
+                      (devenv-processes--parse-table output2))))
+          "processes-list")))
+     "processes-list")))
+
+(defun devenv-processes--maybe-refresh (root)
+  "Refresh the dashboard buffer for ROOT when one exists."
+  (dolist (buffer (buffer-list))
+    (with-current-buffer buffer
+      (when (and (derived-mode-p 'devenv-processes-mode)
+                 (equal devenv-processes--root root))
+        (devenv-processes--refresh)))))
+
+(defun devenv-processes--name-at-point ()
+  "Return the process name on the current dashboard line."
+  (or (tabulated-list-get-id)
+      (user-error "No process on this line")))
+
+(defun devenv-processes--act (verb)
+  "Run `devenv processes VERB' on the process at point, then refresh."
+  (let ((name (devenv-processes--name-at-point))
+        (buffer (current-buffer))
+        (root devenv-processes--root))
+    (message "devenv processes %s %s…" verb name)
+    (devenv--run root (list "processes" verb name)
+                 (lambda (exit _output)
+                   (message "devenv processes %s %s: %s" verb name
+                            (if (zerop exit) "ok" "failed"))
+                   (when (buffer-live-p buffer)
+                     (with-current-buffer buffer
+                       (devenv-processes--refresh))))
+                 verb)))
+
+(defun devenv-processes-start ()
+  "Start the process at point."
+  (interactive nil devenv-processes-mode)
+  (devenv-processes--act "start"))
+
+(defun devenv-processes-stop ()
+  "Stop the process at point."
+  (interactive nil devenv-processes-mode)
+  (devenv-processes--act "stop"))
+
+(defun devenv-processes-restart ()
+  "Restart the process at point."
+  (interactive nil devenv-processes-mode)
+  (devenv-processes--act "restart"))
+
+(defun devenv-processes-show-logs ()
+  "Show logs for the process at point."
+  (interactive nil devenv-processes-mode)
+  (let ((default-directory devenv-processes--root))
+    (devenv-processes-logs (devenv-processes--name-at-point))))
+
+(defun devenv-processes-revert (&optional _ignore-auto _noconfirm)
+  "Refresh the dashboard; suitable for `revert-buffer-function'."
+  (interactive nil devenv-processes-mode)
+  (devenv-processes--refresh))
+
+(defvar-keymap devenv-processes-mode-map
+  :parent tabulated-list-mode-map
+  :doc "Keymap for `devenv-processes-mode'."
+  "s" #'devenv-processes-start
+  "k" #'devenv-processes-stop
+  "r" #'devenv-processes-restart
+  "l" #'devenv-processes-show-logs
+  "RET" #'devenv-processes-show-logs
+  "u" #'devenv-up
+  "d" #'devenv-down)
+
+(define-derived-mode devenv-processes-mode tabulated-list-mode
+  "devenv-processes"
+  "Dashboard over the devenv process manager.
+Observes processes managed by `devenv up'; keys start, stop,
+restart, and tail individual processes."
+  (setq tabulated-list-format [("Process" 28 t)
+                               ("Status" 14 t)
+                               ("Detail" 0 nil)])
+  (setq tabulated-list-padding 1)
+  (setq-local revert-buffer-function #'devenv-processes-revert)
+  (tabulated-list-init-header))
+
+;;;###autoload
+(defun devenv-processes ()
+  "Open the process dashboard for the current devenv project."
+  (interactive)
+  (let* ((root (devenv--root-or-error))
+         (buffer (get-buffer-create
+                  (format "*devenv processes: %s*"
+                          (file-name-nondirectory
+                           (directory-file-name root))))))
+    (with-current-buffer buffer
+      (devenv-processes-mode)
+      (setq devenv-processes--root root)
+      (devenv-processes--refresh))
+    (pop-to-buffer buffer)))
+
+;;;; Environment reload
+
+(defun devenv--project-buffers (root)
+  "Return live buffers whose `default-directory' sits under ROOT."
+  (seq-filter (lambda (buffer)
+                (with-current-buffer buffer
+                  (and default-directory
+                       (not (file-remote-p default-directory))
+                       (file-in-directory-p default-directory root))))
+              (buffer-list)))
+
+(defun devenv--offer-eglot-reconnect (root)
+  "Offer to reconnect eglot servers serving buffers under ROOT.
+Eglot snapshots the environment when a server starts, so after
+an environment change reconnecting is the only way a language
+server picks up new PATH entries and variables."
+  (when (featurep 'eglot)
+    (let (servers)
+      (dolist (buffer (devenv--project-buffers root))
+        (with-current-buffer buffer
+          (when (and (fboundp 'eglot-managed-p) (eglot-managed-p))
+            (when-let* ((server (eglot-current-server)))
+              (cl-pushnew server servers)))))
+      (when (and servers
+                 (y-or-n-p (format "Reconnect %d eglot server%s with \
+the new environment? "
+                                   (length servers)
+                                   (if (cdr servers) "s" ""))))
+        (dolist (server servers)
+          (eglot-reconnect server))))))
+
+;;;###autoload
+(defun devenv-reload ()
+  "Reload the devenv environment for the current project.
+Invalidates cached introspection, then refreshes buffer-local
+environments: through envrc when it manages this project (the
+recommended direnv substrate), or through `devenv-env-mode'
+buffers when the native loader is active.  Finally offers to
+reconnect any eglot servers so they see the new environment."
+  (interactive)
+  (let ((root (devenv--root-or-error)))
+    (devenv--cache-invalidate root)
+    (cond
+     ((and (fboundp 'envrc-reload-all)
+           (seq-some (lambda (buffer)
+                       (buffer-local-value 'envrc-mode buffer))
+                     (devenv--project-buffers root)))
+      (message "devenv: refreshing environment via envrc…")
+      (envrc-reload-all))
+     ((devenv-env--buffers root)
+      (message "devenv: refreshing native environment…")
+      (devenv-env--refresh root))
+     (t
+      (message "devenv: introspection cache cleared")))
+    (devenv--offer-eglot-reconnect root)))
+
+;;;; Native environment loader (opt-in; envrc is the default substrate)
+
+(defvar devenv-env--pending (make-hash-table :test #'equal)
+  "Roots with an environment fetch in flight, mapped to buffers.")
+
+(defvar devenv-env--eglot-replay nil
+  "Buffers whose deferred `eglot-ensure' replays after env load.")
+
+(defconst devenv-env--cache-ttl 3600
+  "Seconds to keep a fetched environment.
+Deliberately much longer than `devenv-cache-ttl': the shell env
+only changes when the config does, and `devenv-reload'
+invalidates it explicitly.")
+
+(defun devenv-env--parse (json-string &optional ignored)
+  "Parse `devenv print-dev-env --json' JSON-STRING output.
+Return a list of \"NAME=VALUE\" strings for every exported
+variable, skipping names in IGNORED (defaults to
+`devenv-env-ignored-variables')."
+  (let* ((ignored (or ignored devenv-env-ignored-variables))
+         (parsed (devenv--json-parse json-string))
+         (variables (alist-get 'variables parsed))
+         pairs)
+    (dolist (entry variables)
+      (let* ((name (symbol-name (car entry)))
+             (props (cdr entry))
+             (type (alist-get 'type props))
+             (value (alist-get 'value props)))
+        (when (and (equal type "exported")
+                   (stringp value)
+                   (not (member name ignored)))
+          (push (concat name "=" value) pairs))))
+    (nreverse pairs)))
+
+(defun devenv-env--path-from-pairs (pairs)
+  "Return the `exec-path' list encoded in PAIRS' PATH entry, or nil."
+  (when-let* ((path-entry (seq-find (lambda (pair)
+                                      (string-prefix-p "PATH=" pair))
+                                    pairs)))
+    (append (parse-colon-path (substring path-entry 5))
+            (list exec-directory))))
+
+(defun devenv-env--apply (buffer pairs)
+  "Apply environment PAIRS buffer-locally to BUFFER, envrc-style."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq-local process-environment
+                  (append pairs (default-value 'process-environment)))
+      (when-let* ((path (devenv-env--path-from-pairs pairs)))
+        (setq-local exec-path path)))))
+
+(defun devenv-env--cached-pairs (root)
+  "Return cached environment pairs for ROOT, or nil."
+  (let ((entry (gethash (cons root 'env) devenv--cache))
+        (devenv-cache-ttl devenv-env--cache-ttl))
+    (when (devenv--cache-fresh-p entry)
+      (cdr entry))))
+
+(defun devenv-env--fetch (root)
+  "Fetch ROOT's environment asynchronously and apply it when done.
+All buffers registered under ROOT in `devenv-env--pending' get
+the result; deferred `eglot-ensure' calls are replayed."
+  (devenv--run
+   root '("print-dev-env" "--json")
+   (lambda (exit output)
+     (let ((buffers (gethash root devenv-env--pending))
+           (pairs (when (zerop exit)
+                    (condition-case nil
+                        (devenv-env--parse output)
+                      (error nil)))))
+       (remhash root devenv-env--pending)
+       (if (null pairs)
+           (message "devenv: loading environment for %s failed; see %s"
+                    (abbreviate-file-name root) devenv-log-buffer-name)
+         (puthash (cons root 'env) (cons (float-time) pairs)
+                  devenv--cache)
+         (dolist (buffer buffers)
+           (devenv-env--apply buffer pairs))
+         (message "devenv: environment loaded for %s"
+                  (abbreviate-file-name root))
+         (let ((replay devenv-env--eglot-replay))
+           (setq devenv-env--eglot-replay nil)
+           (dolist (buffer replay)
+             (cond
+              ((not (buffer-live-p buffer)))
+              ((memq buffer buffers)
+               (with-current-buffer buffer
+                 (when (fboundp 'eglot-ensure) (eglot-ensure))))
+              ;; Belongs to a different, still-pending root: keep it.
+              (t (push buffer devenv-env--eglot-replay))))))))
+   "print-dev-env"))
+
+(defun devenv-env--buffers (root)
+  "Return live buffers under ROOT that have `devenv-env-mode' on."
+  (seq-filter (lambda (buffer)
+                (buffer-local-value 'devenv-env-mode buffer))
+              (devenv--project-buffers root)))
+
+(defun devenv-env--refresh (root)
+  "Re-fetch ROOT's environment and re-apply it to its buffers."
+  (remhash (cons root 'env) devenv--cache)
+  (dolist (buffer (devenv-env--buffers root))
+    (push buffer (gethash root devenv-env--pending)))
+  (devenv-env--fetch root))
+
+;;;###autoload
+(define-minor-mode devenv-env-mode
+  "Apply the project's devenv environment buffer-locally.
+Fetches `devenv print-dev-env --json' asynchronously (cached per
+project) and sets `process-environment' and `exec-path' locally
+in this buffer, in the style of envrc.  Prefer envrc + direnv
+when the project has a .envrc; this mode is for devenv projects
+without direnv."
+  :lighter devenv-env-lighter
+  (if devenv-env-mode
+      (let ((root (devenv-project-root)))
+        (if (null root)
+            (setq devenv-env-mode nil)
+          (let ((pairs (devenv-env--cached-pairs root)))
+            (if pairs
+                (devenv-env--apply (current-buffer) pairs)
+              (let ((pending (gethash root devenv-env--pending)))
+                (push (current-buffer)
+                      (gethash root devenv-env--pending))
+                (unless pending
+                  (devenv-env--fetch root)))))))
+    (kill-local-variable 'process-environment)
+    (kill-local-variable 'exec-path)))
+
+(defun devenv-env--turn-on ()
+  "Enable `devenv-env-mode' when this buffer should manage its env.
+The buffer must sit inside a devenv project that direnv does not
+already cover (no .envrc anywhere above), with the devenv binary
+available.  Never activates in the minibuffer or remote buffers."
+  (when (and (not (minibufferp))
+             (not (file-remote-p default-directory))
+             (executable-find devenv-executable)
+             (devenv-project-root)
+             (not (locate-dominating-file default-directory ".envrc"))
+             (not (bound-and-true-p envrc-mode)))
+    (devenv-env-mode 1)))
+
+(defun devenv-env--around-eglot-ensure (orig-fun &rest args)
+  "Defer ORIG-FUN (`eglot-ensure', ARGS) while the env is loading.
+Eglot snapshots the environment at connect time; connecting
+before the async fetch lands would give the server the global
+environment.  Deferred buffers replay once the env is applied."
+  (let ((root (and devenv-env-mode (devenv-project-root))))
+    (if (and root (gethash root devenv-env--pending))
+        (cl-pushnew (current-buffer) devenv-env--eglot-replay)
+      (apply orig-fun args))))
+
+;;;###autoload
+(define-globalized-minor-mode devenv-env-global-mode devenv-env-mode
+  devenv-env--turn-on
+  :group 'devenv
+  (if devenv-env-global-mode
+      (advice-add 'eglot-ensure :around
+                  #'devenv-env--around-eglot-ensure)
+    (advice-remove 'eglot-ensure #'devenv-env--around-eglot-ensure)))
+
+;;;; Eglot: serve devenv.nix with `devenv lsp'
+
+(defvar devenv--eglot-fallback-contact '("nil")
+  "Contact used for Nix buffers that are not devenv.nix files.
+Captured from `eglot-server-programs' by `devenv-eglot-setup' so
+ordinary Nix buffers keep whatever server they had before.")
+
+(defun devenv--devenv-nix-file-p (file)
+  "Return non-nil when FILE is a devenv config inside a devenv project.
+Matches devenv.nix and devenv.local.nix by basename, then checks
+that a devenv project root covers the file."
+  (and (stringp file)
+       (string-match-p "\\`devenv\\(\\.local\\)?\\.nix\\'"
+                       (file-name-nondirectory file))
+       (devenv-project-root (file-name-directory (expand-file-name file)))
+       t))
+
+(defun devenv--eglot-contact (&optional interactive _project)
+  "Return the eglot contact for the current Nix buffer.
+Buffers visiting devenv.nix / devenv.local.nix get the bundled
+`devenv lsp' server (a nixd preconfigured with the project's
+devenv options); every other Nix buffer is delegated to the
+previously registered contact.  INTERACTIVE is passed through
+when the fallback is itself a contact function, as produced by
+`eglot-alternatives'."
+  (if (and (devenv--devenv-nix-file-p (buffer-file-name))
+           (executable-find devenv-executable))
+      (list devenv-executable "lsp")
+    (let ((fallback devenv--eglot-fallback-contact))
+      (if (functionp fallback)
+          (funcall fallback interactive)
+        fallback))))
+
+(defun devenv--eglot-entry-covers-nix-p (key)
+  "Return non-nil when `eglot-server-programs' KEY covers Nix modes."
+  (cl-flet ((mode-sym (item) (if (consp item) (car item) item)))
+    (cond
+     ((symbolp key) (memq key '(nix-mode nix-ts-mode)))
+     ((listp key) (cl-some (lambda (item)
+                             (memq (mode-sym item)
+                                   '(nix-mode nix-ts-mode)))
+                           key))
+     (t nil))))
+
+;;;###autoload
+(defun devenv-eglot-setup ()
+  "Route devenv.nix buffers to `devenv lsp' in `eglot-server-programs'.
+Idempotent: captures the currently registered Nix contact as the
+fallback for ordinary Nix buffers, then installs a routing entry
+at the front of the list.  Call after eglot is loaded."
+  (interactive)
+  (require 'eglot)
+  (let ((existing (cl-find-if
+                   (lambda (entry)
+                     (and (devenv--eglot-entry-covers-nix-p (car entry))
+                          (not (eq (cdr entry) #'devenv--eglot-contact))))
+                   eglot-server-programs)))
+    (when existing
+      (setq devenv--eglot-fallback-contact (cdr existing))))
+  (unless (cl-rassoc #'devenv--eglot-contact eglot-server-programs)
+    (push (cons '(nix-mode nix-ts-mode) #'devenv--eglot-contact)
+          eglot-server-programs))
+  eglot-server-programs)
+
+;;;; MCP: register `devenv mcp' with mcp.el
+
+(defun devenv--mcp-server-name (root)
+  "Return the mcp.el server name used for ROOT."
+  (format "devenv-%s"
+          (file-name-nondirectory (directory-file-name root))))
+
+;;;###autoload
+(defun devenv-mcp-setup ()
+  "Register the current project's `devenv mcp' server with mcp.el.
+Adds a stdio entry to `mcp-hub-servers' named after the project
+\(e.g. \"devenv-myproject\") that starts `devenv mcp' in the
+project root.  Its tools — nixpkgs package search, devenv option
+search, and process control — then become available to MCP
+clients: start the server from the `mcp-hub' dashboard, then
+`gptel-mcp-connect' exposes the tools to gptel."
+  (interactive)
+  (unless (require 'mcp nil t)
+    (user-error "Package mcp.el is not installed"))
+  (let* ((root (devenv--root-or-error))
+         (name (devenv--mcp-server-name root))
+         (spec (list :command "sh"
+                     :args (list "-c"
+                                 (format "cd %s && exec %s mcp"
+                                         (shell-quote-argument root)
+                                         devenv-executable)))))
+    (setf (alist-get name mcp-hub-servers nil nil #'equal) spec)
+    (message "devenv: registered MCP server %S — start it from M-x \
+mcp-hub, then M-x gptel-mcp-connect exposes its tools to gptel"
+             name)))
+
+;;;###autoload
+(defun devenv-mcp-remove ()
+  "Remove the current project's `devenv mcp' entry from mcp.el."
+  (interactive)
+  (unless (boundp 'mcp-hub-servers)
+    (user-error "Package mcp.el is not loaded"))
+  (let ((name (devenv--mcp-server-name (devenv--root-or-error))))
+    (setf (alist-get name mcp-hub-servers nil 'remove #'equal) nil)
+    (message "devenv: removed MCP server %S" name)))
+
+;;;; Transient entry point
+
+;;;###autoload (autoload 'devenv "devenv" nil t)
+(transient-define-prefix devenv ()
+  "Devenv commands for the current project."
+  ["Options"
+   ("-c" "Clean eval (ignore external env)" "--clean")
+   ("-r" "Refresh eval cache" "--refresh-eval-cache")]
+  ["Run"
+   [("t" "Task…" devenv-task-run)
+    ("s" "Script…" devenv-script-run)]
+   [("T" "Test (enterTest)" devenv-test)
+    ("b" "Build…" devenv-build)]]
+  ["Processes"
+   [("u" "Up (start all)" devenv-up)
+    ("d" "Down (stop all)" devenv-down)]
+   [("p" "Dashboard" devenv-processes)
+    ("l" "Logs…" devenv-processes-logs)]]
+  ["Introspect"
+   [("i" "Info" devenv-info)
+    ("/" "Search packages/options…" devenv-search)]
+   [(":" "Eval attribute…" devenv-eval)
+    ("$" "Show invocation log" devenv-show-log)]]
+  ["Environment"
+   [("r" "Reload environment" devenv-reload)
+    ("e" "Native env loader (global)" devenv-env-global-mode)]
+   [("M" "Register MCP server" devenv-mcp-setup)]]
+  ["Maintenance"
+   [("U" "Update inputs (devenv.lock)" devenv-update)
+    ("G" "Garbage-collect generations" devenv-gc)]]
+  (interactive)
+  (devenv--root-or-error)
+  (transient-setup 'devenv))
+
+(provide 'devenv)
+;;; devenv.el ends here

--- a/lisp/init-ai.el
+++ b/lisp/init-ai.el
@@ -17,6 +17,9 @@
 ;;
 ;;   mcp              M-x mcp-connect-server + gptel-mcp-connect
 ;;                                  Model Context Protocol tool use via gptel.
+;;                                  `devenv-mcp-setup' (init-devenv, C-c v M)
+;;                                  registers the project's `devenv mcp'
+;;                                  server here.
 ;;
 ;; Auth: API keys come from the environment first (OPENROUTER_API_KEY /
 ;; ANTHROPIC_API_KEY / GEMINI_API_KEY) and fall back to auth-source —

--- a/lisp/init-devenv.el
+++ b/lisp/init-devenv.el
@@ -1,0 +1,58 @@
+;;; init-devenv.el --- devenv.sh project tooling -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Wiring for the in-repo devenv.sh integration library
+;; (lisp/devenv.el).  The library is self-contained and reusable; this
+;; module only binds it into the Jotain configuration:
+;;
+;;   - `C-c v' opens the devenv transient (tasks, scripts, processes,
+;;     test/build, introspection, environment reload, MCP).
+;;   - devenv.nix buffers get the bundled `devenv lsp' language server
+;;     (a nixd preconfigured with the project's devenv options) while
+;;     `nil' keeps serving every other Nix buffer.
+;;
+;; Environment loading stays with envrc (init-prog.el): `.envrc' says
+;; `use devenv', so every project buffer already carries the devenv
+;; shell environment buffer-locally.  The library's own native loader
+;; (`devenv-env-global-mode') is deliberately NOT enabled here — it
+;; exists for devenv projects without direnv, and its predicate skips
+;; envrc-managed projects anyway.
+;;
+;; The devenv-side counterpart of this integration is the Claude Code
+;; MCP wiring in devenv.nix (`claude.code.enable'); see also
+;; `devenv-mcp-setup' for exposing `devenv mcp' to gptel via mcp.el.
+
+;;; Code:
+
+;;; @doc Native devenv.sh integration (the in-repo `lisp/devenv.el`
+;;; library). `C-c v` opens a transient with task and script runners,
+;;; `devenv test`/`build` through compilation-mode with Nix error
+;;; matching, a process-manager dashboard (start/stop/restart/logs),
+;;; and environment introspection (`devenv eval`/`info`/`search`).
+;;; `devenv-reload` refreshes the project environment through envrc
+;;; (the direnv substrate configured in init-prog) and offers to
+;;; reconnect eglot servers so they see the new environment.
+;;; devenv.nix buffers are routed to the bundled `devenv lsp` server
+;;; while `nil` keeps serving other Nix files, and `devenv-mcp-setup`
+;;; registers the project's `devenv mcp` server with mcp.el so gptel
+;;; can call its tools. Everything degrades to a clean error when the
+;;; `devenv` binary is not on PATH.
+(use-package devenv
+  :ensure nil ; In-repo library (lisp/devenv.el)
+  :defer t
+  :commands (devenv-task-run devenv-script-run devenv-test devenv-build
+             devenv-up devenv-down devenv-processes devenv-processes-logs
+             devenv-info devenv-search devenv-eval devenv-reload
+             devenv-eglot-setup devenv-mcp-setup devenv-env-global-mode)
+  :bind ("C-c v" . devenv)
+  :init
+  ;; Route devenv.nix buffers to `devenv lsp' once eglot is loaded.
+  ;; Gated on the binary so a machine without devenv keeps eglot's
+  ;; stock Nix contact untouched.
+  (with-eval-after-load 'eglot
+    (when (executable-find "devenv")
+      (devenv-eglot-setup))))
+
+(provide 'init-devenv)
+;;; init-devenv.el ends here

--- a/lisp/init-devenv.el
+++ b/lisp/init-devenv.el
@@ -36,16 +36,22 @@
 ;;; devenv.nix buffers are routed to the bundled `devenv lsp` server
 ;;; while `nil` keeps serving other Nix files, and `devenv-mcp-setup`
 ;;; registers the project's `devenv mcp` server with mcp.el so gptel
-;;; can call its tools. Everything degrades to a clean error when the
-;;; `devenv` binary is not on PATH.
+;;; can call its tools. `devenv-allow`/`devenv-revoke` manage devenv
+;;; 2.1's auto-activation trust database, which also gates the native
+;;; env loader, and `devenv-modeline-mode` (enabled here) shows the
+;;; per-buffer status — devenv[on]/[off]/[!] — in the mode line.
+;;; Everything degrades to a clean error when the `devenv` binary is
+;;; not on PATH.
 (use-package devenv
   :ensure nil ; In-repo library (lisp/devenv.el)
   :defer t
   :commands (devenv-task-run devenv-script-run devenv-test devenv-build
              devenv-up devenv-down devenv-processes devenv-processes-logs
              devenv-info devenv-search devenv-eval devenv-reload
-             devenv-eglot-setup devenv-mcp-setup devenv-env-global-mode)
+             devenv-allow devenv-revoke devenv-eglot-setup
+             devenv-mcp-setup devenv-env-global-mode)
   :bind ("C-c v" . devenv)
+  :hook (after-init . devenv-modeline-mode)
   :init
   ;; Route devenv.nix buffers to `devenv lsp' once eglot is loaded.
   ;; Gated on the binary so a machine without devenv keeps eglot's

--- a/lisp/init-keys.el
+++ b/lisp/init-keys.el
@@ -109,6 +109,7 @@ Region active → deactivate it.  Otherwise call regular
     "C-c o"     "combobulate"
     "C-c r"     "eglot-refactor"
     "C-c t"     "toggle-theme"
+    "C-c v"     "devenv"
     ;; C-c <punct> — AI and special leaves.
     "C-c RET"   "gptel-send"
     "C-c M-RET" "gptel-menu"

--- a/lisp/init-project.el
+++ b/lisp/init-project.el
@@ -66,7 +66,8 @@ projects sharing a basename across different roots stay distinct."
   (project-list-file (jotain-var-file "projects.el"))
   (project-buffers-viewer 'project-list-buffers-ibuffer)
   (project-vc-extra-root-markers
-   '(".project" "package.json" "Cargo.toml" "pyproject.toml" "flake.nix")))
+   '(".project" "package.json" "Cargo.toml" "pyproject.toml" "flake.nix"
+     "devenv.nix")))
 
 ;;;; projection — per-project commands keyed off .dir-locals.el
 
@@ -125,7 +126,10 @@ projects sharing a basename across different roots stay distinct."
                       ("meson compile"  . "meson compile -C builddir")
                       ("meson test"     . "meson test -C builddir")))
      (nix-ts-mode  . (("nix flake check" . "nix flake check")
-                      ("nix fmt"        . "nix fmt")))
+                      ("nix fmt"        . "nix fmt")
+                      ("devenv test"    . "devenv -q test")
+                      ("devenv build"   . "devenv -q build")
+                      ("devenv up"      . "devenv -q up")))
      (rust-ts-mode . (("cargo test"     . "cargo test")
                       ("cargo clippy"   . "cargo clippy --all-targets")
                       ("cargo build"    . "cargo build")))

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -279,7 +279,8 @@ in
         emacs -Q --batch --eval '
           (let ((failed nil))
             (dolist (f (append (list "early-init.el" "init.el")
-                               (directory-files "lisp" t "^init-.*\\.el$")))
+                               (directory-files "lisp" t "^\\(init-.*\\|devenv\\)\\.el$")
+                               (directory-files "test" t "\\.el$")))
               (condition-case err
                   (with-temp-buffer
                     (insert-file-contents f)
@@ -308,7 +309,24 @@ in
           -L lisp \
           --eval "(require 'pcre2el)" \
           --eval "(setq byte-compile-error-on-warn t)" \
-          -f batch-byte-compile early-init.el init.el lisp/init-*.el
+          -f batch-byte-compile early-init.el init.el lisp/devenv.el lisp/init-*.el
+        touch $out
+      '';
+
+  # ── Elisp unit tests (ERT, batch) ────────────────────────────────
+  # Pure-function tests only: no devenv binary, no network, no
+  # subprocesses — safe inside the Nix sandbox.
+  elisp-test =
+    pkgs.runCommandLocal "check-elisp-test"
+      {
+        nativeBuildInputs = [ pkgs.jotainEmacsPackages ];
+        inherit src;
+      }
+      ''
+        cd $src
+        emacs --batch -L lisp -L test \
+          -l ert -l test/devenv-test.el \
+          -f ert-run-tests-batch-and-exit
         touch $out
       '';
 }

--- a/nix/info-manual.nix
+++ b/nix/info-manual.nix
@@ -89,6 +89,10 @@ let
       out = "usage-launching.texi";
     }
     {
+      src = "usage/devenv.mdx";
+      out = "usage-devenv.texi";
+    }
+    {
       src = "finding-information-in-emacs.mdx";
       out = "finding-information-in-emacs.texi";
     }

--- a/nix/packages-doc.nix
+++ b/nix/packages-doc.nix
@@ -75,6 +75,10 @@ let
       title = "Per-project commands";
     }
     {
+      file = "init-devenv.el";
+      title = "devenv.sh integration";
+    }
+    {
       file = "init-ai.el";
       title = "AI assistants";
     }

--- a/test/devenv-test.el
+++ b/test/devenv-test.el
@@ -249,5 +249,14 @@
   (should (equal (devenv--mcp-server-name "/home/u/proj/") "devenv-proj"))
   (should (equal (devenv--mcp-server-name "/home/u/proj") "devenv-proj")))
 
+(ert-deftest devenv-test-mcp-command-quoting ()
+  "The MCP launch command shell-quotes both the root and the binary."
+  (let ((devenv-executable "/opt/my tools/devenv"))
+    (let ((cmd (devenv--mcp-command "/home/u/my proj/")))
+      (should-not (string-match-p "/home/u/my proj" cmd))
+      (should-not (string-match-p "/opt/my tools/devenv mcp" cmd))
+      (should (string-suffix-p " mcp" cmd))
+      (should (string-prefix-p "cd " cmd)))))
+
 (provide 'devenv-test)
 ;;; devenv-test.el ends here

--- a/test/devenv-test.el
+++ b/test/devenv-test.el
@@ -1,0 +1,253 @@
+;;; devenv-test.el --- ERT tests for devenv.el -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Batch-safe unit tests for the pure functions in lisp/devenv.el.
+;; No devenv binary, no network, no subprocesses: everything here
+;; exercises parsing, routing, and cache logic on canned data.
+;;
+;; Run with:
+;;   emacs --batch -L lisp -L test -l ert -l test/devenv-test.el \
+;;         -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+(require 'eglot) ; make `eglot-server-programs' a special variable
+(require 'devenv)
+
+;;;; Command construction
+
+(ert-deftest devenv-test-command-basic ()
+  "Global arguments are spliced between the executable and args."
+  (let ((devenv-executable "devenv")
+        (devenv-global-arguments '("-q")))
+    (should (equal (devenv--command '("info"))
+                   '("devenv" "-q" "info")))))
+
+(ert-deftest devenv-test-command-with-transient-args ()
+  "Extra global flags land before the subcommand."
+  (let ((devenv-executable "devenv")
+        (devenv-global-arguments '("-q")))
+    (should (equal (devenv--command '("test") '("--clean"))
+                   '("devenv" "-q" "--clean" "test")))))
+
+(ert-deftest devenv-test-shell-command-quotes ()
+  "Arguments with shell metacharacters are quoted."
+  (let ((cmd (devenv--shell-command '("devenv" "shell" "my script"))))
+    (should (string-match-p "devenv shell" cmd))
+    (should-not (equal cmd "devenv shell my script"))))
+
+;;;; First-line extraction (error reporting)
+
+(ert-deftest devenv-test-first-line ()
+  "The first non-empty line is extracted from noisy stderr."
+  (should (equal (devenv--first-line "\n\nerror: boom\nmore") "error: boom"))
+  (should (equal (devenv--first-line "") ""))
+  (should (equal (devenv--first-line nil) "")))
+
+;;;; Cache
+
+(ert-deftest devenv-test-cache-freshness ()
+  "Entries are fresh within the TTL and stale after it."
+  (let ((devenv-cache-ttl 30)
+        (now (float-time)))
+    (should (devenv--cache-fresh-p (cons now 'value) now))
+    (should (devenv--cache-fresh-p (cons (- now 29) 'value) now))
+    (should-not (devenv--cache-fresh-p (cons (- now 31) 'value) now))
+    (should-not (devenv--cache-fresh-p nil now))))
+
+(ert-deftest devenv-test-cache-roundtrip-and-invalidate ()
+  "Cached values are returned without refetch; invalidation refetches."
+  (let ((devenv--cache (make-hash-table :test #'equal))
+        (devenv-cache-ttl 300)
+        (calls 0))
+    (cl-flet ((fetch () (cl-incf calls) 'fetched))
+      (should (eq (devenv--cached "/proj/" 'tasks #'fetch) 'fetched))
+      (should (eq (devenv--cached "/proj/" 'tasks #'fetch) 'fetched))
+      (should (= calls 1))
+      ;; Other roots are unaffected by a scoped invalidation.
+      (devenv--cached "/other/" 'tasks #'fetch)
+      (should (= calls 2))
+      (devenv--cache-invalidate "/proj/")
+      (devenv--cached "/proj/" 'tasks #'fetch)
+      (should (= calls 3))
+      (devenv--cached "/other/" 'tasks #'fetch)
+      (should (= calls 3)))))
+
+;;;; Task list parsing
+
+(ert-deftest devenv-test-tasks-parse-array ()
+  "A JSON array of task objects yields (NAME . DESCRIPTION) pairs."
+  (let ((parsed '(((name . "app:build") (description . "Build the app"))
+                  ((name . "app:test")))))
+    (should (equal (devenv--tasks-parse parsed)
+                   '(("app:build" . "Build the app")
+                     ("app:test" . nil))))))
+
+(ert-deftest devenv-test-tasks-parse-object ()
+  "A JSON object keyed by task name also yields pairs."
+  (let ((parsed '((app:build . ((description . "Build the app")))
+                  (app:test . ((exec . "pytest"))))))
+    (should (equal (devenv--tasks-parse parsed)
+                   '(("app:build" . "Build the app")
+                     ("app:test" . nil))))))
+
+(ert-deftest devenv-test-tasks-parse-empty ()
+  "Empty or unrecognized input parses to nil, not an error."
+  (should (null (devenv--tasks-parse nil)))
+  (should (null (devenv--tasks-parse "garbage"))))
+
+;;;; Environment parsing (print-dev-env --json)
+
+(defconst devenv-test--env-json
+  (concat
+   "{\"variables\":{"
+   "\"PATH\":{\"type\":\"exported\",\"value\":\"/nix/store/aaa/bin:/usr/bin\"},"
+   "\"DEVENV_ROOT\":{\"type\":\"exported\",\"value\":\"/proj\"},"
+   "\"PS1\":{\"type\":\"exported\",\"value\":\"$ \"},"
+   "\"shellHook\":{\"type\":\"var\",\"value\":\"echo hi\"},"
+   "\"BROKEN\":{\"type\":\"exported\",\"value\":null}"
+   "}}")
+  "Canned `devenv print-dev-env --json' output.")
+
+(ert-deftest devenv-test-env-parse-exported-only ()
+  "Only exported string variables become NAME=VALUE pairs."
+  (let* ((devenv-env-ignored-variables '("PS1" "SHLVL" "TERM" "HOME"))
+         (pairs (devenv-env--parse devenv-test--env-json)))
+    (should (member "PATH=/nix/store/aaa/bin:/usr/bin" pairs))
+    (should (member "DEVENV_ROOT=/proj" pairs))
+    ;; Ignored variable filtered out.
+    (should-not (seq-find (lambda (p) (string-prefix-p "PS1=" p)) pairs))
+    ;; Non-exported and null-valued variables filtered out.
+    (should-not (seq-find (lambda (p) (string-prefix-p "shellHook=" p)) pairs))
+    (should-not (seq-find (lambda (p) (string-prefix-p "BROKEN=" p)) pairs))))
+
+(ert-deftest devenv-test-env-parse-custom-ignore ()
+  "The IGNORED argument overrides `devenv-env-ignored-variables'."
+  (let ((pairs (devenv-env--parse devenv-test--env-json '("PATH"))))
+    (should-not (seq-find (lambda (p) (string-prefix-p "PATH=" p)) pairs))
+    (should (seq-find (lambda (p) (string-prefix-p "PS1=" p)) pairs))))
+
+(ert-deftest devenv-test-env-path-extraction ()
+  "PATH pairs convert to an `exec-path'-shaped list."
+  (let ((path (devenv-env--path-from-pairs
+               '("FOO=bar" "PATH=/nix/store/aaa/bin:/usr/bin"))))
+    (should (equal (butlast path)
+                   '("/nix/store/aaa/bin/" "/usr/bin/")))
+    ;; `exec-directory' stays at the tail, envrc-style.
+    (should (equal (car (last path)) exec-directory)))
+  (should (null (devenv-env--path-from-pairs '("FOO=bar")))))
+
+(ert-deftest devenv-test-env-apply-buffer-local ()
+  "Applying pairs sets buffer-local env without touching globals."
+  (with-temp-buffer
+    (devenv-env--apply (current-buffer)
+                       '("DEVENV_TEST_MARKER=yes"
+                         "PATH=/devenv-test-bin:/usr/bin"))
+    (should (local-variable-p 'process-environment))
+    (should (local-variable-p 'exec-path))
+    (should (equal (getenv "DEVENV_TEST_MARKER") "yes"))
+    (should (member "/devenv-test-bin/" exec-path)))
+  ;; Global environment untouched.
+  (should-not (getenv "DEVENV_TEST_MARKER")))
+
+;;;; Process list parsing
+
+(ert-deftest devenv-test-processes-parse-json-array ()
+  "A JSON array of process objects yields (NAME STATUS DETAIL) rows."
+  (let ((rows (devenv-processes--parse-json
+               '(((name . "web") (status . "running") (pid . 4242))
+                 ((name . "db") (status . "stopped"))))))
+    (should (equal (car rows) '("web" "running" "4242")))
+    (should (equal (cadr rows) '("db" "stopped" "")))))
+
+(ert-deftest devenv-test-processes-parse-json-object ()
+  "A JSON object keyed by process name also yields rows."
+  (let ((rows (devenv-processes--parse-json
+               '((web . ((status . "running") (pid . 4242)))))))
+    (should (equal (car rows) '("web" "running" "4242")))))
+
+(ert-deftest devenv-test-processes-parse-table ()
+  "The plain-text table output parses into rows, skipping headers."
+  (let ((rows (devenv-processes--parse-table
+               "NAME      STATUS    PID\nweb       running   4242\ndb        stopped\n")))
+    (should (equal (car rows) '("web" "running" "4242")))
+    (should (equal (cadr rows) '("db" "stopped" "")))))
+
+(ert-deftest devenv-test-processes-entries-shape ()
+  "Rows become tabulated-list entries keyed by process name."
+  (let ((entries (devenv-processes--entries '(("web" "running" "4242")))))
+    (should (equal (caar entries) "web"))
+    (should (equal (cadar entries) ["web" "running" "4242"]))))
+
+;;;; devenv.nix routing predicate
+
+(ert-deftest devenv-test-devenv-nix-file-p ()
+  "Only devenv.nix / devenv.local.nix inside a devenv project match."
+  (let* ((root (make-temp-file "devenv-test-root" t))
+         (config (expand-file-name "devenv.nix" root)))
+    (unwind-protect
+        (progn
+          (with-temp-file config (insert "{ }\n"))
+          (should (devenv--devenv-nix-file-p config))
+          (with-temp-file (expand-file-name "devenv.local.nix" root)
+            (insert "{ }\n"))
+          (should (devenv--devenv-nix-file-p
+                   (expand-file-name "devenv.local.nix" root)))
+          ;; Other Nix files in the same project do not match.
+          (should-not (devenv--devenv-nix-file-p
+                       (expand-file-name "flake.nix" root)))
+          ;; A devenv.nix basename outside any devenv project does not
+          ;; match either (no dominating devenv.nix above temp roots
+          ;; is assumed; the file itself dominates its own directory).
+          (should-not (devenv--devenv-nix-file-p nil)))
+      (delete-directory root t))))
+
+;;;; Eglot contact routing
+
+(ert-deftest devenv-test-eglot-setup-captures-fallback ()
+  "Setup captures the previous Nix contact and installs the router."
+  (let ((eglot-server-programs
+         (list (cons '(nix-mode nix-ts-mode) '("nil"))))
+        (devenv--eglot-fallback-contact '("nil")))
+    (devenv-eglot-setup)
+    (should (equal devenv--eglot-fallback-contact '("nil")))
+    (should (eq (cdar eglot-server-programs) #'devenv--eglot-contact))
+    ;; Idempotent: a second call adds nothing.
+    (let ((len (length eglot-server-programs)))
+      (devenv-eglot-setup)
+      (should (= (length eglot-server-programs) len)))))
+
+(ert-deftest devenv-test-eglot-contact-fallback-for-plain-nix ()
+  "Non-devenv Nix buffers get the captured fallback contact."
+  (let ((devenv--eglot-fallback-contact '("nil")))
+    (with-temp-buffer
+      ;; No file name: never a devenv.nix buffer.
+      (should (equal (devenv--eglot-contact) '("nil"))))))
+
+(ert-deftest devenv-test-eglot-contact-functional-fallback ()
+  "A functional fallback (eglot-alternatives) is called through."
+  (let ((devenv--eglot-fallback-contact
+         (lambda (&optional _interactive) '("alt-server"))))
+    (with-temp-buffer
+      (should (equal (devenv--eglot-contact) '("alt-server"))))))
+
+(ert-deftest devenv-test-eglot-entry-covers-nix-p ()
+  "Key matching handles symbols, lists, and :language-id forms."
+  (should (devenv--eglot-entry-covers-nix-p 'nix-mode))
+  (should (devenv--eglot-entry-covers-nix-p '(nix-mode nix-ts-mode)))
+  (should (devenv--eglot-entry-covers-nix-p
+           '((nix-ts-mode :language-id "nix"))))
+  (should-not (devenv--eglot-entry-covers-nix-p 'python-mode))
+  (should-not (devenv--eglot-entry-covers-nix-p '(go-mode go-ts-mode))))
+
+;;;; MCP server naming
+
+(ert-deftest devenv-test-mcp-server-name ()
+  "MCP server entries are named after the project directory."
+  (should (equal (devenv--mcp-server-name "/home/u/proj/") "devenv-proj"))
+  (should (equal (devenv--mcp-server-name "/home/u/proj") "devenv-proj")))
+
+(provide 'devenv-test)
+;;; devenv-test.el ends here

--- a/test/devenv-test.el
+++ b/test/devenv-test.el
@@ -249,6 +249,59 @@
   (should (equal (devenv--mcp-server-name "/home/u/proj/") "devenv-proj"))
   (should (equal (devenv--mcp-server-name "/home/u/proj") "devenv-proj")))
 
+;;;; Auto-activation trust (devenv allow / revoke / hook-should-activate)
+
+(ert-deftest devenv-test-activation-state ()
+  "Exit code and stdout of hook-should-activate map to trust states.
+Exit 0 with the project path on stdout means trusted; exit 2
+means the project exists but is not trusted; exit 0 with empty
+output means no project; anything else (including a missing
+subcommand on devenv 1.x) is `unsupported'."
+  (should (eq (devenv--activation-state 0 "/home/u/proj\n") 'allowed))
+  (should (eq (devenv--activation-state 2 "") 'blocked))
+  (should (eq (devenv--activation-state 0 "") 'no-project))
+  (should (eq (devenv--activation-state 0 "  \n") 'no-project))
+  (should (eq (devenv--activation-state 1 "error: unrecognized subcommand")
+              'unsupported))
+  (should (eq (devenv--activation-state nil "") 'unsupported)))
+
+(ert-deftest devenv-test-activation-state-permits-loading ()
+  "Trusted and pre-trust-model devenv versions permit auto-loading."
+  (should (devenv--activation-permits-p 'allowed))
+  (should (devenv--activation-permits-p 'unsupported))
+  (should-not (devenv--activation-permits-p 'blocked))
+  (should-not (devenv--activation-permits-p 'no-project)))
+
+;;;; Modeline status
+
+(ert-deftest devenv-test-modeline-compute-state ()
+  "Modeline state derives from root, active env, and trust state."
+  ;; Not in a devenv project.
+  (should (eq (devenv-modeline--compute-state nil nil nil) 'none))
+  ;; Environment loaded (DEVENV_PROFILE visible in the buffer).
+  (should (eq (devenv-modeline--compute-state "/p/" "/nix/store/x" nil)
+              'active))
+  ;; Project present, trust denied.
+  (should (eq (devenv-modeline--compute-state "/p/" nil 'blocked)
+              'blocked))
+  ;; Project present, env not loaded (trusted, unknown, or no info).
+  (should (eq (devenv-modeline--compute-state "/p/" nil 'allowed)
+              'inactive))
+  (should (eq (devenv-modeline--compute-state "/p/" nil nil) 'inactive)))
+
+(ert-deftest devenv-test-modeline-format ()
+  "Each modeline state renders its label; `none' renders empty."
+  (should (equal (devenv-modeline--format 'none) ""))
+  (should (string-match-p "devenv\\[on\\]" (devenv-modeline--format 'active)))
+  (should (string-match-p "devenv\\[off\\]"
+                          (devenv-modeline--format 'inactive)))
+  (should (string-match-p "devenv\\[!\\]"
+                          (devenv-modeline--format 'blocked)))
+  ;; Non-empty segments carry a leading space so they never glue onto
+  ;; the previous mode-line element.
+  (dolist (state '(active inactive blocked))
+    (should (string-prefix-p " " (devenv-modeline--format state)))))
+
 (ert-deftest devenv-test-mcp-command-quoting ()
   "The MCP launch command shell-quotes both the root and the binary."
   (let ((devenv-executable "/opt/my tools/devenv"))


### PR DESCRIPTION
## Summary

A first-of-its-kind native Emacs integration for [devenv](https://devenv.sh) (no devenv package exists on MELPA/ELPA/GitHub — current community practice is envrc + `use devenv`, which this builds on rather than replaces). Targets devenv 2.1+ and degrades gracefully on older versions; every subcommand is gated on `executable-find` so machines without devenv are unaffected.

Two-file design:

- **`lisp/devenv.el`** — standalone, reusable, MELPA-quality library (own `devenv-` namespace, no `jotain-` dependencies, no `use-package` forms so the Nix package scanner ignores it; soft-deps on envrc/eglot/mcp/gptel via `declare-function`).
- **`lisp/init-devenv.el`** — thin house-convention wiring module (`C-c v`, eglot routing, `@doc` block).

### What it does

- **`M-x devenv` / `C-c v`** — transient over the whole surface, with `--clean` / `--refresh-eval-cache` infixes.
- **Tasks & scripts** — annotated `completing-read` over `devenv tasks list --json` and `devenv eval scripts`; task runs honor the 2.1 dependency modes (`before`/`single`/`after`/`all`).
- **test / build / update / gc** — compilation buffers with Nix-trace error matching (`at /file.nix:L:C` is jumpable).
- **Processes** — `devenv up` (attached live buffer or detached) / `devenv down`, plus a tabulated dashboard over the 2.x native process manager: `s`tart / `k` stop / `r`estart / `l`ogs per process, async refresh, JSON with plain-table fallback for older devenv.
- **Introspection** — `devenv info`, `devenv search`, `devenv eval <attr>` → pretty-printed JSON; every CLI invocation is recorded in `*devenv log*`.
- **Environment** — envrc (already configured in init-prog) stays the substrate. `devenv-reload` invalidates caches, refreshes via `envrc-reload-all`, and offers `eglot-reconnect` (eglot snapshots env at connect time). An **opt-in** native loader (`devenv-env-global-mode`) covers devenv projects without direnv: buffer-local `print-dev-env --json` with an `eglot-ensure` defer/replay shim; its predicate skips any project with a `.envrc` so it can never double-manage.
- **LSP** — `devenv.nix`/`devenv.local.nix` buffers route to the bundled `devenv lsp` (nixd preconfigured with the project's devenv options) while `nil` keeps serving every other Nix buffer (the routing contact delegates to the previously registered contact).
- **MCP** — `devenv-mcp-setup` registers the project's `devenv mcp` stdio server in `mcp-hub-servers` under a per-project name for gptel tool use (package/option search + process control).
- All invocations set `AI_AGENT=1` (devenv ≥ 2.1 quiet mode) so stdout stays machine-readable.

### TDD & checks

Written test-first: `test/devenv-test.el` (23 ERT tests over the pure functions — env/tasks/process parsing, cache TTL, eglot contact routing, command construction) ran red before the implementation and green after, on a local Emacs. New `elisp-test` flake check runs them in the sandbox (no devenv binary needed); `elisp-lint`/`elisp-compile` extended to cover `lisp/devenv.el` and `test/`. `just test` now points at the flake check.

### Docs

New `docs/usage/devenv.mdx` user guide (site + info manual via `nix/info-manual.nix` + `jotain.texi`), `modules.mdx` load order + section, `keybindings.mdx` row, and the regenerated `package-reference.mdx` section (hand-synced to the generator's format; `packages-doc-in-sync` verifies).

## Verification

- Local (Emacs 29.3): 23/23 ERT green; `devenv.el` + `init-devenv.el` byte-compile clean with `byte-compile-error-on-warn`; parens check on all touched elisp; smoke-tested root discovery, devenv.nix routing predicate, eglot entry install, and argv construction against this repo.
- CI is the authority for Emacs 30 + the Nix layer — watching `nix flake check` on this PR.

### Manual smoke checklist (needs a machine with devenv)

- [ ] `C-c v` opens the transient at the repo root; errors politely outside a devenv project
- [ ] `C-c v i` / `C-c v /` render info and search buffers
- [ ] Open `devenv.nix` → `M-x eglot` connects via `devenv lsp`; `nix/checks.nix` still gets `nil`
- [ ] `C-c v r` routes through `envrc-reload-all` and offers eglot reconnect
- [ ] `C-c v M` registers `devenv-jotain` in `mcp-hub-servers`; `gptel-mcp-connect` lists its tools
- [ ] In a scratch project with a process: `C-c v u`, dashboard keys `s/k/r/l/g`, `C-c v d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbaSvC41dqwcZo6g8cjMzk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbaSvC41dqwcZo6g8cjMzk)_