### PR TITLE
Document Embark workflows and action-menu tips

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -435,15 +435,27 @@ replaces a dozen built-ins with a single, consistent UI.
 
 ### `embark`
 
-Right-click for the keyboard. C-. on any candidate (file,
-symbol, region, command name) opens a menu of actions valid for
-that thing. C-h B replaces describe-bindings with a paged view.
+Right-click for the keyboard. `C-.' (embark-act) on any
+candidate — file, symbol, region, buffer, command name, URL —
+opens a menu of actions valid for that thing; `C-;' (embark-dwim)
+skips the menu and runs the default action (visit the file, browse
+the URL, jump to the definition). Press `C-h' after `C-.' to turn
+the menu into a searchable `completing-read' — the best way to
+discover what applies. Inside the menu `i'/`w' insert or copy the
+candidate, `A' (embark-act-all) acts on every candidate at once,
+and `B' (embark-become) re-runs the typed input through another
+command; `C-u C-.' keeps the minibuffer open for successive
+actions. `C-h B' replaces describe-bindings with a paged view.
 
 ### `embark-consult`
 
-Glue between embark and consult — exports a consult result
-list (e.g. consult-ripgrep) into a grep buffer with C-c C-o for
-the classic search → wgrep refactor flow.
+Glue between embark and consult — teaches `embark-export' to
+turn a consult result list into the right major mode: consult-grep
+and consult-ripgrep become a grep buffer, consult-line an occur
+buffer, file candidates a dired buffer, buffer candidates an
+ibuffer buffer. The grep/ripgrep export is the classic search →
+`C-c C-o' → wgrep (`C-x C-q') refactor flow that edits every match
+in place across all the matched files.
 
 ### `avy`
 

--- a/docs/keybindings.mdx
+++ b/docs/keybindings.mdx
@@ -71,6 +71,9 @@ window switching, spell-check, region growth, and multi-cursor.
 | `C-=` | `expreg-expand` |
 | `C->` | `mc/mark-next-like-this` |
 | `C-<` | `mc/mark-previous-like-this` |
+| `C-.` | `embark-act` |
+| `C-;` | `embark-dwim` |
+| `C-h B` | `embark-bindings` |
 
 ## Disabled by default
 
@@ -87,6 +90,40 @@ A few major modes rebind `C-c` leaves locally:
 - `helpful-mode`: `C-c C-d` → `helpful-at-point`
 - `sops-mode`: `C-c C-c` save, `C-c C-k` cancel, `C-c C-d` edit
 - `embark` exports: `C-c C-o` → `embark-export`
+
+## Embark action menu
+
+`C-.` (`embark-act`) opens a keyboard-driven "right-click" menu of the
+actions that apply to the thing at point — a minibuffer candidate, a
+file name, a buffer, a URL, an Elisp symbol, the active region. `C-;`
+(`embark-dwim`) skips the menu and runs the default action. The keys
+below are pressed *after* `C-.`, inside the action menu:
+
+| Key | Action |
+| --- | --- |
+| `C-h` | Searchable `completing-read` of every applicable action — the discovery entry point |
+| `E` | `embark-export` — promote the candidate set to a buffer (grep for ripgrep/grep, occur for `consult-line`, dired for files, ibuffer for buffers) |
+| `A` | `embark-act-all` — run one action on *every* current candidate |
+| `B` | `embark-become` — re-run the input you typed through a different command |
+| `i` | Insert the candidate into the buffer you came from |
+| `w` | Copy the candidate to the kill-ring |
+
+Two habits worth forming:
+
+- **Search → edit.** `consult-ripgrep` → `C-. E` exports to a grep
+  buffer, then `C-x C-q` (`wgrep`) makes it editable so you can rewrite
+  every match in place and save across all files at once.
+- **Keep the session alive.** Acting on a candidate exits the
+  minibuffer by default; call it with a prefix (`C-u C-.`) to stay in
+  the minibuffer for successive actions — handy for deleting or
+  renaming several files in a row.
+
+Because Embark resolves candidate paths through `project.el`, the full
+file-action arsenal (`w` copy path, `r` rename, `d` delete, `j` jump to
+dired) works directly on the project-relative candidates of
+`project-find-file` without a dired detour. `embark-become`'s file map
+already offers `p` for `project-find-file`, so `C-. B p` re-runs a
+plain `C-x C-f` input through the project finder.
 
 ## Window navigation
 

--- a/lisp/init-completion.el
+++ b/lisp/init-completion.el
@@ -195,9 +195,17 @@
 
 ;;;; Embark — actions on anything
 
-;;; @doc Right-click for the keyboard. C-. on any candidate (file,
-;;; symbol, region, command name) opens a menu of actions valid for
-;;; that thing. C-h B replaces describe-bindings with a paged view.
+;;; @doc Right-click for the keyboard. `C-.' (embark-act) on any
+;;; candidate — file, symbol, region, buffer, command name, URL —
+;;; opens a menu of actions valid for that thing; `C-;' (embark-dwim)
+;;; skips the menu and runs the default action (visit the file, browse
+;;; the URL, jump to the definition). Press `C-h' after `C-.' to turn
+;;; the menu into a searchable `completing-read' — the best way to
+;;; discover what applies. Inside the menu `i'/`w' insert or copy the
+;;; candidate, `A' (embark-act-all) acts on every candidate at once,
+;;; and `B' (embark-become) re-runs the typed input through another
+;;; command; `C-u C-.' keeps the minibuffer open for successive
+;;; actions. `C-h B' replaces describe-bindings with a paged view.
 (use-package embark
   :bind
   (("C-."   . embark-act)
@@ -213,9 +221,13 @@
                  nil
                  (window-parameters (mode-line-format . none)))))
 
-;;; @doc Glue between embark and consult — exports a consult result
-;;; list (e.g. consult-ripgrep) into a grep buffer with C-c C-o for
-;;; the classic search → wgrep refactor flow.
+;;; @doc Glue between embark and consult — teaches `embark-export' to
+;;; turn a consult result list into the right major mode: consult-grep
+;;; and consult-ripgrep become a grep buffer, consult-line an occur
+;;; buffer, file candidates a dired buffer, buffer candidates an
+;;; ibuffer buffer. The grep/ripgrep export is the classic search →
+;;; `C-c C-o' → wgrep (`C-x C-q') refactor flow that edits every match
+;;; in place across all the matched files.
 (use-package embark-consult
   :after (embark consult)
   :hook (embark-collect-mode . consult-preview-at-point-mode)


### PR DESCRIPTION
Applies the learnings from emacsredux's ["All aboard Embark"](https://emacsredux.com/blog/2026/07/14/all-aboard-embark/) article.

The core setup the article recommends was **already in place** in this config — `embark` and `embark-consult` with the `C-.` / `C-;` / `C-h B` bindings, `prefix-help-command` → `embark-prefix-help-command`, `wgrep`, and (per the article's footnote) `project.el`-based path resolution so file actions work on `project-find-file` candidates. So the actual gap was documentation of the workflows the article highlights.

## Changes

**`lisp/init-completion.el`** — expanded the `embark` and `embark-consult` `@doc` markers to cover:
- `embark-dwim` (default action) alongside `embark-act`
- the searchable `C-h` action menu (best discovery path)
- `embark-act-all` (`A`), `embark-become` (`B`), and insert/copy (`i`/`w`)
- the full set of `embark-export` targets — grep (ripgrep/grep), occur (`consult-line`), dired (files), ibuffer (buffers) — not just the grep case

**`docs/configuration/package-reference.mdx`** — refreshed to match the new `@doc` markers (kept byte-identical to what `just docs-refresh-packages` produces so the `packages-doc-in-sync` check passes).

**`docs/keybindings.mdx`**:
- added the global `C-.` / `C-;` / `C-h B` bindings to the "Other global bindings" table (they were previously undocumented)
- added a new **"Embark action menu"** section documenting the in-menu keys, the search → `C-. E` → `wgrep` edit-in-place flow, `C-u C-.` to keep the minibuffer alive for successive actions, and how the file-action arsenal works on `project-find-file` candidates via `project.el`

## Notes

- Docs-only change; the elisp edits touch `;;;` comment blocks only, so byte-compilation and the paren check are unaffected.
- The Nix toolchain isn't available in this environment, so `package-reference.mdx` was updated by hand to match the generator's verbatim strip-and-join of the `@doc` lines; the `packages-doc-in-sync` CI check will confirm parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNovC7fp7QH8g3kVfRYgtE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNovC7fp7QH8g3kVfRYgtE)_