### PR TITLE
writing: drive jinx from global-jinx-mode

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -986,8 +986,15 @@ text-mode buffer and opted out of the column-sensitive ones: YAML
 ### `jinx`
 
 Just-in-time spell check using enchant — no on-save scan, no
-per-buffer flyspell setup. M-$ corrects the word at point;
-C-M-$ switches dictionaries.
+per-buffer flyspell setup. `global-jinx-mode' replaces both
+`flyspell-mode' and `flyspell-prog-mode' in one shot: jinx keys off
+faces, so in a code buffer it checks only comments and strings and
+leaves the code alone, no `flyspell-prog-mode' equivalent needed.
+Enabled from `emacs-startup' rather than a bag of per-mode hooks so
+prose *and* code get checked. M-$ corrects the word at point
+(C-u M-$ walks every misspelling); C-M-$ switches dictionaries.
+Data/config buffers that only look like prose opt back out in
+init-lang-data.
 
 ### `markdown-mode`
 

--- a/journal/2026-07-20.md
+++ b/journal/2026-07-20.md
@@ -1,0 +1,60 @@
+# 2026-07-20
+
+## Spell-check: switch jinx to `global-jinx-mode`
+
+### Summary
+
+Applied the learnings from Emacs Redux's
+["Replacing Flyspell with Jinx"](https://emacsredux.com/blog/2026/07/13/replacing-flyspell-with-jinx/).
+Jotain already spell-checks with jinx rather than flyspell, so the migration
+itself was done long ago; the piece still missing was the post's central
+recommendation — drive jinx from **`global-jinx-mode`** instead of a handful of
+per-mode hooks.
+
+### Change
+
+- **`lisp/init-writing.el`** — the `jinx` `use-package` block replaced its
+  `:hook ((text-mode . jinx-mode) (org-mode . jinx-mode))` pair with a single
+  `:hook (emacs-startup . global-jinx-mode)`. Keybindings (`M-$` →
+  `jinx-correct`, `C-M-$` → `jinx-languages`) are unchanged.
+
+### Why
+
+- **One mode replaces two.** `global-jinx-mode` subsumes both `flyspell-mode`
+  and `flyspell-prog-mode`. Jinx decides *what* to check by **face**, so in a
+  programming buffer it limits itself to comments and strings automatically —
+  no separate prog-mode variant, no per-language hooks.
+- **Code comments/docstrings are now checked.** The old per-mode hooks fired
+  only in `text-mode` (and, redundantly, `org-mode`, which already derives from
+  `text-mode`). Prose was covered; typos in comments and docstrings across every
+  `prog-mode` buffer went unchecked. Global mode closes that gap — this was
+  Finding 4/11 of the 2026-07 deep-research review.
+- **Redundant hook dropped.** `(org-mode . jinx-mode)` was a no-op on top of the
+  `text-mode` hook; folding everything into the global mode removes it.
+
+### Interaction with `init-lang-data.el`
+
+Data/config buffers that merely *derive* from `text-mode` but read as code —
+YAML in particular — still want jinx off. `jotain-lang-data--enable-prog-mode-features`
+already turns it back off unconditionally
+(`(when (bound-and-true-p jinx-mode) (jinx-mode -1))`). Ordering still holds
+under global mode: `global-jinx-mode` enables jinx during
+`after-change-major-mode-hook`, then the mode's own `yaml-mode-hook` runs the
+opt-out afterward, so those buffers end up jinx-free exactly as before.
+
+### Docs
+
+- **`docs/configuration/package-reference.mdx`** — regenerated body text to
+  match the updated `;;; @doc` block on the jinx form (hand-synced; no Nix in
+  this environment to run `just docs-refresh-packages`). The
+  `packages-doc-in-sync` flake check compares byte-for-byte against the `@doc`
+  markers, so this must track the source comment exactly.
+
+### Not changed (deployment-dependent, pre-existing)
+
+- **`Jinx: No dictionaries available for "en_US"`** on hosts whose enchant has
+  no en_US backend. Global mode surfaces this in more buffers than the old
+  text-mode-only hooks did, but it is the same deployment gap noted on
+  2026-06-09 — the Nix-wrapped `jotainEmacsPackages` ships the dictionary; a
+  bare host still needs a hunspell/nuspell dict on `DICPATH`. No config change
+  belongs here.

--- a/lisp/init-writing.el
+++ b/lisp/init-writing.el
@@ -45,11 +45,17 @@
          (message-mode     . jotain-writing--keep-monospace)))
 
 ;;; @doc Just-in-time spell check using enchant — no on-save scan, no
-;;; per-buffer flyspell setup. M-$ corrects the word at point;
-;;; C-M-$ switches dictionaries.
+;;; per-buffer flyspell setup. `global-jinx-mode' replaces both
+;;; `flyspell-mode' and `flyspell-prog-mode' in one shot: jinx keys off
+;;; faces, so in a code buffer it checks only comments and strings and
+;;; leaves the code alone, no `flyspell-prog-mode' equivalent needed.
+;;; Enabled from `emacs-startup' rather than a bag of per-mode hooks so
+;;; prose *and* code get checked. M-$ corrects the word at point
+;;; (C-u M-$ walks every misspelling); C-M-$ switches dictionaries.
+;;; Data/config buffers that only look like prose opt back out in
+;;; init-lang-data.
 (use-package jinx
-  :hook ((text-mode . jinx-mode)
-         (org-mode  . jinx-mode))
+  :hook (emacs-startup . global-jinx-mode)
   :bind (("M-$"   . jinx-correct)
          ("C-M-$" . jinx-languages)))
 


### PR DESCRIPTION
## What & why

Applies the central learning from Emacs Redux's [*Replacing Flyspell with Jinx*](https://emacsredux.com/blog/2026/07/13/replacing-flyspell-with-jinx/). Jotain already spell-checks with jinx rather than flyspell, so the migration itself was done long ago — the missing piece was the post's key recommendation: drive jinx from **`global-jinx-mode`** instead of a bag of per-mode hooks.

`lisp/init-writing.el` — the `jinx` `use-package` block swaps

```elisp
:hook ((text-mode . jinx-mode)
       (org-mode  . jinx-mode))
```

for

```elisp
:hook (emacs-startup . global-jinx-mode)
```

Keybindings are unchanged (`M-$` → `jinx-correct`, `C-M-$` → `jinx-languages`).

### Why this is the right shape

- **One mode replaces two.** `global-jinx-mode` subsumes both `flyspell-mode` and `flyspell-prog-mode`. Jinx decides *what* to check by **face**, so in a programming buffer it limits itself to comments and strings automatically — no prog-mode variant, no per-language hooks.
- **Comments/docstrings are now checked.** The old hooks fired only in `text-mode` (and, redundantly, `org-mode`, which already derives from `text-mode`). Prose was covered; typos in comments and docstrings across every `prog-mode` buffer went unchecked. Global mode closes that gap — this was Finding 4/11 of the 2026-07 deep-research review.
- **Redundant hook dropped.** `(org-mode . jinx-mode)` was a no-op on top of the `text-mode` hook.

### Interaction with `init-lang-data.el`

Code-shaped config buffers that merely *derive* from `text-mode` (YAML in particular) still want jinx off. `jotain-lang-data--enable-prog-mode-features` already turns it back off unconditionally. Ordering still holds under global mode: `global-jinx-mode` enables jinx during `after-change-major-mode-hook`, then the mode's own hook runs the opt-out afterward — those buffers end up jinx-free exactly as before.

## Changes

- `lisp/init-writing.el` — jinx now enabled via `global-jinx-mode` on `emacs-startup`; `@doc` block updated to explain it.
- `docs/configuration/package-reference.mdx` — regenerated body to match the updated `@doc` block (hand-synced; no Nix in the build environment to run `just docs-refresh-packages`). The `packages-doc-in-sync` flake check compares byte-for-byte, so this must track the source comment exactly.
- `journal/2026-07-20.md` — change log entry.

## Notes / not changed

- The `Jinx: No dictionaries available for "en_US"` situation on hosts whose enchant lacks an en_US backend is a pre-existing, deployment-dependent gap (noted 2026-06-09). Global mode surfaces it in more buffers, but the fix belongs at the deployment layer (the Nix-wrapped `jotainEmacsPackages` ships the dictionary); no config change belongs in this PR.

## Verification

- Elisp block re-read for balanced parens; no `emacs`/`nix` available in this environment to run `just compile` / `nix flake check` locally — relying on CI (`check` + `test` jobs) to gate byte-compilation and the docs-in-sync check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLQLfKhZhNiZJ8Xa7XKwhM)_