### PR TITLE
Add Emacs internals + Elisp knowledge base and AI skills

### DIFF
--- a/.claude/knowledge/emacs/README.md
+++ b/.claude/knowledge/emacs/README.md
@@ -1,0 +1,49 @@
+# Emacs & Emacs Lisp knowledge base
+
+Curated, source-cited reference material for working on this repo's Emacs 30/31
+configuration and its Nix build layer. It exists so that answers about Emacs
+internals and Elisp practice come from the canonical manuals — not from memory.
+
+## Where things live
+
+The substance is packaged as two **skills** (auto-discoverable, loaded on
+demand) plus this index:
+
+- **`.claude/skills/emacs-internals/`** — how Emacs works underneath:
+  garbage collection & object representation, the gap buffer / markers /
+  overlays, the redisplay engine, the command loop & keymaps, byte & native
+  compilation, threads, and the build/dump pipeline. Reach for it when
+  explaining or debugging core behavior, tuning performance (GC, redisplay,
+  startup), or reasoning about native-comp / eln caches.
+
+- **`.claude/skills/elisp-dev/`** — how to write good Elisp here: naming and
+  file conventions, lexical binding, macro hygiene, hooks vs. advice,
+  `defcustom`/`setopt`, `use-package` patterns, modern libraries
+  (pcase/seq/map/cl-lib/rx), debugging & ERT testing, and an Emacs 30/31
+  changes digest. Reach for it when writing or reviewing any Elisp.
+
+Each skill has a `SKILL.md` entry point with a table routing to
+self-contained `references/*.md` files. Read only the reference you need.
+
+## Primary sources
+
+Everything traces back to these — cite them when correcting the notes:
+
+- **GNU Emacs Lisp Reference Manual** (Emacs 30.2): the Internals appendix
+  (E), plus the Variables, Macros, Customization, Loading, Modes, Display,
+  Command Loop, Keymaps, Byte/Native Compilation, and Threads chapters.
+  Read in Emacs with `C-h i m Elisp RET`, or `C-h S` (`info-lookup-symbol`)
+  on any symbol.
+- **GNU Emacs Manual** (`C-h r`) for user-facing behavior.
+- **Source commentary**: `src/xdisp.c` (redisplay design), `src/comp.c` +
+  `lisp/emacs-lisp/comp*.el` (native compilation), `src/buffer.h`.
+- **`etc/NEWS.30` / `etc/NEWS.31`** for version-specific changes.
+- bbatsov/emacs-lisp-style-guide and the use-package manual for style.
+
+## How to keep it honest
+
+These notes target Emacs 30/31 and carry version flags (e.g. igc/MPS is not
+in mainline 30/31; pure space is gone in 31). When a note conflicts with the
+installed Emacs, **trust the running Emacs and its manual**: verify with
+`C-h f`/`C-h v`/`C-h S`, then fix the reference file in the same change so
+the knowledge base doesn't drift.

--- a/.claude/skills/elisp-dev/SKILL.md
+++ b/.claude/skills/elisp-dev/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: elisp-dev
+description: Modern Emacs Lisp development practices (Emacs 30/31) — coding and naming conventions, lexical binding, macro hygiene, hooks vs. advice, defcustom/setopt, use-package patterns, modern libraries (pcase/seq/map/cl-lib/rx), debugging, and ERT testing. Use when writing or reviewing any Elisp in this repo (lisp/init-*.el, early-init.el, init.el, test/).
+---
+
+# Emacs Lisp development
+
+Practices distilled from the GNU Elisp Reference Manual "Tips and Conventions"
+appendix, the official style guidance, and this repo's own conventions
+(CLAUDE.md / AGENTS.md). Repo rules win where they overlap.
+
+## Hard rules for this repo
+
+1. Every file starts with `;;; file.el --- desc -*- lexical-binding: t; -*-`
+   and modules end with `(provide 'init-<concern>)`.
+2. `setopt` for `defcustom` variables, `setq` only for plain `defvar`s.
+3. `use-package` blocks: built-ins and Nix-provided packages get
+   `:ensure nil` (because `use-package-always-ensure` is `t`).
+4. No builtins/third-party split — a package enhancing a built-in lives in
+   the same `lisp/init-*.el` module as the built-in.
+5. Byte-compilation is a gate: `just compile` runs with
+   `byte-compile-error-on-warn`, so any warning fails CI. Write
+   warning-clean code (declare functions, require at compile time, no
+   obsolete APIs).
+6. LSP (`eglot-ensure` hooks) and formatters (apheleia) are centralised in
+   `lisp/init-prog.el` — don't scatter them into language modules.
+
+## Reference files
+
+Read the one(s) relevant to the task:
+
+| File | Covers |
+|------|--------|
+| `references/conventions.md` | Naming (`foo-` public, `foo--` private), library headers, autoload cookies, docstring conventions, key-binding conventions, comment style |
+| `references/lexical-binding-and-macros.md` | Lexical vs. dynamic binding, closures, special variables; macro hygiene (gensym, evaluation-count pitfalls, `declare indent/debug`), `eval-when-compile` vs `eval-and-compile` |
+| `references/hooks-advice-loading.md` | Hooks (`add-hook` depth, mode hooks, derived-mode conventions), advice combinators and why hooks beat advice, autoloads, `with-eval-after-load` pitfalls, load-order reasoning |
+| `references/customization.md` | `defcustom` `:type`/`:set`/`:initialize`, why `setopt` matters, buffer-local options, themes vs. custom |
+| `references/modern-libraries.md` | `pcase`/`pcase-let`, `seq`, `map`, `cl-lib`, `rx`, threading macros, `named-let`, generalized variables (`setf`), string utilities |
+| `references/debugging-and-testing.md` | edebug, `debug-on-error`, `M-x profiler`, benchmarking, ERT patterns (fixtures, `should` forms, `ert-deftest` naming, running via `just test`) |
+| `references/emacs-30-31-changes.md` | Emacs 30/31 NEWS filtered for config authors — new APIs to adopt, obsoletions to avoid, version-gating |
+
+## Workflow in this repo
+
+- New module: create `lisp/init-<concern>.el` with the file shape above, add
+  `(require 'init-<concern>)` to `init.el` at the right load point.
+- Validate: `just check-elisp` (fast paren/syntax), `just compile`
+  (byte-compile, warnings as errors), `just test` (ERT under `test/`,
+  `test-*.el`, loaded with `-L lisp`).
+- Run isolated: `just run` (uses `--init-directory`, never touches
+  `~/.emacs.d`); `just debug` for `--debug-init`.

--- a/.claude/skills/elisp-dev/references/conventions.md
+++ b/.claude/skills/elisp-dev/references/conventions.md
@@ -1,0 +1,102 @@
+# Coding, naming, and documentation conventions
+
+Source: GNU Elisp Reference Manual appendix D (Tips and Conventions),
+bbatsov/emacs-lisp-style-guide, checkdoc. Repo rules (CLAUDE.md/AGENTS.md)
+override where they conflict.
+
+## Symbol naming
+
+- **Every global symbol** (function, variable, face, constant) starts with
+  the library prefix: `foo-thing`, never bare `thing`. In this repo the
+  prefix is the module concern (`init-...`) for module-internal helpers.
+- **Private symbols use a double hyphen**: `foo--internal` — not public API,
+  may change without notice. Reach for it liberally for helpers.
+- Predicates: single word ends in `p` (`stringp`), multi-word ends in `-p`
+  (`buffer-live-p`).
+- Boolean variables: **do not** use `-p`; use a `-flag` suffix or a
+  "Non-nil means …" docstring.
+- A single function value → `-function`; a list of functions (abnormal
+  hook) → `-functions`; a normal hook → `-hook`; one predicate function →
+  `-predicate`.
+- Face names must **not** end in `-face` (checkdoc-enforced).
+- Prefer `file`/`file-name`/`directory` over `path` in names — GNU reserves
+  "path" for search paths (`load-path`, `exec-path`).
+- Prefix unused lexical args with `_` to silence the byte-compiler:
+  `(lambda (x _y) x)`.
+- `lisp-case` throughout; spaces not tabs (`indent-tabs-mode` nil); no
+  closing parens on their own line; ≤80 columns; no trailing whitespace.
+- Keep positional params ≤3–4; beyond that use `cl-defun` keyword args or a
+  plist.
+
+## Library / file headers
+
+For a standalone library the first line is exactly:
+
+```elisp
+;;; foo.el --- One-line description  -*- lexical-binding: t; -*-
+```
+
+then copyright/license, then `;; Header: value` lines (`Author:`,
+`Maintainer:`, `Version:`, `Package-Requires:` as
+`((emacs "30.1") (compat "30.1"))`, `Keywords:` from `finder-known-keywords`
+only, `URL:`), then `;;; Commentary:`, `;;; Code:`, the code, `(provide
+'foo)`, and the mandatory footer `;;; foo.el ends here`.
+
+This repo's `lisp/init-*.el` modules follow the abbreviated house form: the
+`-*- lexical-binding: t; -*-` cookie on line 1 and `(provide 'init-<concern>)`
+at the end — that is the required shape, don't add full FSF headers to them.
+
+## Autoload cookies (`;;;###autoload`)
+
+- Cookie on its own line before a definition → an autoload stub is scraped
+  into the generated loaddefs. Recognized specially for `defun`, `defmacro`,
+  `define-minor-mode`, `define-derived-mode`, `defcustom`, `defgroup`,
+  `define-globalized-minor-mode`, and friends; any other form after the
+  cookie is copied verbatim (runs at activation).
+- **Autoload only user entry points**: interactive commands, `auto-mode-alist`
+  additions. Never autoload internal functions, plain variables, or user
+  options.
+- **Never add an autoload cookie to silence a compiler warning** — use
+  `(defvar foo)`, `declare-function`, or `require` instead.
+- In this Nix/`use-package` repo, packages are on `load-path` already;
+  autoload cookies matter mainly for the repo's own `lisp/` commands if any
+  need deferring — most config wiring is done through `use-package` keywords
+  instead.
+
+## Comments
+
+- `;` margin comment aligned right of code; `;;` aligned with code, describes
+  following lines (also used to comment out code); `;;;` left-margin Outline
+  headings (three = section, four = subsection). `M-;` does the right thing.
+- Annotation keywords `TODO`/`FIXME`/`HACK`/`REVIEW` as `KEYWORD: text` on
+  the line above the code.
+
+## Docstrings
+
+- **First line**: one or two complete sentences, self-contained (apropos
+  shows only it), capital start, period end, ≤ ~74 chars. Functions answer
+  "what does it do"; variables "what does the value mean".
+- **Imperative present tense**: "Return the cons of A and B." — not
+  "Returns…". Predicates: "Return t if …". Boolean vars: "Non-nil means …".
+- **Arguments in CAPS** matching the arglist: "Evaluate FORM…".
+- Quote symbols as `` `symbol' `` (renders as curly quotes); `t`/`nil` bare;
+  don't quote non-symbol expressions.
+- Key references: `\\[command]` not a hardcoded `C-x`; `\\<map>` /
+  `\\{map}` for a mode's own bindings.
+- Never indent continuation lines to align with source; verify with
+  `M-x checkdoc`. Emacs 30 warns on control chars and (separately) overwide
+  docstrings — both are byte-compile warnings, which `just compile` fails on.
+
+## Etiquette that catches config bugs
+
+- In Lisp use `forward-line`, never `next-line`/`previous-line`.
+- Don't call mark-moving/interactive helpers (`beginning-of-buffer`,
+  `replace-string`, `replace-regexp`, `insert-file`) from code — use their
+  programmatic equivalents (`goto-char (point-min)`, `re-search-forward`+
+  `replace-match`, `insert-file-contents`).
+- Signal errors with `error`/`signal` (message: capital first letter, **no**
+  trailing period); never report failures via `message`/`beep`.
+- `#'fn` for function references (compiler checks definedness), `'sym` for
+  data symbols; never `'(lambda …)` or a bare `(lambda …)` where `#'f`
+  suffices.
+- Prefer `when`/`unless` over one-armed `if`; `t` not `:else` in `cond`.

--- a/.claude/skills/elisp-dev/references/customization.md
+++ b/.claude/skills/elisp-dev/references/customization.md
@@ -1,0 +1,56 @@
+# Customization: defcustom, setopt, and options
+
+Source: GNU Elisp Reference Manual ch. 15 (Customization) and 12.8 (Setting
+Variables). This underpins the repo's hard rule: **`setopt` for `defcustom`
+variables, `setq` only for plain `defvar`s.**
+
+## `defcustom`
+
+- `(defcustom OPTION STANDARD DOC &rest KEYWORDS)` declares a user option and
+  marks the symbol special (dynamic). STANDARD is an *expression* that must
+  stay harmless to re-evaluate; a saved/customized value wins over it.
+- **Always give `:type`** — it drives validation and the Customize UI.
+  `:options` suggests values for `hook`/`alist`/`plist` types.
+- `:set SETFN` — `(lambda (symbol value) …)` run by Customize **and by
+  `setopt`** and by `C-M-x`; default `set-default-toplevel-value`. Options
+  that rebuild keymaps/timers/font-lock or toggle a mode define a `:set`, so
+  they only take effect when set through `setopt`/Customize.
+- `:initialize` — usually left default; `custom-initialize-default` is the
+  choice for a minor-mode variable so that merely defining it doesn't enable
+  the mode; `custom-initialize-delay` for preloaded/autoloaded files.
+- `:local t` (auto buffer-local), `:risky`, `:safe`/`safe-local-variable`,
+  `:set-after` (ordering), `:require` (load a feature when set via Custom),
+  `:group`, `:package-version`.
+
+## `setopt` vs `setq`
+
+- `setopt` is like `setq` but routes through the Customize machinery: it
+  **runs the option's `:set` function** and **type-checks against `:type`**
+  (error on mismatch). It does *not* mark the variable for saving to
+  `custom-file` (unlike `customize-set-variable`), so it's the correct verb
+  for a declarative init.
+- `setq` on an option with a `:set` callback **silently skips the
+  callback** — the value is stored but the side effect (rebuild/toggle)
+  never runs. That is the entire reason for the repo rule.
+- `setopt` also works on plain (non-custom) variables — it just sets them —
+  so it is a safe default for "set a user option" in config. Avoid it in
+  performance-critical inner loops (validation overhead); there `setq` a
+  plain `defvar`.
+- Emacs 29 introduced `setopt`; Emacs 31 adds `setopt-local` and
+  `set-local`.
+
+## `custom-file` in this repo
+
+`init.el` points `custom-file` at `var/custom.el` and treats it as
+**write-only** — it is never loaded back. The declarative config in
+`lisp/init-*.el` is the single source of truth, so any option a user might
+want to change should be expressed as a `setopt` (or `use-package :custom`)
+in the modules, not left to interactive Customize. Don't add code that
+`(load custom-file)`.
+
+## `use-package :custom`
+
+`:custom (foo 1)` goes through the same `:set`/`:type` path as `setopt` and
+is the preferred way to set an option owned by the package a `use-package`
+block configures. Prefer it over `setq`/`setopt` in `:init`/`:config` when
+the option belongs to that package.

--- a/.claude/skills/elisp-dev/references/debugging-and-testing.md
+++ b/.claude/skills/elisp-dev/references/debugging-and-testing.md
@@ -1,0 +1,66 @@
+# Debugging, profiling, and ERT testing
+
+Source: GNU Elisp Reference Manual (Debugging chapter, Profiling), ERT
+manual, this repo's workflow (`just test`, `test/test-*.el`).
+
+## Debugging
+
+- **`M-x toggle-debug-on-error`** / `(setq debug-on-error t)` — enter the
+  backtrace debugger on any error. `just debug` starts Emacs with
+  `--debug-init` and `debug-on-error` for startup problems.
+- `debug-on-entry` / `cancel-debug-on-entry` — break on entry to a function.
+  `debug-on-variable-change` (add-variable-watcher) — break when a variable
+  changes. `debug-on-signal` — catch even handled signals.
+- **Edebug** — instrument a definition with `C-u C-M-x` in its body, then
+  run it; step with `SPC`, inspect with `e`, set breakpoints with `b`.
+  Macros need a correct `(declare (debug …))` spec for Edebug to step into
+  their calls.
+- `M-x trace-function` logs calls/returns to `*trace-output*`. For "what set
+  this variable / why is this mode on" use `C-h v`, `C-h o`, and
+  `find-variable`/`find-function` (`C-h f` then the source link).
+
+## Profiling
+
+- **`M-x profiler-start`** (`cpu`, `mem`, or both) → do the slow thing →
+  `M-x profiler-report`; the tree shows where time/allocation goes. This is
+  the right tool for "Emacs is slow/janky", including redisplay and
+  fontification hotspots (look for `redisplay_internal`, `jit-lock`,
+  font-lock functions).
+- `benchmark-run` / `benchmark-progn` for microbenchmarks;
+  `M-x emacs-init-time` and this repo's `just bench` (wraps `require` with
+  timing advice via `bench/early-init.el`) for startup cost.
+- `M-x memory-report` for a heap overview; `garbage-collect` and
+  `gc-elapsed`/`gcs-done` for GC pressure (see the internals skill's
+  `objects-and-gc.md`).
+
+## ERT testing (this repo: `test/test-*.el`, run with `just test`)
+
+- `(ert-deftest prefix-name () "Docstring." BODY)`. Test names are a single
+  global namespace — **prefix every test with the module/package name**; the
+  name should state the behavior, and the docstring's first line stands
+  alone (shown on failure).
+- Assertions: `(should FORM)`, `(should-not FORM)`,
+  `(should-error FORM :type 'error-symbol)`. `should` records and *explains*
+  its argument form on failure, so prefer `(should (equal actual expected))`
+  over an opaque boolean — the explainer diffs the two.
+- `skip-unless` for conditional skips; `:tags` for grouping;
+  `:expected-result :failed` for known failures; `ert-info` adds context.
+- **Environment hygiene**: each test must restore prior global state. Use
+  `with-temp-buffer` for buffer work, `save-window-excursion` for windows,
+  `let` for options (they're dynamic/special, so `let` restores them),
+  `cl-letf` to stub functions
+  (`(cl-letf (((symbol-function 'y-or-n-p) (lambda (&rest _) t))) …)`),
+  `unwind-protect` for temp files/processes.
+  - Note: `cl-letf` on a **primitive** (subr) may not take effect under
+    native compilation unless a trampoline exists — see the internals
+    skill's `compilation.md`. Stub Lisp-level functions where possible.
+- Factor side-effect-free cores out of interactive commands so the logic is
+  testable without simulating the command loop. Keep fixtures as plain
+  helper functions that take a body thunk.
+- Run in batch (what CI does):
+  `emacs -Q -batch -L lisp -l ert -l test/test-foo.el -f ert-run-tests-batch-and-exit`.
+  `just test` wraps this; `test/` files load repo code with `-L lisp`.
+- Lint gauntlet before considering Elisp done: `just check-elisp` (parens),
+  `just compile` (byte-compile, warnings-as-errors), `M-x checkdoc`,
+  and `relint` for regexps. Emacs 30's `package-isolate` runs a subprocess
+  with only named packages for clean-environment reproduction.

--- a/.claude/skills/elisp-dev/references/emacs-30-31-changes.md
+++ b/.claude/skills/elisp-dev/references/emacs-30-31-changes.md
@@ -4,7 +4,9 @@ Source: `etc/NEWS.30`, `etc/NEWS.31`, use-package manual. Filtered to what
 matters for a config repo like this one. Emacs 31 is branched (feature
 freeze May 2026) and near release as of mid-2026; treat its items as
 "landing soon", and gate anything version-specific with `static-if` /
-`(when (>= emacs-major-version 31) …)`.
+`(when (>= emacs-major-version 31) …)`. Conversely, don't guard for versions
+at or below the repo's Emacs 30 floor (e.g. `(>= emacs-major-version 29)`) —
+such guards are dead and misleading.
 
 ## Emacs 30 (this repo's baseline)
 

--- a/.claude/skills/elisp-dev/references/emacs-30-31-changes.md
+++ b/.claude/skills/elisp-dev/references/emacs-30-31-changes.md
@@ -1,0 +1,86 @@
+# Emacs 30 / 31 changes for config and package authors
+
+Source: `etc/NEWS.30`, `etc/NEWS.31`, use-package manual. Filtered to what
+matters for a config repo like this one. Emacs 31 is branched (feature
+freeze May 2026) and near release as of mid-2026; treat its items as
+"landing soon", and gate anything version-specific with `static-if` /
+`(when (>= emacs-major-version 31) …)`.
+
+## Emacs 30 (this repo's baseline)
+
+### Runtime / compiler
+- **Native compilation on by default** when libgccjit is present; bytecode
+  loaded eagerly. `compilation-safety` option added.
+- New byte-compiler warnings (all fail `just compile`): missing
+  `lexical-binding` cookie, empty bodies, quoted error names in
+  `condition-case`/`ignore-error`, `condition-case` without handlers,
+  `unwind-protect` without unwind forms, **mutation of constants**, ignored
+  return values, control chars in docstrings, over-wide docstrings.
+- New object types `closure` / `interpreted-function`; `cl-type-of` is
+  finer-grained.
+- **Obsoletions**: `defadvice`; `easy-mmode-define-{minor,global}-mode`;
+  `subr-native-elisp-p` → `native-comp-function-p`.
+
+### New Lisp worth using
+- `handler-bind`, `static-if`, `value<`, extended `sort`
+  (`:key`/`:lessp`/`:reverse`/`:in-place`), `merge-ordered-lists`,
+  `require-with-check`, `define-advice` (names advice `SYMBOL@NAME`),
+  `derived-mode-p` list API + `derived-mode-add-parents`,
+  `major-mode-remap-alist` / `major-mode-remap-defaults`, `declare` `ftype`
+  and `important-return-value`, built-in JSON parser
+  (`json-available-p` always t).
+
+### Config-facing features (relevant to modules here)
+- **`use-package :vc`** (install from upstream repo) + `use-package-vc-prefer-newest`.
+- **which-key**, **completion-preview-mode**, **EditorConfig**, Compat,
+  Track-Changes now built in.
+- Tree-sitter: TS modes registered as submodes of their non-TS mode (so
+  dir-locals inherit), `treesit-thing-settings`, outline/imenu support,
+  `treesit-install-language-grammar`. This repo routes via
+  `major-mode-remap-alist` (dropped `treesit-auto`).
+- `trusted-content` / `safe-local-variable-directories` security options
+  (CVE-2024-53920 context — never set `trusted-content` to `:all` from a mode).
+- `advice-remove` interactive; `customize-dirlocals`.
+
+## Emacs 31 (landing soon)
+
+### Lexical-binding endgame
+- Default changeable via `(set-default-toplevel-value 'lexical-binding t)`;
+  **load-time warning for cookie-less files**; `-x`/`--script` lexical by
+  default. Keep every file's cookie.
+
+### Obsolete / incompatible (watch when bumping)
+- **`if-let`/`when-let` obsolete → `if-let*`/`when-let*`/`and-let*`**; the
+  single-binding `(if-let (sym val))` form is gone.
+- Nested backquotes banned inside pcase patterns.
+- `rx` atom `any` (the "." sense) obsolete → `anychar`.
+- Mutating string/list literals now genuinely breaks (more constant
+  coalescing).
+- `purecopy` → obsolete alias of `identity` (pure space removed).
+- `FOO-ts-mode-indent-offset` → `FOO-ts-indent-offset`.
+- `debug` in batch no longer kills Emacs; `exec-path` default matches PATH.
+
+### New Lisp
+- **`cond*`** (pattern-matching conditional); un-prefixed
+  `incf`/`decf`/`plusp`/`minusp`/`oddp`/`evenp`; `take-while`/`drop-while`,
+  `all`/`any`; `static-when`/`static-unless`; `setopt-local`/`set-local`;
+  `defvar-local` value optional; `hash-table-contains-p`;
+  `ensure-proper-list`; `with-work-buffer`; binary `%b`/`%B` in `format`;
+  `secure-hash` SHA-3; `native-compile-directory`; load-path lookup caching.
+
+### Config-facing features
+- **User Lisp directory** (`user-lisp/` under the config dir): auto
+  byte-compiled, autoload-scraped, and added to `load-path`
+  (`user-lisp-directory`, `user-lisp-auto-scrape`). Obsoletes the
+  `use-package :vc` + `:load-path` combo and
+  `package-vc-install-from-checkout`. Relevant if this repo ever ships local
+  Lisp outside `lisp/`.
+- **`treesit-enabled-modes`** (t or a list — populates `major-mode-remap-alist`
+  from `treesit-major-mode-remap-alist`), `treesit-auto-install-grammar`
+  (`ask`/`always`), keyword `treesit-language-source-alist` (`:commit`),
+  built-in grammar recipes for TypeScript/Rust/TOML/YAML/Dockerfile — may
+  let this repo simplify its tree-sitter and grammar wiring.
+- `defvar-keymap :prefix`/`:continue`, `use-package`/`bind-keys`
+  `:continue-only` for repeat-mode; PGTK follows system dark/light; ElDoc
+  and Elisp semantic-highlighting improvements; `lisp-indent-local-overrides`
+  file-local.

--- a/.claude/skills/elisp-dev/references/hooks-advice-loading.md
+++ b/.claude/skills/elisp-dev/references/hooks-advice-loading.md
@@ -1,0 +1,98 @@
+# Hooks, advice, modes, and loading
+
+Source: GNU Elisp Reference Manual ch. 16 (Loading), 13.12 (Advising
+Functions), 24 (Major/Minor Modes), 24.1 (Hooks). The order of preference
+for changing behavior is **hook > new command + remap > advice** — reach
+for the lowest-impact tool that works.
+
+## Hooks
+
+- Normal hook: name ends `-hook`, holds a list of no-arg functions.
+  Abnormal hook: ends `-functions`, functions take args / return meaningful
+  values. Singular `-function`: one function value — modify with
+  `add-function`, not `add-hook`.
+- `add-hook HOOK FN &optional DEPTH LOCAL`:
+  - No duplicate adds (`equal` comparison — this is why anonymous lambdas on
+    hooks are a problem: an edited lambda leaves the old one behind and
+    can't be removed. Use **named functions**).
+  - New functions run **first** by default. If order matters use DEPTH
+    (−100..100, higher = later; legacy `t`/`append` ≈ 90). Never use ±100 —
+    leave room for others.
+  - LOCAL non-nil makes it buffer-local and appends `t` (meaning "also run
+    the global value").
+- Modify hooks only with `add-hook`/`remove-hook`, never `setq` (clobbers
+  other packages). `let`-binding a hook for temporary suppression is fine.
+- In `use-package`, `:hook (text-mode . foo-mode)` is the idiomatic way to
+  attach; it implies deferral. Names are given without the `-hook` suffix
+  unless `use-package-hook-name-suffix` is nil.
+
+## Advice
+
+- Prefer `advice-add`/`advice-remove`/`define-advice` over raw
+  `add-function` on `symbol-function`: they handle macros, autoloads,
+  docstrings, and not-yet-defined functions, and are listable/undoable.
+
+### Combinator semantics
+
+| WHERE | composition | returns |
+|-------|-------------|---------|
+| `:before` | `fn` then `old` | old's |
+| `:after` | `old` then `fn` | old's |
+| `:override` | replace `old` | fn's |
+| `:around` | `fn` gets `old` as its first arg | fn's |
+| `:before-while` | `(and (fn) (old))` | gated |
+| `:before-until` | `(or (fn) (old))` | short-circuit |
+| `:after-while` | `(and (old) (fn))` | fn's |
+| `:after-until` | `(or (old) (fn))` | fn's if old nil |
+| `:filter-args` | `fn` transforms the arg list, then `old` | old's |
+| `:filter-return` | `old` then `fn` transforms its result | fn's |
+
+### When NOT to advise
+
+- Advice on a named function others rely on breaks their assumptions and
+  confuses debugging. Prefer a hook; if none exists prefer a new command +
+  command remapping; use advice only in personal config or when there is no
+  hook. Released libraries must not advise other packages' or Emacs's
+  functions — request an upstream hook instead.
+- **Never advise primitives**: the advice machinery uses some of them
+  (infinite recursion), and native-code C-to-C calls bypass advice unless a
+  trampoline exists (see the internals `compilation.md`).
+- `defadvice` is obsolete since Emacs 30 — use `advice-add`/`define-advice`.
+
+## Mode conventions
+
+- **`define-derived-mode`** is the way to write a major mode: it creates the
+  keymap/syntax-table/abbrev-table/hook, handles `delay-mode-hooks` and
+  `run-mode-hooks`, and takes `:syntax-table`, `:abbrev-table`,
+  `:interactive nil`, `:after-hook`. Parent should be `prog-mode`,
+  `text-mode`, `special-mode`, or `fundamental-mode`. Emacs 30:
+  `derived-mode-p` takes a list; `major-mode-remap-alist` /
+  `major-mode-remap-defaults` remap modes (how this repo routes to
+  tree-sitter modes instead of `treesit-auto`).
+- **`define-minor-mode`** generates the toggle command, the mode variable,
+  and the `minor-mode-alist` lighter (lighter starts with a space).
+- Major modes must not set user preferences (don't force Auto Fill); they
+  configure so user-enabled features work (`font-lock-defaults`,
+  `indent-line-function`, `completion-at-point-functions`,
+  `imenu-generic-expression`, buffer-local `eldoc-documentation-functions`).
+- Use `make-local-variable` in the mode body; **never**
+  `make-variable-buffer-local` on another package's variable (it's global).
+- Keybinding reservations: `C-c LETTER` and `F5`–`F9` are the **user's** —
+  never bind them from a mode. `C-c C-<letter>` / `C-c DIGIT` are the mode's.
+
+## Loading
+
+- `(require 'feat)` loads `feat.el(c)` unless already in `features`; the file
+  must `(provide 'feat)`. Top-level `require` runs during byte-compilation
+  (gives macro visibility, silences warnings).
+- **Don't `require` inside a `let` that binds the library's own variables** —
+  they become unbound when the `let` exits. Require outside.
+- Emacs 30: `require-with-check` detects a feature provided by a *different*
+  file than expected (shadowed installs).
+- **`with-eval-after-load LIBRARY BODY`** runs BODY after LIBRARY loads (or
+  immediately if already loaded). LIBRARY is a bare filename string or a
+  feature symbol. Caveats: BODY runs in a null lexical context (don't
+  capture); an error aborts the rest of BODY; heavy work delays every
+  reload. The manual restricts it to personal init files — which is exactly
+  this repo — but `use-package`'s `:config`/`:after` are the cleaner
+  expression of the same idea and should be preferred here.

--- a/.claude/skills/elisp-dev/references/hooks-advice-loading.md
+++ b/.claude/skills/elisp-dev/references/hooks-advice-loading.md
@@ -20,8 +20,9 @@ for the lowest-impact tool that works.
     leave room for others.
   - LOCAL non-nil makes it buffer-local and appends `t` (meaning "also run
     the global value").
-- Modify hooks only with `add-hook`/`remove-hook`, never `setq` (clobbers
-  other packages). `let`-binding a hook for temporary suppression is fine.
+- Modify hooks only with `add-hook`/`remove-hook`, never `setq` or `setopt`
+  with a list literal (both clobber other packages' functions; `add-hook` is
+  additive). `let`-binding a hook for temporary suppression is fine.
 - In `use-package`, `:hook (text-mode . foo-mode)` is the idiomatic way to
   attach; it implies deferral. Names are given without the `-hook` suffix
   unless `use-package-hook-name-suffix` is nil.

--- a/.claude/skills/elisp-dev/references/lexical-binding-and-macros.md
+++ b/.claude/skills/elisp-dev/references/lexical-binding-and-macros.md
@@ -1,0 +1,96 @@
+# Lexical binding and macros
+
+Source: GNU Elisp Reference Manual ch. 12 (Variable Scoping) and ch. 14
+(Macros).
+
+## Lexical binding
+
+- Selected by the buffer-local `lexical-binding`, set from the first-line
+  `-*- lexical-binding: t; -*-` cookie. Every file in this repo has it; new
+  files must. Emacs 30 *warns* when the cookie is missing; Emacs 31 warns at
+  plain `load` time and makes `-x`/`--script` files lexical by default.
+- Under lexical binding a variable reference must be textually inside its
+  binding form; closures capture bindings with **indefinite extent**. Lookup
+  order: lexical environment first, then the symbol's dynamic value cell.
+- **`symbol-value`/`boundp`/`set`/`makunbound` see only the dynamic
+  binding** — a lexical variable has no runtime tie to its symbol. Mixing
+  `intern`/`symbol-value` tricks with lexical locals is the classic trap.
+- **Special (dynamic) variables**: anything defined with `defvar` (with a
+  value), `defconst`, or `defcustom` is *always* dynamically bound,
+  everywhere, including by `let`. Test with `special-variable-p`. A special
+  variable must **never** be used as a function/macro parameter name (the
+  byte-compiler warns; behavior is unsupported).
+- **`(defvar foo)` with no value** marks `foo` special only for the rest of
+  the current file/scope — the idiom to declare a dynamic variable you bind
+  locally but that is defined elsewhere, and to silence "reference to free
+  variable" warnings without loading the defining file.
+- `(eval FORM t)` evaluates in the lexical dialect; `(eval FORM)` uses
+  dynamic — a subtle bug source when building forms at runtime.
+- Converting a file: add the cookie, byte-compile, add a `defvar` for each
+  "free variable" warning, delete or `_`-prefix each "unused lexical
+  variable".
+
+## When dynamic binding is right
+
+Use dynamic variables only for genuine dynamic protocol (like
+`case-fold-search`, `default-directory`, `inhibit-read-only`): always
+`defvar`/`defcustom` them at top level with a docstring and prefix. If a
+variable is only ever `let`-bound, use a value-less `defvar` so a stray
+global read errors loudly.
+
+## Macros
+
+### Fundamentals
+
+- `defmacro` receives its arguments **unevaluated**; its result form is then
+  evaluated/compiled in place. Macros can't be `mapcar`'d and can't be
+  interactive. Prefer backquote: `` `(if ,test ,then) ``.
+- Macros must be **defined before they are used in compilation**. A
+  `defmacro` earlier in the same file is available for the rest of that
+  file's compilation; for macros from another file wrap the require in
+  `(eval-when-compile (require 'foo))` (or a plain top-level `require`).
+
+### The five classic macro hazards
+
+1. **Wrong time** — expansion can happen at compile time, long before and
+   possibly instead of run time; never assume run-time context while
+   expanding.
+2. **Evaluation count** — the expansion must evaluate each argument form
+   **exactly once, in order**, unless multiple/zero evaluation is the
+   documented point. Substituting an argument into a `while` condition
+   re-evaluates it every iteration. Fix: bind it once in a `let` in the
+   expansion.
+3. **Hygiene / variable capture** — a plain interned local (`max`) in the
+   expansion captures the caller's same-named variable. Fix: uninterned
+   symbols via `(gensym)` / `(make-symbol "max")`, or `cl-with-gensyms` /
+   `cl-once-only` (cl-lib) which package the "bind each arg once to a
+   gensym" pattern.
+4. **Eval during expansion** — never `eval` argument forms inside the macro
+   body; the caller's context isn't available and results differ
+   interpreted vs compiled. Substitute the expression into the expansion.
+5. **Repeated expansion** — interpreted code re-expands on each call,
+   compiled code once; avoid side effects in expansion, and never mutate
+   (`setcar`) objects that appear as quoted constants — compiled code shares
+   them across calls. (Emacs 30 warns on constant mutation; Emacs 31 makes
+   it genuinely break.)
+
+### `declare` forms
+
+- `(declare (indent SPEC))` — indentation: `nil`, `defun`, integer N
+  (first N args distinguished), or a custom indent function.
+- `(declare (debug SPEC))` — Edebug spec; use `(debug t)` when all args are
+  evaluated normally. Declare it for every non-trivial macro or Edebug can't
+  step into calls.
+- Emacs 30 adds function `declare` forms: `(ftype (function (int) int))` and
+  `important-return-value t`.
+- Style: write a macro only when a function won't do (macros don't compose,
+  can't be passed as values); keep the real logic in a helper function and
+  let the macro be thin sugar; write the intended call site first.
+
+## `eval-when-compile` vs `eval-and-compile`
+
+- `eval-when-compile` — compute at compile time only; the value is inlined.
+  For compile-time constants and requiring macro libraries.
+- `eval-and-compile` — run at both compile and load time. Use when a
+  definition is needed *to compile the rest of the file* and also at run
+  time (e.g. a function called by a macro's expansion).

--- a/.claude/skills/elisp-dev/references/modern-libraries.md
+++ b/.claude/skills/elisp-dev/references/modern-libraries.md
@@ -1,0 +1,98 @@
+# Modern Emacs Lisp libraries and idioms
+
+Source: GNU Elisp Reference Manual, `seq.el`/`map.el`/`cl-lib`/`rx`/`pcase`
+nodes, NEWS.30/NEWS.31. Prefer these over hand-rolled list surgery; they are
+built in on Emacs 30/31.
+
+## pcase
+
+- `pcase EXP &rest CASES`. Patterns: `_` (any), `SYM` (bind), `'VAL` /
+  self-quoting literal (equal), `` `(,a ,b) `` (destructure), `(pred FN)`,
+  `(app FN PAT)`, `(guard EXPR)`, `(and …)`, `(or …)`, `(rx …)`,
+  `(cl-type TYPE)`, `(map KEY …)`, `(seq PAT …)`.
+- Family: `pcase-let`, `pcase-let*`, `pcase-dolist`, `pcase-lambda`,
+  `pcase-exhaustive` (errors on no match), `pcase-defmacro`.
+- Keep patterns readable — deeply clever `pcase` is a maintenance liability;
+  for simple bind-and-test, `if-let*`/`when-let*` are clearer. Emacs 31 adds
+  `cond*` as an official cond/pattern-matching hybrid.
+
+## seq.el (generic over lists/vectors/strings)
+
+`seq-map` `seq-filter` `seq-remove` `seq-reduce` `seq-find` `seq-some`
+`seq-every-p` `seq-contains-p` `seq-count` `seq-sort` `seq-sort-by`
+`seq-uniq` `seq-take` `seq-drop` `seq-take-while` `seq-drop-while`
+`seq-subseq` `seq-mapn` `seq-do` `seq-map-indexed` `seq-group-by`
+`seq-partition` `seq-difference`/`-intersection`/`-union` `seq-empty-p`
+`seq-elt` (setf-able) `seq-let` `seq-keep` `seq-split`. Side-effect-free,
+extensible via `cl-defgeneric`. Rule of thumb: `dolist` for side effects,
+`seq-*` for value transformations, `seq-do` only with a named function.
+
+## map.el (generic over alists/plists/hash-tables/arrays)
+
+`map-elt` (setf-able) `map-put!` `map-delete` `map-nested-elt` `map-keys`
+`map-values` `map-pairs` `map-length` `map-do` `map-filter` `map-some`
+`map-contains-key` `map-merge` `map-merge-with` `map-into` `map-let`, and the
+`(map …)` pcase pattern. Emacs 31 adds `hash-table-contains-p`.
+
+## cl-lib
+
+- Always `cl-lib`, never the removed `cl`. Highlights: `cl-defun`/
+  `cl-defmacro` (keyword & optional args), `cl-loop`, `cl-case`,
+  `cl-typecase`, `cl-destructuring-bind`, `cl-flet`/`cl-labels` (lexical
+  local functions), `cl-letf` (temporarily rebind *places* incl. function
+  cells — the standard test-double trick; `flet` is dead), `cl-defstruct`,
+  `cl-defgeneric`/`cl-defmethod`, `cl-check-type`, `cl-assert`,
+  `cl-with-gensyms`, `cl-once-only`.
+- **Generalized variables**: `setf` works on `car`, `nth`, `plist-get`,
+  `alist-get`, `map-elt`, `symbol-function`, `buffer-local-value`, …;
+  `cl-incf`/`cl-decf`/`push`/`pop`/`cl-callf`/`cl-rotatef` on places;
+  `gv-define-setter` for new ones. `(setf (alist-get k a) v)` (with
+  `:remove` for deletion) is the idiomatic alist updater.
+- Emacs 31 promotes `incf`/`decf`/`plusp`/`minusp`/`oddp`/`evenp` to core
+  (un-prefixed).
+
+## rx (structured regexps)
+
+`(rx …)` compiles to a regexp string at compile time: `seq` `or` `group`
+`group-n` `opt` `zero-or-more`/`*` `one-or-more`/`+` `repeat` `any` (as a
+set) `not` `syntax` `bol`/`eol`/`bos`/`eos` `word-boundary` `literal`
+`regexp` `eval`; `rx-define`/`rx-let` for reusable components; also usable as
+a pcase pattern with group bindings. Use it for any nontrivial regexp;
+`relint` checks hand-written ones. (Emacs 31 obsoletes the `any` *atom* for
+"."; use `anychar`.)
+
+## Binding, threading, and control-flow macros
+
+- `if-let*` / `when-let*` / `and-let*` / `while-let` — bind-and-test chains.
+  **Emacs 31 obsoletes `if-let`/`when-let`** and the single-binding
+  `(if-let (sym val))` spelling; use the starred forms now.
+- `thread-first` / `thread-last` — pipeline macros for genuinely linear
+  transformations (don't force non-linear code into them).
+- `named-let` — Scheme-style tail-recursive local loop (compiles tail calls
+  to iteration; elisp has no general TCO).
+- `ensure-list` — normalize x-or-list-of-x arguments.
+- `handler-bind` (Emacs 30) — run an error handler *without* unwinding the
+  stack (backtrace-preserving).
+- `static-if` (30) / `static-when` / `static-unless` (31) — compile-time
+  feature/version gating with no runtime cost.
+- `with-memoization`, `benchmark-progn`, `while-no-input`.
+
+## Strings, keymaps, sorting
+
+- `string-empty-p` `string-join` `string-trim` `string-pad`
+  `string-search` `string-replace` (prefer over
+  `replace-regexp-in-string` for literal replacement) `string-chop-newline`.
+- **`defvar-keymap`** + `keymap-set`/`keymap-global-set`/`keymap-lookup`
+  (Emacs 29) replace `define-key`/`kbd`. `defvar-keymap` takes `:repeat`;
+  Emacs 31 adds `:prefix`/`:continue`.
+- Emacs 30 extended `sort` with `:key`/`:lessp`/`:reverse`/`:in-place`, and
+  added `value<`, `merge-ordered-lists`, `take`/`ntake`, `drop`.
+
+## Performance idioms (measure first)
+
+- `memq`/`member`/`assq`/`assoc` beat manual loops; `buffer-local-value` is
+  far cheaper than `with-current-buffer` for a single variable read; batch
+  `insert` one concatenated string rather than many small inserts; hash
+  tables for large keyed lookups (plists only for tiny ones). Use
+  `defsubst`/`define-inline` only on measured hot paths. Profile with
+  `M-x profiler-start` and `benchmark-run`, not intuition.

--- a/.claude/skills/emacs-internals/SKILL.md
+++ b/.claude/skills/emacs-internals/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: emacs-internals
+description: Knowledge base on GNU Emacs internals (Emacs 30/31) — garbage collection, object representation, buffers and text, the redisplay engine, the command loop and keymaps, byte/native compilation, threads, and the build/dump pipeline. Use when explaining or debugging core Emacs behavior, tuning performance (GC, redisplay, startup), reasoning about native-comp/eln caches, or reviewing Elisp whose correctness depends on runtime semantics.
+---
+
+# Emacs internals knowledge base
+
+Reference notes distilled from the GNU Emacs Lisp Reference Manual (Internals
+appendix and related chapters), the `src/xdisp.c` design commentary, and the
+native-compilation literature. Targets Emacs 30/31, which is what this repo
+builds and runs (see `emacs.nix`).
+
+## How to use this skill
+
+Read only the reference file(s) relevant to the question — each is
+self-contained:
+
+| File | Covers |
+|------|--------|
+| `references/objects-and-gc.md` | Lisp_Object tagging, fixnums/bignums, symbols, strings, vectors; mark-and-sweep GC, `gc-cons-threshold`/`gc-cons-percentage`, stack allocation, `memory-report`, the MPS/igc branch |
+| `references/buffers-and-text.md` | Gap buffer, markers, overlays (interval-tree since 29), text properties, buffer-local variables, character/byte positions |
+| `references/redisplay.md` | Glyph matrices, desired vs. current matrix, the display iterator, redisplay optimizations and what defeats them, jit-lock/fontification, forcing redisplay |
+| `references/command-loop-and-keymaps.md` | `read-key-sequence` → key lookup → command execution, `this-command`/`last-command`, pre/post-command hooks, event representation, keymap format and the active-keymap precedence order, quitting |
+| `references/compilation.md` | Byte-code objects and `.elc` semantics, `eval-when-compile` vs `eval-and-compile`; native-comp pipeline (LAP → LIMPLE → libgccjit → `.eln`), speed levels, trampolines, eln-cache layout and invalidation |
+| `references/threads-and-build.md` | Cooperative threads (global lock, yield points, mutexes/condvars); building and dumping (`temacs`, portable dumper `.pdmp`, purespace removal) |
+
+## Repo-specific anchors
+
+- GC startup tuning lives in `early-init.el` (`gc-cons-threshold` set to
+  `most-positive-fixnum` during init) — see `references/objects-and-gc.md`
+  for why and what to restore afterwards.
+- Native-comp eln cache is redirected to `var/eln-cache/` in `early-init.el`;
+  `just clean` removes it. The `igc` build variant (`just build-igc`) uses the
+  MPS garbage collector.
+- Startup/benchmarking: `just bench` wraps `require` with timing advice
+  (`bench/early-init.el`).
+
+When a claim here conflicts with the actual manual, trust the manual: use
+`C-h S` (`info-lookup-symbol`) or the online GNU Elisp Reference Manual, and
+fix the reference file in the same change.

--- a/.claude/skills/emacs-internals/references/buffers-and-text.md
+++ b/.claude/skills/emacs-internals/references/buffers-and-text.md
@@ -1,0 +1,90 @@
+# Buffer internals: gap buffer, markers, overlays, text properties
+
+Source: GNU Elisp Reference Manual (Emacs 30.2), E.9.1 Buffer Internals plus
+the Buffer Gap / Text Properties / Overlays chapters.
+
+## Two C structures (`src/buffer.h`)
+
+- `struct buffer_text` holds the text itself; `struct buffer` holds
+  everything else and points at a `buffer_text`. **Indirect buffers** are
+  two or more `struct buffer`s sharing one `buffer_text` (each keeps its own
+  point/narrowing via `pt_marker`/`begv_marker`/`zv_marker`).
+
+## The gap buffer
+
+- Buffer text is one linear C `char` array with a movable **gap** in the
+  middle (`beg` = base address; `gpt`/`gpt_byte` = gap position; `z`/`z_byte`
+  = end; `gap_size`).
+- Insertion/deletion happens at the gap; editing at a new position first
+  *moves the gap* there (a `memmove` proportional to the distance).
+  Consequences:
+  - Sequential edits at one location are cheap; alternating edits at distant
+    locations are O(buffer size) each.
+  - Char position vs byte position are distinct in multibyte buffers;
+    primitives track both (`position-bytes`, `byte-to-position`).
+- Modification ticks: `modiff` (every text modification — exposed as
+  `buffer-modified-tick`), `chars_modiff` (character changes only,
+  `buffer-chars-modified-tick`), `overlay_modiff`, `save_modiff` (value at
+  last save). Redisplay uses `beg_unchanged`/`end_unchanged` to bound the
+  region it must reexamine.
+
+## Markers
+
+- Each buffer's markers form a **linked chain** (the `markers` field is one
+  marker whose chain links the rest). Every insertion/deletion walks the
+  chain to adjust marker positions — thousands of markers in one buffer make
+  editing linearly slower. Delete markers you create in loops
+  (`set-marker` to nil) or use `save-excursion` sparingly in hot paths.
+- Markers store both char and byte positions and have an insertion type
+  (`marker-insertion-type`) controlling which side of an insertion at the
+  marker position they end up on.
+- Point (`pt`), the mark, and window starts are markers or marker-like
+  fields; narrowing bounds are `begv`/`zv`.
+
+## Text properties
+
+- Stored in an **interval tree** per `buffer_text` (`intervals` field,
+  `struct interval`; also used for string properties). Lookup and
+  next-change scanning are O(log n).
+- Text properties are *part of the text*: copied with it (`buffer-substring`
+  vs `buffer-substring-no-properties`), and property changes count as buffer
+  modifications (but not as character changes — see `chars_modiff`).
+
+## Overlays
+
+- Since the **Emacs 29 "noverlay" rewrite** (`src/itree.c`), each buffer's
+  overlays live in an **interval tree** too (`overlays` field in
+  `struct buffer`). Lookup is O(log n + k); the historical pathology where
+  thousands of overlays made redisplay and editing crawl (the old
+  `overlay_center` two-list scheme) is gone, though overlays are still
+  heavier than text properties.
+- Overlays are buffer-local, not part of the text (never copied with it),
+  and support `priority`, `window`, and before/after-string properties that
+  only redisplay interprets.
+- Rule of thumb: text properties for *content-attached* data (fontification,
+  syntax), overlays for *annotation/UI* (highlights, inline hints) — and
+  prefer text properties in very hot paths.
+
+## Buffer-local variables
+
+- Built-in per-buffer variables (`DEFVAR_PER_BUFFER`) live as slots in
+  `struct buffer` with a `local_flags` bitmap marking which are localized
+  (e.g. `mode_line_format`, `tab_width`, `truncate_lines`,
+  `enable-multibyte-characters`…). All other buffer-local bindings live in
+  the `local_var_alist`.
+- `inhibit_buffer_hooks`: buffers created for internal/temp use (e.g.
+  `with-temp-buffer`, generate-new-buffer with INHIBIT-BUFFER-HOOKS) skip
+  `kill-buffer-hook`/`buffer-list-update-hook` — that's why temp buffers are
+  cheap and why global buffer hooks don't see them.
+- The `next` chain links **all** buffers including killed ones (GC uses it);
+  a "killed" buffer object survives until unreferenced.
+
+## Practical performance notes
+
+- Long lines historically defeated redisplay/scanning caches; Emacs 29+
+  mitigates with `long-line-threshold` and forced narrowing
+  (`long-line-optimizations-p`).
+- `cache_long_line_scans` / `cache-long-scans` enables newline caching for
+  buffers where scanning is hot.
+- Counting positions: prefer `line-number-at-pos` sparingly in hot loops —
+  it scans; cache or use `count-lines` over bounded regions.

--- a/.claude/skills/emacs-internals/references/command-loop-and-keymaps.md
+++ b/.claude/skills/emacs-internals/references/command-loop-and-keymaps.md
@@ -1,0 +1,127 @@
+# The command loop, keymaps, and quitting
+
+Sources: GNU Elisp Reference Manual (Emacs 30.2), Command Loop and Keymaps
+chapters; `src/keyboard.c`.
+
+## One iteration of the command loop
+
+1. `read-key-sequence` reads events, echoing after `echo-keystrokes`
+   seconds, translating via input-decode-map → local-function-key-map →
+   key-translation-map, and looking keys up in the **active keymaps** as it
+   goes (it stops as soon as the sequence is a complete binding).
+2. The binding is executed via `command-execute`: the interactive spec is
+   evaluated to produce arguments (`interactive` string codes or a Lisp
+   form), then the command body runs.
+3. Around execution: `pre-command-hook` (before), `post-command-hook`
+   (after — runs *before* redisplay). Errors in these hooks no longer
+   remove the offending function (they used to); they're reported and
+   execution continues, but treat both hooks as ultra-hot paths.
+4. After the command: point adjustment (moving point out of invisible text
+   / composed sequences, unless `disable-point-adjustment`), then redisplay
+   if no input is pending.
+
+### Command-loop state variables
+
+- `this-command` (set before the command runs; commands may change it, e.g.
+  to group undo), `last-command` / `real-last-command` (previous command),
+  `this-original-command` (pre-remapping command).
+- `this-command-keys` / `this-command-keys-vector`, `last-command-event`,
+  `last-input-event`.
+- `current-prefix-arg` / `prefix-arg` (raw prefix for this / next command);
+  `prefix-numeric-value` converts. `C-u` = `(4)`, `C-u C-u` = `(16)`,
+  `M--` = `-`.
+- Special events (`special-event-map`: focus, delete-frame, sigusr…) are
+  dispatched inside `read-event` itself, invisibly to the sequence reader —
+  the event appears only in `last-input-event`.
+
+### Writing commands
+
+- `(interactive SPEC &rest MODES)` — string codes (`"p"`, `"P"`, `"r"`,
+  `"sPrompt"`, `"e"`…) or any Lisp form returning the arg list. The MODES
+  tail (Emacs 28+) declares which modes the command applies to and powers
+  `M-X` and command completion predicates.
+- A command is any `commandp` object: interactive-declared function,
+  keyboard macro, or `(declare (interactive-only …))`-free callable.
+  Commands intended only for Lisp use should declare `interactive-only`.
+
+## Keymaps
+
+### Format
+
+- A keymap is a list `(keymap . ALIST-OR-CHAR-TABLE...)`; global/dense maps
+  use a char-table for character events, sparse keymaps an alist. Bindings
+  map an event type to a command, another keymap (prefix key), a string
+  (keyboard macro), or an indirection. `keymap-set`/`keymap-lookup`
+  (Emacs 29+) are the modern string-syntax API (`"C-c C-f"`), replacing
+  `define-key`/`kbd` in new code.
+
+### Active keymap precedence (highest first)
+
+1. `overriding-terminal-local-map` (used by transient maps —
+   `set-transient-map`)
+2. `overriding-local-map`
+3. `keymap` **text/overlay property at point** (at the position clicked for
+   mouse events)
+4. `emulation-mode-map-alists` (e.g. evil, viper)
+5. `minor-mode-overriding-map-alist` (major mode overriding minor modes)
+6. `minor-mode-map-alist` (enabled minor modes, in list order)
+7. Buffer's **local map** (major mode) — or a `local-map` text/overlay
+   property, which *replaces* the buffer's local map (so it sits below
+   minor-mode maps, unlike the `keymap` property which sits above)
+8. `global-map`
+
+`current-active-maps` and `(key-binding KEY)` resolve exactly this order —
+use them when debugging "why does this key do X here".
+
+### Remapping and translation
+
+- Command remapping: `(keymap-set map "<remap> <old-cmd>" 'new-cmd)`;
+  resolved at lookup time; `this-original-command` preserves the original.
+  `keymap-lookup` follows remaps unless NO-REMAP.
+- Translation maps run at different stages: `input-decode-map`
+  (terminal escape sequences → events; terminal-local),
+  `local-function-key-map` (function-key → ASCII fallback),
+  `key-translation-map` (last, above everything; for self-inserting
+  swaps). A translation entry can be a function (dynamic translation).
+  Pitfall: a complete binding whose sequence is a prefix of a translation
+  (`ESC`, `M-[`, `M-O`) prevents the translation from being seen — matters
+  for TTY key protocols (kkp/xterm modifyOtherKeys).
+
+### Key-binding conventions (for config code)
+
+- `C-c LETTER` is reserved for users; `C-c C-LETTER` and `C-c DIGIT`/
+  `C-c {}<>:;` for major modes; `F5`–`F9` for users. Don't bind `C-h`,
+  `C-g`, or `ESC ESC ESC`.
+
+## Reading input programmatically
+
+- `read-event` / `read-char` / `read-key` (decoded), `read-key-sequence`
+  (full sequence with all translations). `while-no-input` runs its body
+  and aborts (like a quit) the moment input arrives — the standard tool for
+  making expensive idle work responsive. `input-pending-p` polls.
+- `sit-for SECONDS` — redisplay, then wait for input or timeout;
+  `sleep-for` waits unconditionally without redisplay.
+
+## Quitting
+
+- `C-g` sets `quit-flag`; the flag is checked only at safe points
+  (`maybe_quit` in C, between byte-codes in Lisp), then signals `quit` to
+  the innermost command loop. While *waiting for input*, `C-g` is instead
+  an ordinary event bound to `keyboard-quit`.
+- `inhibit-quit` non-nil defers quits; when the binding unwinds with
+  `quit-flag` still set, the quit fires immediately. `with-local-quit`
+  re-enables quitting locally — the right wrapper for code called from
+  timers, process filters/sentinels, and pre/post-command hooks (which run
+  with `inhibit-quit` bound).
+- `minibuffer-quit` signals quit without aborting keyboard-macro
+  definition/execution.
+
+## Recursive editing
+
+- `recursive-edit` nests a full command loop; implemented as
+  `(catch 'exit …)` — throw nil = return (`exit-recursive-edit`, `C-M-c`),
+  throw t = abort with quit (`abort-recursive-edit`, `C-]`); `top-level`
+  unwinds all levels. `recursion-depth` reports nesting. Minibuffer input
+  is a recursive edit. Prefer a special mode or dedicated buffer over
+  `recursive-edit` in application code; legitimate users: the debugger,
+  `query-replace`'s `C-r`.

--- a/.claude/skills/emacs-internals/references/compilation.md
+++ b/.claude/skills/emacs-internals/references/compilation.md
@@ -1,0 +1,122 @@
+# Byte compilation and native compilation
+
+Sources: GNU Elisp Reference Manual (Emacs 30.2) Byte Compilation & Native
+Compilation chapters; `src/comp.c`, `lisp/emacs-lisp/comp*.el`; Corallo et
+al., "Bringing GNU Emacs to Native Code" (ELS'20). This repo runs Emacs 30
+with native-comp on by default.
+
+## Byte compilation
+
+- Byte compilation turns Lisp into a portable bytecode object executed by
+  the C interpreter loop in `bytecode.c`. `.elc` files hold these objects.
+  Byte-code / interpreted functions are now `closure` objects (Emacs 30
+  reworked the representation; the old "Byte-Code Objects" manual node is
+  now "Closure Function Objects").
+- **`eval-when-compile`** — evaluate at compile time only; result is
+  substituted (use for compile-time constants and to `require` macros).
+- **`eval-and-compile`** — evaluate at *both* compile and load time (use
+  when a macro/function is needed to compile the rest of the file *and* at
+  run time).
+- Macros must be defined before their first *use* in compilation:
+  `(eval-when-compile (require 'cl-lib))` before macro-heavy code. A plain
+  top-level `require` is also run by the compiler and additionally silences
+  undefined-function/variable warnings.
+- Silence warnings correctly, never with a bogus autoload cookie:
+  `(defvar foo)` for a variable defined elsewhere, `declare-function` for a
+  function, `(with-suppressed-warnings ...)` for a specific known-safe call.
+- `disassemble` shows the bytecode; `byte-compile-error-on-warn` turns
+  warnings into hard errors — this repo's `just compile` uses it, so
+  warning-clean code is mandatory.
+
+## Native compilation (gccemacs)
+
+### Pipeline
+
+`elisp → (byte-compiler front end) → LAP → LIMPLE (SSA CFG IR) →
+libgccjit IR → GCC optimizer → .eln shared object`
+
+- Only lexically-scoped code is natively compiled; dynamic-scope files fall
+  back to bytecode. `.eln` output is persistent and reloadable — not a JIT
+  in the transient sense; expensive optimization amortizes across sessions.
+- Native functions register as subrs (`subrp` is t); distinguish them with
+  **`native-comp-function-p`** (Emacs 30 name; was `subr-native-elisp-p`).
+- The `comp-passes` pipeline (Emacs 30): spill-lap, limplify, fwprop (×3),
+  call-optim, ipa-pure, add-cstrs, tco, remove-type-hints, sanitizer,
+  compute-function-types, final. Only `final` invokes GCC (in a subprocess).
+
+### Speed levels (`native-comp-speed`, default 2)
+
+| level | meaning |
+|-------|---------|
+| −1 | keep bytecode, no native code (still writes a bytecode `.eln`) |
+| 0 | native, no optimization (`-O0`) |
+| 1 | light optimizations, advanced frame layout |
+| 2 | **default** — full optimization, semantics-preserving |
+| 3 | maximum — **may change semantics**, use only when needed |
+
+- Per-function override: `(declare (speed N))`; also `(declare (safety N))`.
+- **Why 3 is dangerous** (and 2 is the default):
+  - Intra-compilation-unit calls become direct/inlined, so **redefining or
+    advising a function defined in the same file won't affect callers within
+    that file** — they keep calling the old code.
+  - Type hints (`comp-hint-fixnum`/`comp-hint-cons`) are *trusted* rather
+    than checked; a wrong hint is undefined behavior / crash.
+- `compilation-safety` (default 1): 0 lets mis-declared function types
+  produce crashing code; 1 stays memory-safe. "Safe ≠ correct."
+
+### Deferred / async (JIT) compilation
+
+- `native-comp-jit-compilation` (default t): loading a `.elc` with no
+  matching `.eln` spawns a batch subprocess to compile it, then swaps the
+  native definitions in. Disable per-file with
+  `native-comp-jit-compilation-deny-list` (regexps).
+- Async subprocesses start from a **pristine environment**, so a missing
+  `require` that was masked in your live session becomes an async-only
+  warning/error — the most common native-comp failure mode. Control noise
+  with `native-comp-async-report-warnings-errors` (t / `silent`).
+- `native-comp-async-jobs-number` (0 = half the CPUs). Log buffers:
+  `*Async-native-compile-log*`, `*Native-compile-Log*`.
+
+### eln-cache layout and invalidation
+
+- Search/write path: `native-comp-eln-load-path` (the `.eln` analogue of
+  `load-path`; async output goes to the first writable entry). This repo
+  redirects it to `var/eln-cache/` in `early-init.el` via
+  `startup-redirect-eln-cache`.
+- Per-ABI subdirectory `emacs-version "-" comp-abi-hash` (e.g.
+  `30.1-abcdef12/`). `comp-abi-hash` is an 8-char MD5 over the Emacs
+  version, build configuration, and **every preloaded primitive's
+  name+arity** — so a different Emacs build, or any primitive signature
+  change, silently invalidates the whole cache directory (old dirs are just
+  never consulted). This is why a Nix Emacs rebuild recompiles everything.
+- File name: `basename-<pathhash>-<contenthash>.eln` (both 8-char MD5, of
+  the resolved absolute path and of the source contents). The content hash
+  means editing a source invalidates its `.eln` and lets `dlopen` load the
+  new one; for cache GC, all but the newest `basename-pathhash-*` are safe
+  to delete.
+
+### Trampolines and primitive redefinition
+
+- At speed ≥ 2 native code calls primitives *directly* through a function
+  pointer table, bypassing symbol function cells. So `fset`/advice on a
+  **primitive** would be invisible to native callers.
+- Fix: Emacs installs a natively-compiled **trampoline** shim in that
+  primitive's table slot doing a normal symbol-based `funcall`. Trampolines
+  are cached in the eln cache and reused across sessions.
+- `native-comp-enable-subr-trampolines` (default t): t generates on demand;
+  nil means **advice/redefinition of primitives is silently ignored** by
+  native code unless the trampoline already exists; a string names a
+  directory (session-only if unusual). `native-comp-never-optimize-functions`
+  defaults to `(eval)`.
+- Practical fallout: mocking/spying frameworks (buttercup, `cl-letf` on a
+  primitive) behave differently under native-comp; sandboxed builds (Nix)
+  may need trampolines pre-generated. When a test that stubs a *primitive*
+  passes interpreted but fails compiled, suspect trampolines.
+
+### Renames to remember
+
+`subr-native-elisp-p` → `native-comp-function-p`;
+`native-comp-deferred-compilation-deny-list` →
+`native-comp-jit-compilation-deny-list`; `comp-speed`/`comp-debug` →
+`native-comp-speed`/`native-comp-debug`; `comp.el` split into
+`comp.el`+`comp-common.el`+`comp-run.el`+`comp-cstr.el` (Emacs 30).

--- a/.claude/skills/emacs-internals/references/objects-and-gc.md
+++ b/.claude/skills/emacs-internals/references/objects-and-gc.md
@@ -1,0 +1,113 @@
+# Object representation and garbage collection
+
+Source: GNU Elisp Reference Manual (Emacs 30.2), appendix E (Internals) and
+ch. 2–3. Version notes flagged inline. The GC description covers the classic
+in-tree collector — the default in Emacs 30 and 31; the MPS/igc collector
+(see end) changes most of it.
+
+## Tagged pointers (`Lisp_Object`)
+
+- `Lisp_Object` is a tagged pointer. Every value is one of: integer, symbol,
+  string, cons cell, float, or "vectorlike". The tag lives in a 3-bit
+  bitfield (`enum Lisp_Type`); the remaining bits are the value.
+- Fixnums are *immediate* (stored in the bits); everything else is a heap
+  pointer.
+- Width is normally pointer-width. The `--with-wide-int` build makes
+  `Lisp_Object` 64-bit on 32-bit platforms to widen the fixnum range.
+- Core structs in `src/lisp.h`: `struct Lisp_Cons`, `struct Lisp_String`,
+  `struct Lisp_Vector`, `struct Lisp_Symbol`, `struct Lisp_Float`.
+- Tag space is scarce, so everything else (buffers, windows, frames,
+  processes, markers, overlays, hash tables, byte-code objects…) is a
+  **pseudovector**: a `Lisp_Vectorlike` discriminated by `enum pvec_type`
+  stored in the `union vectorlike_header` `size` field, which also encodes
+  the count of `Lisp_Object` slots and trailing non-Lisp data size.
+
+## Integers: fixnums and bignums
+
+- Two kinds since Emacs 27: fixnums (immediate) and bignums (arbitrary
+  precision, heap-allocated).
+- Fixnum range is machine-dependent; guaranteed at least 30 bits
+  (−2^29 … 2^29−1). Typical: 2^61−1 max on 64-bit. See
+  `most-positive-fixnum` / `most-negative-fixnum`.
+- An integer in fixnum range is *always* a fixnum; a bignum is never
+  numerically equal to a fixnum. Consequence: **`eq` on integers is not
+  reliable** — use `eql` or `=`.
+- `integer-width` bounds bignum creation (values ≥ 2^n signal `range-error`).
+- Characters are just integers in `0 … (max-char)`.
+
+## Emacs 30 type-system additions
+
+- Interpreted closures are first-class `closure` objects (function
+  representation reworked in 30); `cl-type-of`, type descriptors, and a
+  documented type hierarchy were added.
+- Objects are self-typing; each primitive type has a predicate. Use
+  `cl-type-of` for the most specific type name.
+
+## Garbage collection (classic mark-and-sweep)
+
+### Allocation model
+
+- Objects are segregated by type into blocks: small strings pack into 8 KB
+  blocks, small vectors into 4 KB blocks; conses/symbols/markers get
+  type-specific blocks with per-type free lists. Large vectors, long
+  strings, and buffers are allocated individually.
+- Emacs does **not** GC when a free list empties — it asks the OS for more
+  memory and GCs only after `gc-cons-threshold` bytes have been consed.
+
+### Algorithm
+
+- **Conservative stack-scanning mark & sweep.** Roots: all symbols (values +
+  function slots) plus anything that *looks like* a Lisp pointer on the C
+  stack. Conservative scanning may overestimate reachability, so one sweep
+  is not guaranteed to collect every dead object.
+- Sweep: conses/symbols/markers go back on free lists; live strings are
+  **compacted** into fewer 8 KB blocks; vector-block free areas are
+  coalesced and indexed by size.
+- GC can move string data and buffer text — C code must never hold pointers
+  into them across Lisp evaluation (this constrains primitives, not Lisp).
+
+### Triggering and tuning
+
+- `gc-cons-threshold` — bytes of Lisp allocation since the last GC that
+  allow the next one. Default `GC_DEFAULT_THRESHOLD`: **800,000 on 64-bit**
+  (400,000 on plain 32-bit). Buffer contents don't count. Values below
+  1/10 of the default last only until the next GC.
+- `gc-cons-percentage` — threshold as a fraction of the current heap.
+  Default **0.1 interactive, 1.0 in batch** (and while dumping).
+- **Both criteria must be satisfied** for GC to run; the check is periodic
+  and approximate, not per-allocation.
+- The manual explicitly advises against keeping `gc-cons-threshold` large
+  for prolonged periods: fewer but much longer pauses, higher memory
+  pressure. The legitimate pattern is a *temporary* raise around a critical
+  section — which is exactly what this repo does: `early-init.el` sets it to
+  `most-positive-fixnum` during startup and restores a sane value on
+  `emacs-startup-hook`. Calling `garbage-collect` explicitly just before a
+  latency-critical section guarantees no GC inside it (if it conses less
+  than the threshold).
+- Observability: `garbage-collect` (returns per-type `(NAME SIZE USED FREE)`
+  usage), `gcs-done`, `gc-elapsed`, `garbage-collection-messages`,
+  `post-gc-hook` (GC is inhibited while it runs — keep it cheap),
+  `memory-report` (approximate `*Memory Report*` buffer), `memory-limit`,
+  `memory-info`, `memory-use-counts`, and the cumulative counters
+  `cons-cells-consed`, `strings-consed`, `intervals-consed`, etc.
+
+## Stack-allocated objects
+
+- C-internal only: `AUTO_CONS`, `AUTO_STRING`, … allocate conses/strings
+  with block lifetime on the C stack — never GC'd, never visible to Lisp.
+  Stack strings are ASCII-only and often immutable. Debug misuse with
+  `GC_CHECK_MARKED_OBJECTS`.
+
+## Pure storage (historical) and the igc/MPS collector
+
+- Pure storage: read-only, shared memory for preloaded-library data, filled
+  only while `temacs` loads the preloaded files (`purecopy`, `purify-flag`,
+  `pure-bytes-used`). Under pdump it was already nearly irrelevant;
+  **Emacs 31 (master) removed pure space entirely** — `purecopy` is a
+  compatibility no-op. Treat `purecopy` in modern code as noise.
+- **igc/MPS**: the `feature/igc` branch (packaged by emacs-overlay as
+  `emacs-igc`; built here via `just build-igc`) replaces mark-sweep with
+  Ravenbrook MPS — an incremental, mostly-copying, generational collector.
+  Under igc, `gc-cons-threshold` semantics and `garbage-collect` output do
+  not apply as written; GC pauses become small and incremental. The 30.2
+  manual contains no igc documentation.

--- a/.claude/skills/emacs-internals/references/redisplay.md
+++ b/.claude/skills/emacs-internals/references/redisplay.md
@@ -1,0 +1,124 @@
+# The redisplay engine
+
+Sources: GNU Elisp Reference Manual (Emacs 30.2) Display chapter and the
+design commentary at the top of `src/xdisp.c`.
+
+## Architecture
+
+- Redisplay is decoupled from mutation: editing code never draws; the
+  command loop (and `sit-for`/`redisplay`) trigger it.
+  `redisplay_internal` in `xdisp.c` is the single entry point.
+- Three steps: (1) decide which frames need consideration (often just the
+  selected window); (2) per window, `redisplay_window` computes a **desired
+  glyph matrix** describing how the window should look, reusing the
+  **current glyph matrix** (what's on the glass) where possible; (3)
+  `update_window`/`update_frame` diff desired vs. current and draw only the
+  difference, then desired rows become current.
+- **Glyph matrices** are 2-D arrays of `struct glyph`; one glyph row per
+  screen line (left margin / text area / right margin arrays). Desired
+  matrices are sparse — only rows needing update are enabled.
+  `display_line` produces one row from the iterator.
+- On text terminals, windows sub-allocate from a **frame matrix** (rows are
+  slices of frame rows), enabling frame-global scroll optimizations.
+
+## The iterator (`struct it`)
+
+- All complexity — overlays, text properties, display tables, invisibility,
+  compositions, bidi — hides behind the iterator: `init_iterator`, then
+  `get_next_display_element` / `set_iterator_to_next`.
+- Infrequently-changing state (face, invisibility, display specs) is only
+  re-examined at **stop positions** (`compute_stop_pos`: next text-property
+  change, overlay change, or composition boundary). At a stop,
+  `handle_stop` runs handlers in order: `fontified` → `face` → `display` →
+  `invisible` → `composition`, plus overlay changes.
+- Display *simulation* without drawing uses the same machinery:
+  `move_it_to`, `move_it_by_lines` back `vertical-motion`,
+  `posn-at-point`, window-start recentering. Anything that simulates
+  layout can therefore trigger fontification and pay full layout cost —
+  this is why `line-move-visual`/`vertical-motion` on long lines is
+  expensive.
+- Bidi reordering (`bidi.c`) happens inside `set_iterator_to_next`; R2L
+  rows get glyphs prepended and are drawn left-to-right by back-ends.
+  Disabling bidi in pure-ASCII buffers (as this repo's `early-init.el`
+  does via `bidi-paragraph-direction 'left-to-right` and
+  `bidi-inhibit-bpa`) skips reordering and the bracket-pairing algorithm.
+
+## Optimization ladder (tried in order per window)
+
+1. `try_cursor_movement` — nothing changed, point moved within the
+   displayed text: just move the cursor.
+2. `try_window_reusing_current_matrix` — text unchanged, window start
+   changed (scrolling): shift/reuse current-matrix rows.
+3. `try_window_id` — bounded insert/delete: regenerate only the changed
+   region, reuse the rest.
+4. `try_window` — regenerate the whole window matrix (still no font
+   re-dimensioning).
+5. Even a full regeneration may draw nothing: `update_frame` diffs desired
+   vs. current before touching the glass.
+
+### What defeats the cheap paths
+
+- Buffer changes spanning the window; font changes (force matrix
+  re-dimensioning); `prevent_redisplay_optimizations_p` on the buffer;
+  non-zero `windows_or_buffers_changed`; cursor inside scroll margins.
+- Conditional `(when …)` display specs that depend on point: redisplay
+  re-evaluates them only where it believes text changed — a documented
+  anti-pattern.
+- Change tracking: `beg_unchanged`/`end_unchanged` per buffer bound the
+  region redisplay must reexamine; `force-window-update` and
+  `set-buffer-redisplay` widen it deliberately.
+
+## Fontification / jit-lock interplay
+
+- `fontification-functions` are called *by redisplay itself* (the
+  `fontified` property handler, first in the handler table) just before
+  text is displayed; with font-lock the list is `(jit-lock-function)`.
+- Contract: given POS, fontify from POS (recommended chunk ~400–600 chars),
+  set `fontified` non-nil over what you covered. Text never displayed is
+  never fontified — fontification is lazy and display-driven.
+- Under long-line optimizations (Emacs 29+), fontification functions run
+  narrowed around POS (`long-line-optimizations-in-fontification-functions`).
+
+## Forcing and observing redisplay
+
+- `(redisplay)` attempts immediate redisplay; `(redisplay t)` prevents
+  preemption by pending input; return t only means "attempted".
+  `(sit-for 0)` ≡ `(redisplay)`.
+- `force-window-update OBJECT` marks window(s) for the *next* redisplay.
+  `redraw-frame` / `redraw-display` clear and redraw.
+- Hooks: `pre-redisplay-function` / `pre-redisplay-functions` (per-window,
+  buffer current). `post-command-hook` runs *before* the command loop's
+  redisplay, not after.
+- Redisplay is preempted by pending input — a busy loop that never reads
+  input starves display updates; use `(redisplay t)` or `sit-for` inside.
+- Mode lines: `force-mode-line-update`, and `:eval` forms in
+  `mode-line-format` run during redisplay — keep them cheap and
+  side-effect-free; they can run asynchronously relative to command
+  execution (mouse-highlight/expose paths).
+
+## Echo area essentials
+
+- `message` logs to `*Messages*` (respecting `message-log-max`) and
+  displays in the echo area; `inhibit-message` suppresses display but
+  keeps logging. Always `(message "%s" str)` for literal strings.
+  `set-message-functions` pipeline (`set-minibuffer-message`,
+  `inhibit-message`, `set-multi-message`) routes messages.
+
+## Overlays vs text properties for display (cost model)
+
+- Overlay `priority`: higher wins per attribute; face attributes merge;
+  all overlays outrank text properties. Overlay `before-string`/
+  `after-string`/`display` are interpreted only by redisplay.
+- A *replacing* `display` spec makes redisplay skip covered text entirely
+  (its `invisible` and other properties are then ignored).
+- Invisible text: `buffer-invisibility-spec` + `invisible` property;
+  changing the spec is far cheaper than rewriting properties;
+  `(ATOM . t)` spec entries show an ellipsis.
+
+## Debugging redisplay
+
+- `M-x trace-redisplay` (in builds with `--enable-checking=glyphs`),
+  `dump-glyph-matrix`. Practically: bisect with `redisplay-skip-fontification-on-input`, `jit-lock-defer-time`,
+  and check `(elp-instrument-package "font-lock")` or the `profiler` for
+  fontification hotspots; suspect mode-line `:eval`s and per-window hooks
+  first for "constant CPU while idle".

--- a/.claude/skills/emacs-internals/references/threads-and-build.md
+++ b/.claude/skills/emacs-internals/references/threads-and-build.md
@@ -1,0 +1,86 @@
+# Threads and the build/dump pipeline
+
+Sources: GNU Elisp Reference Manual (Emacs 30.2) Threads chapter and
+Building Emacs / Pure Storage nodes; emacs-devel on the igc/MPS branch.
+
+## Threads (cooperative concurrency)
+
+- Emacs threads are a **limited, mostly-cooperative** form of concurrency.
+  All threads share one heap; effectively a **global lock (GIL-like)** —
+  exactly one thread runs Lisp at a time. The manual states the
+  cooperative-switching contract; "correct programs should not rely on
+  cooperative threading."
+- **Yield points** (the only places a switch can happen): explicit
+  `thread-yield`; waiting for keyboard input or process output (e.g. inside
+  `accept-process-output`); and the blocking ops `mutex-lock`,
+  `condition-wait`, `thread-join`.
+- **No preemption**: a CPU-bound Lisp loop that never hits a yield point
+  starves every other thread and freezes the UI until it yields or blocks.
+  GC stops all threads.
+- **Per-thread state**: dynamic `let` bindings, the current buffer, and the
+  match data are per-thread (the interpreter special-cases dynamic-binding
+  unwinding — you cannot replicate it with `unwind-protect`). Global
+  variable values and lexical closures are *shared*.
+
+### API
+
+- `make-thread FUNCTION &optional NAME` — starts with no let bindings;
+  current buffer inherited from the creator. `current-thread`,
+  `all-threads`, `main-thread`, `threadp`, `thread-live-p`, `thread-name`,
+  `thread-join` (returns the function's value), `thread-yield`.
+- `thread-signal THREAD ERROR-SYMBOL DATA` — deliver a signal into another
+  thread (unblocks it if blocked); **signals to the main thread surface as
+  a message, not a raised error**. `thread-last-error` is a single global
+  slot overwritten by each abnormal exit.
+- Mutexes are **recursive**: `make-mutex`, `mutex-lock`/`mutex-unlock`,
+  and the safe wrapper `with-mutex`. Condition variables:
+  `make-condition-variable`, `condition-wait` (releases the mutex while
+  waiting; loop against a predicate — spurious wakeups happen),
+  `condition-notify`.
+- `list-threads` / the `*Threads*` buffer inspect live threads.
+- Practical guidance: threads are for hiding latency (network, subprocess),
+  not for parallel CPU work. For most config-level concurrency, prefer
+  timers, process filters/sentinels, and `while-no-input` — they interleave
+  with the command loop without the thread caveats.
+
+## Building and dumping Emacs
+
+- The build compiles the C core into a bootstrap executable **`temacs`**,
+  which loads the preloaded Lisp libraries and then *dumps* its state so a
+  normal startup doesn't re-load them.
+- **Portable dumper (pdumper)** is the only supported method in Emacs 30:
+  it writes a `.pdmp` file that the same executable maps at startup.
+  `dump-emacs-portable` performs it; `pdumper-stats` reports whether the
+  session was restored from a dump and the load time. The old **unexec**
+  dumper is deprecated and compiled out by default (`dump-emacs`
+  unavailable).
+- A `.pdmp` is **not portable** — only the exact executable that produced
+  it can load it. This matters for Nix: the Emacs binary and its dump are a
+  matched pair in the same store path.
+- **Delayed initialization**: preloaded code must defer install-path and
+  environment computation to startup (dump time ≠ run time). Escape
+  hatches: `custom-initialize-delay` as a defcustom `:initialize`, and
+  `before-init-hook` / `after-pdump-load-hook`.
+- **Pure storage** (`purecopy`, `purify-flag`, `pure-bytes-used`) was
+  read-only shared memory for preloaded data. Already near-vestigial under
+  pdump; **Emacs 31 (master) removed it entirely** — `purecopy` is a
+  compatibility no-op. Ignore `purecopy` in modern code.
+
+## The igc / MPS garbage-collector branch (status)
+
+- **igc** replaces the classic stop-the-world mark-sweep collector with an
+  **incremental, generational, moving** collector built on Ravenbrook's
+  Memory Pool System (MPS). Build flag `./configure --with-mps`; packaged by
+  emacs-overlay as `emacs-igc` (this repo's `just build-igc`).
+- Authors: Gerd Möllmann, Pip Cet, Helmut Eller, with Eli Zaretskii and
+  Stefan Kangas. History: `scratch/igc` (2024) → `feature/igc` →
+  `feature/igc3` (2026).
+- **Status: igc did NOT make Emacs 31** (feature freeze May 2026); work
+  continues on `feature/igc3`, realistic target Emacs 32. Mainline 30/31
+  keep the classic GC, so the `gc-cons-threshold` tuning in
+  `objects-and-gc.md` applies to the builds this repo ships by default. Under
+  igc, that tuning is largely irrelevant — GC pauses become small and
+  incremental — but object pinning/moving assumptions interact with
+  native-comp and the pdumper, which is why stabilization is slow.
+- Nothing in the threads or compilation APIs changes on the igc branches;
+  MPS addresses GC pause latency, not the single-threaded execution model.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Use the devenv shell; with direnv this is automatic. Without it, prefix commands
 
 Elisp files use `-*- lexical-binding: t; -*-`, one concern per `lisp/init-*.el` module, and end with `(provide 'init-<concern>)`. Add new modules to `init.el` at the right load point. Prefer `setopt` for `defcustom` values. Built-ins and Nix-provided packages in `use-package` blocks should use `:ensure nil`. Keep LSP hooks and formatter wiring centralized in `lisp/init-prog.el`. Nix formatting is controlled by `nix/treefmt.nix` with `nixfmt`, `deadnix`, and `statix`.
 
+For Emacs internals and Elisp practice, use the source-cited skills in `.claude/skills/` (`emacs-internals`, `elisp-dev`), indexed at `.claude/knowledge/emacs/README.md`, rather than answering from memory.
+
 ## Testing Guidelines
 
 Place ERT files under `test/` using `test-*.el` names. Keep tests focused on module behavior or helper functions and load project code with `-L lisp`. Run `just test` for ERT, `just check-elisp` for syntax-only validation, and `just check` before opening a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,31 @@ There's also an `emacs-smoke` script (defined in `devenv.nix`) that byte-compile
 
 - `just bench [output]` — benchmark startup: launches Emacs through `bench/early-init.el` which wraps `require` and `package-refresh-contents` with timing advice, then prints results sorted by load time. Optionally saves to a file.
 
+## Emacs & Elisp knowledge base and skills
+
+Two on-demand skills in `.claude/skills/` hold source-cited reference material
+for this Emacs 30/31 config; `.claude/knowledge/emacs/README.md` indexes them.
+**Use them instead of answering Emacs questions from memory** — each reference
+traces back to the GNU Emacs Lisp Reference Manual, `src/` commentary, or NEWS.
+
+- **`emacs-internals`** — GC & object representation, the gap buffer /
+  markers / overlays, redisplay, the command loop & keymaps, byte & native
+  compilation, threads, and build/dump. Reach for it when explaining or
+  debugging core behavior, tuning performance (GC, redisplay, startup), or
+  reasoning about native-comp / eln caches. Repo anchors it already documents:
+  the `gc-cons-threshold` startup dance and eln-cache redirect in
+  `early-init.el`, and the `igc` build variant.
+- **`elisp-dev`** — naming/file conventions, lexical binding, macro hygiene,
+  hooks vs. advice, `defcustom`/`setopt`, `use-package` patterns, modern
+  libraries (pcase/seq/map/cl-lib/rx), debugging & ERT, and an Emacs 30/31
+  changes digest. Reach for it when writing or reviewing any Elisp.
+
+The skills encode the repo's hard rules (`setopt` not `setq` for options,
+`:ensure nil` for built-ins/Nix packages, no builtins/third-party split,
+warning-clean byte-compilation, LSP/formatters centralized in `init-prog.el`).
+When a note conflicts with the installed Emacs, trust the running Emacs
+(`C-h f`/`C-h v`/`C-h S`) and fix the reference in the same change.
+
 ## Architecture
 
 ### Elisp layer — three parts


### PR DESCRIPTION
## Summary

Adds a source-cited knowledge base and two on-demand **skills** so Emacs and Emacs Lisp questions in this repo are answered from the canonical manuals rather than from memory. Targets Emacs 30/31 (what the repo builds and runs) with version flags throughout.

Research was gathered by deep-reading the GNU Emacs Lisp Reference Manual (Internals appendix, plus the Variables, Macros, Customization, Loading, Modes, Display, Command Loop, Keymaps, Byte/Native Compilation, and Threads chapters), the `src/xdisp.c` and `comp.c`/`comp*.el` commentary, `etc/NEWS.30`/`NEWS.31`, and the native-compilation literature.

## What's added

**`.claude/skills/emacs-internals/`** — how Emacs works underneath:
- `objects-and-gc.md` — Lisp_Object tagging, fixnums/bignums, mark-sweep GC, `gc-cons-threshold`/`gc-cons-percentage` semantics and defaults, stack allocation, pure-space status, igc/MPS
- `buffers-and-text.md` — gap buffer, markers, overlays (interval tree since 29), text properties, buffer-local variables
- `redisplay.md` — glyph matrices, the display iterator, the optimization ladder and what defeats it, jit-lock/fontification
- `command-loop-and-keymaps.md` — the command loop, active-keymap precedence order, remapping/translation, quitting, recursive edit
- `compilation.md` — bytecode, the native-comp pipeline, speed levels and speed-3 semantics, eln-cache layout/invalidation, trampolines
- `threads-and-build.md` — cooperative threads, temacs/pdumper, igc/MPS branch status

**`.claude/skills/elisp-dev/`** — how to write good Elisp here:
- `conventions.md`, `lexical-binding-and-macros.md`, `hooks-advice-loading.md`, `customization.md`, `modern-libraries.md`, `debugging-and-testing.md`, `emacs-30-31-changes.md`

**`.claude/knowledge/emacs/README.md`** indexes both skills and lists primary sources.

The skills encode the repo's existing hard rules (`setopt` not `setq` for options, `:ensure nil` for built-ins/Nix packages, no builtins/third-party split, warning-clean byte-compilation, centralized LSP/formatters) and tie back to repo anchors like the `early-init.el` GC dance and eln-cache redirect.

## Instruction wiring

`CLAUDE.md` and `AGENTS.md` now point agents at the skills and instruct them to prefer the source-cited references over memory, and to fix a reference in-place when it conflicts with the running Emacs.

## Notes

- Docs only — no Elisp or Nix behavior changes, so `just check`/`just compile`/`just test` are unaffected.
- The two `SKILL.md` files are auto-discovered by the Claude Code skill system; the `references/*.md` files load on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188TmS5qWveeoTVGDgGTa7z

---
_Generated by [Claude Code](https://claude.ai/code/session_0188TmS5qWveeoTVGDgGTa7z)_