### PR TITLE
completion: apply cape learnings — TAB trigger and Elisp symbol capf

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -456,6 +456,15 @@ Frecency-ranked directory jump (like the shell zoxide). Adds
 visited files automatically; M-g z surfaces the most-recent
 matches first.
 
+### `emacs` *(built-in / Nix)*
+
+`tab-always-indent' = `complete' turns TAB into the single
+trigger for the whole completion stack: it indents the line when
+indentation is pending and otherwise summons corfu with every
+`completion-at-point-functions' entry — the major mode's own capf
+plus the cape fallbacks wired up below. Auto-completion still fires
+on its own, but this gives an explicit, muscle-memory trigger.
+
 ### `corfu`
 
 In-buffer completion popup — the corfu equivalent of company.
@@ -472,7 +481,12 @@ corfu.
 
 Completion-at-point Extensions — extra capf functions (dabbrev,
 file path, keyword) that feed corfu when the major mode's own
-capf finds nothing useful.
+capf finds nothing useful. These three go on the *global*
+`completion-at-point-functions' so they act as fallbacks after the
+buffer-local, major-mode capfs run. `cape-elisp-symbol' is instead
+added buffer-locally in Elisp buffers, where it completes symbols
+even inside comments and docstrings (out there `elisp-completion-at-point'
+only fires in code), without polluting completion elsewhere.
 
 ## `init-navigation.el` — dired, project, windows
 

--- a/lisp/init-completion.el
+++ b/lisp/init-completion.el
@@ -244,6 +244,17 @@
 
 ;;;; In-buffer completion
 
+;;; @doc `tab-always-indent' = `complete' turns TAB into the single
+;;; trigger for the whole completion stack: it indents the line when
+;;; indentation is pending and otherwise summons corfu with every
+;;; `completion-at-point-functions' entry — the major mode's own capf
+;;; plus the cape fallbacks wired up below. Auto-completion still fires
+;;; on its own, but this gives an explicit, muscle-memory trigger.
+(use-package emacs
+  :ensure nil
+  :custom
+  (tab-always-indent 'complete))
+
 ;;; @doc In-buffer completion popup — the corfu equivalent of company.
 ;;; Auto-triggered after 2 chars so it feels like a modern editor
 ;;; without a long delay.
@@ -266,17 +277,31 @@
 
 ;;; @doc Completion-at-point Extensions — extra capf functions (dabbrev,
 ;;; file path, keyword) that feed corfu when the major mode's own
-;;; capf finds nothing useful.
+;;; capf finds nothing useful. These three go on the *global*
+;;; `completion-at-point-functions' so they act as fallbacks after the
+;;; buffer-local, major-mode capfs run. `cape-elisp-symbol' is instead
+;;; added buffer-locally in Elisp buffers, where it completes symbols
+;;; even inside comments and docstrings (out there `elisp-completion-at-point'
+;;; only fires in code), without polluting completion elsewhere.
 (use-package cape
   :demand t
-  :functions (cape-dabbrev cape-file cape-keyword)
+  :functions (cape-dabbrev cape-file cape-keyword cape-elisp-symbol)
   :custom
   (cape-file-directory-must-exist t)
   (cape-file-prefix '("~" "/" "./" "../"))
   :init
   (add-hook 'completion-at-point-functions #'cape-dabbrev)
   (add-hook 'completion-at-point-functions #'cape-file)
-  (add-hook 'completion-at-point-functions #'cape-keyword))
+  (add-hook 'completion-at-point-functions #'cape-keyword)
+  (defun jotain-cape-setup-elisp ()
+    "Add `cape-elisp-symbol' as an Elisp fallback capf.
+The positive depth appends it after the mode's own
+`elisp-completion-at-point', so in code the richer built-in wins and
+`cape-elisp-symbol' only kicks in where the built-in returns nil —
+comments and docstrings."
+    (add-hook 'completion-at-point-functions #'cape-elisp-symbol 90 t))
+  (add-hook 'emacs-lisp-mode-hook #'jotain-cape-setup-elisp)
+  (add-hook 'lisp-interaction-mode-hook #'jotain-cape-setup-elisp))
 
 (provide 'init-completion)
 ;;; init-completion.el ends here


### PR DESCRIPTION
Applies the two learnings from the emacsredux post [*Cape, corfu's best friend*](https://emacsredux.com/blog/2026/07/13/cape-corfus-best-friend/) that this config was still missing. The core of the post — `cape-dabbrev` / `cape-file` / `cape-keyword` on `completion-at-point-functions` — was already wired up in `init-completion.el`; this PR adds the rest.

## Changes

- **`tab-always-indent` → `complete`** (new built-in `use-package emacs` block). The post's headline "Tips and Tricks" item: TAB indents the line when indentation is pending and otherwise summons corfu with the whole capf stack (major-mode capf + the cape fallbacks). Auto-completion still fires on its own; this just adds an explicit, muscle-memory trigger.
- **`cape-elisp-symbol` as an Elisp fallback capf.** Added buffer-locally in `emacs-lisp-mode` / `lisp-interaction-mode` so Elisp symbols complete inside comments and docstrings, where the built-in `elisp-completion-at-point` doesn't fire. It's appended with a positive hook depth so the richer built-in still wins in code, and it stays out of every non-Elisp buffer.

## Notes

- Follows the repo conventions: `setopt`-equivalent `:custom` for the `defcustom`, `:ensure nil` for the built-in block, cape functions declared in `:functions` to keep byte-compilation warning-clean.
- Ordering was deliberately chosen so `cape-elisp-symbol` complements rather than shadows `elisp-completion-at-point` (fallback via depth `90`, buffer-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjAYvi691FZXAVRpb1XF6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjAYvi691FZXAVRpb1XF6h)_