### PR TITLE
prog: show only most severe flymake diagnostic at end-of-line

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -725,7 +725,8 @@ commands carry repeat-maps, so `C-x C-a n n n` keeps stepping.
 
 Built-in inline diagnostic display. Indicator chars (! ? ·) and
 end-of-line message rendering keep diagnostics legible without
-opening a side window. M-n / M-p navigate.
+opening a side window: `short` shows only the most severe diagnostic
+per line, so a busy line stays readable. M-n / M-p navigate.
 
 ### `eldoc` *(built-in / Nix)*
 

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -725,7 +725,7 @@ commands carry repeat-maps, so `C-x C-a n n n` keeps stepping.
 
 Built-in inline diagnostic display. Indicator chars (! ? ·) and
 end-of-line message rendering keep diagnostics legible without
-opening a side window: `short` shows only the most severe diagnostic
+opening a side window: `short' shows only the most severe diagnostic
 per line, so a busy line stays readable. M-n / M-p navigate.
 
 ### `eldoc` *(built-in / Nix)*

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -430,14 +430,17 @@ connection alongside any existing language server."
 
 ;;; @doc Built-in inline diagnostic display. Indicator chars (! ? ·) and
 ;;; end-of-line message rendering keep diagnostics legible without
-;;; opening a side window. M-n / M-p navigate.
+;;; opening a side window: `short' shows only the most severe diagnostic
+;;; per line, so a busy line stays readable. M-n / M-p navigate.
 (use-package flymake
   :ensure nil
   :hook (prog-mode . flymake-mode)
   :custom
   (flymake-fringe-indicator-position 'left-fringe)
   (flymake-suppress-zero-counters t)
-  (flymake-show-diagnostics-at-end-of-line t) ; Built-in inline display
+  ;; `short' (Flymake 1.3.6+): only the most severe diagnostic per line at
+  ;; end-of-line. Keeps busy lines legible vs. `t', which stacks them all.
+  (flymake-show-diagnostics-at-end-of-line 'short)
   (flymake-margin-indicators-string
    '((error   "!" compilation-error)
      (warning "?" compilation-warning)


### PR DESCRIPTION
## What

Switch `flymake-show-diagnostics-at-end-of-line` from `t` to `'short` in `lisp/init-prog.el`.

## Why

Implements the learning from [emacsredux: *Flymake can now show diagnostics at the end of the line*](https://emacsredux.com/blog/2026/07/20/flymake-can-now-show-diagnostics-at-the-end-of-the-line/).

The variable accepts more than a boolean (Flymake 1.3.6+):

| Value | Behavior |
|-------|----------|
| `nil` | no end-of-line diagnostics |
| `short` | only the **most severe** diagnostic per line |
| `t` | **all** diagnostics for the line, stacked |
| `fancy` | all diagnostics laid out below the line with Unicode graphics |

The config was already rendering diagnostics at end-of-line (`t`), but stacking every diagnostic for a line works against this module's stated goal of keeping inline diagnostics *legible without opening a side window*. `'short` shows just the most severe issue per line, so a busy line stays readable while the full set is still reachable via `C-c ! l` / `M-n` / `M-p`.

## Changes

- `lisp/init-prog.el` — `flymake-show-diagnostics-at-end-of-line` → `'short`; updated the `@doc` marker and added an inline note on the value semantics.
- `docs/configuration/package-reference.mdx` — refreshed the derived `flymake` entry to match the `@doc` text.

## Testing

No local Nix/Emacs toolchain is available in this environment to run `just check-elisp`; CI (`nix flake check`) exercises paren-check and warnings-as-errors byte-compilation. The change is a single-symbol value swap plus comment/doc updates. `'short` degrades gracefully on older Flymake (any non-nil value shows diagnostics at end-of-line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wyEKpf9V9VuK6BCiQcwje

---
_Generated by [Claude Code](https://claude.ai/code/session_011wyEKpf9V9VuK6BCiQcwje)_