### PR TITLE
Make the modern dev-workflow uniform across languages

### DIFF
--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -329,7 +329,10 @@ basedpyright/pyright, then pylsp.  Resolved at connect time in the project env."
                                typescript-mode typescript-ts-mode
                                python-mode python-ts-mode
                                tuareg-mode
-                               zig-ts-mode))
+                               zig-ts-mode
+                               c-mode c++-mode c-ts-mode c++-ts-mode
+                               nix-ts-mode
+                               haskell-mode))
                   (eglot-inlay-hints-mode 1)))))
 
   ;; Server overrides — most languages don't need an entry, eglot has

--- a/lisp/init-project.el
+++ b/lisp/init-project.el
@@ -115,7 +115,7 @@ projects sharing a basename across different roots stay distinct."
   :commands (compile-multi)
   :custom
   (compile-multi-config
-   '((go-ts-mode   . (("go test"         . "go test ./...")
+   `((go-ts-mode   . (("go test"         . "go test ./...")
                       ("go test current" . "go test .")
                       ("go test -race"   . "go test -race ./...")
                       ("go build"        . "go build ./...")
@@ -124,8 +124,17 @@ projects sharing a basename across different roots stay distinct."
                       ("golangci-lint"   . "golangci-lint run")))
      (go-mod-ts-mode . (("go mod tidy"     . "go mod tidy")
                         ("go mod download" . "go mod download")))
-     (python-mode  . (("pytest"         . "pytest")
-                      ("pytest file"    . "pytest %file-name%")))
+     ;; `python-base-mode' is the shared parent of both `python-mode' and
+     ;; `python-ts-mode', so this fires regardless of which one a .py buffer
+     ;; lands in (the repo routes to python-ts-mode, but a missing grammar
+     ;; falls back to python-mode).  "pytest file" is a function action so
+     ;; the current file is substituted at run time — compile-multi does not
+     ;; template `%…%' placeholders.
+     (python-base-mode . (("pytest"      . "pytest")
+                          ("pytest file" . ,(lambda ()
+                                              (concat "pytest "
+                                                      (shell-quote-argument
+                                                       (or (buffer-file-name) ".")))))))
      (haskell-mode . (("stack test"     . "stack test")
                       ("cabal test"     . "cabal test")))
      (tuareg-mode  . (("dune build"     . "dune build")
@@ -145,7 +154,20 @@ projects sharing a basename across different roots stay distinct."
                       ("cargo build"    . "cargo build")))
      (zig-ts-mode  . (("zig build"      . "zig build")
                       ("zig test"       . "zig build test")
-                      ("zig run"        . "zig build run"))))))
+                      ("zig run"        . "zig build run")))
+     ;; TypeScript / JavaScript — a list trigger is `eval'd by compile-multi,
+     ;; so this one entry covers all three ts-modes.  Neutral `npm' scripts;
+     ;; concrete commands are overridden per project via projection /
+     ;; .dir-locals.el.
+     ((apply #'derived-mode-p '(typescript-ts-mode tsx-ts-mode js-ts-mode))
+      . (("npm test"  . "npm test")
+         ("npm build" . "npm run build")
+         ("npm lint"  . "npm run lint")))
+     ;; C / C++ — CMake / CTest, mirroring the Meson entries above.
+     ((apply #'derived-mode-p '(c-mode c++-mode c-ts-mode c++-ts-mode))
+      . (("cmake configure" . "cmake -B build")
+         ("cmake build"     . "cmake --build build")
+         ("ctest"           . "ctest --test-dir build --output-on-failure"))))))
 
 ;;; @doc Renders compile-multi pickers through consult — gives you
 ;;; orderless filtering and preview on every "what command should I


### PR DESCRIPTION
## Context

This started as a research question: **does the config enable a "modern developer workflow", and is that workflow enabled uniformly across all supported languages?**

**Answer to "does it enable a modern workflow": yes, and coherently.** LSP (`eglot`), format-on-save (`apheleia`), diagnostics (`flymake`), completion (`corfu`/`cape`), snippets (`tempel` + `eglot-tempel`), debugging (`dape`), tree-sitter, project/VC are all present and wired.

**The key strength — the substrate is uniform by design.** There is deliberately no per-language `eglot-ensure` list: `jotain-prog--maybe-eglot-ensure` (on `prog-mode-hook`) auto-starts eglot for *any* project buffer whose server is on the devenv PATH, and `apheleia`/`flymake`/`corfu`/`dape` are global. Enabling `languages.X.enable` in a project's devenv lights up the full workflow with zero per-language Elisp.

**Where it was *not* uniform** — three hand-curated opt-in lists that a new language only joins by hand-editing. This PR closes those gaps.

## Changes

**`lisp/init-project.el` — `compile-multi`**
- **Fix the dead Python entry (real defect).** It was keyed on `python-mode`, but `.py` buffers open in `python-ts-mode` (via `major-mode-remap-alist`), so the pytest commands never appeared in the picker. Re-keyed to `python-base-mode` (the shared parent of both modes). Also replaced `"pytest %file-name%"` — `compile-multi` does not template `%…%` and would have run that literal string — with a function action that substitutes the current file at run time. (This is Finding #2 in `docs/reviews/2026-07-deep-research-review.md`.)
- **Add missing command sets:** TypeScript/JavaScript (`npm test`/`build`/`lint`) and C/C++ (CMake configure/build, CTest). Both use list triggers (`eval`'d by compile-multi) so one entry covers a family of ts-modes.

**`lisp/init-prog.el` — inlay hints**
- Extended the opt-in list to **C/C++, Nix, and Haskell**. clangd, nixd, and HLS all advertise `inlayHintProvider`; for any server that doesn't, `eglot-inlay-hints-mode` is simply a no-op.

**Formatters — audited, no change needed.**
Apheleia's shipped default `apheleia-mode-alist` already maps every remaining supported language (`nix-ts-mode`→nixfmt, `terraform-mode`→opentofu, `sql-mode`→pgformatter, `yaml(-ts)-mode`→prettier-yaml, `web-mode`→prettier, plus css/json/python/rust/ocaml/go/ts). The four explicit mappings this config already adds — meson, zig, goimports, buildifier — are exactly the cases those defaults miss. Format-on-save is therefore already uniform; the terraform→tofu / dockerfile→dprint binary choices are the deliberate PATH/project concern.

## Verification

No Nix/Emacs toolchain is available in the session container, so this was checked by:
- comment/string/char-literal-aware paren balance on both edited files (balanced, never negative),
- confirming the `compile-multi` trigger/action contract and apheleia's default alist against upstream sources.

CI (`nix flake check` → elisp byte-compile with warnings-as-errors) will validate on this PR. Recommended manual spot-checks once merged into a dev shell:
- open a `.py` file in a project → `M-x compile-multi` now shows the pytest entries (previously absent); "pytest file" targets the current file, not a literal `%file-name%`;
- open a C/C++, `.nix`, or `.hs` file whose LSP server is on PATH → `eglot-inlay-hints-mode` is active;
- open a `.ts` and a C/C++ file → the new command sets appear in the picker.

## Follow-up (not in this PR)

An ERT test asserting every supported major mode has a `compile-multi-config` entry would have caught the Python defect; worth adding once `test/` grows an eglot/compile harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8Y7FHKypqFfavkEBpX6R3

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8Y7FHKypqFfavkEBpX6R3)_