### PR TITLE
docs: expose topical Jotain entries under the Emacs Info category

### DIFF
--- a/docs/jotain.texi
+++ b/docs/jotain.texi
@@ -14,7 +14,9 @@ Copyright @copyright{} Markus Jylh@"ankangas.
 
 @dircategory Emacs
 @direntry
-* Jotain: (jotain).             Jotain Emacs configuration.
+* Jotain: (jotain).                          Jotain Emacs configuration.
+* Jotain Keybindings: (jotain)Keybindings.   Prefix conventions and the namespace map.
+* Jotain Options: (jotain)Module Options.    Nix module option reference.
 @end direntry
 
 @titlepage


### PR DESCRIPTION
## What

Enrich the Jotain manual's `@direntry` block in `docs/jotain.texi` with two topical entries so the **Keybindings** and **Module Options** nodes are reachable directly from the top-level Info directory:

```texinfo
@dircategory Emacs
@direntry
* Jotain: (jotain).                          Jotain Emacs configuration.
* Jotain Keybindings: (jotain)Keybindings.   Prefix conventions and the namespace map.
* Jotain Options: (jotain)Module Options.    Nix module option reference.
@end direntry
```

## Why

The manual already declares `@dircategory Emacs`, the same category the GNU Emacs manual uses, so `install-info` (run in `nix/info-manual.nix`) files Jotain under the **"Emacs" heading of the top-level Info directory** — right next to `Emacs`, `Emacs FAQ`, and `Emacs Lisp Intro` in `C-h i`. This is the supported way to "extend" the Emacs doc set.

Injecting an entry into the Emacs manual's *own* `* Menu:` is not possible here: that menu lives inside `emacs.info` in the read-only Nix store, and patching it would break the cache-parity invariant. The extra `@direntry` lines are the one lever we have — they give Jotain a richer footprint under the Emacs category without touching the Emacs derivation.

## Notes

- Both target nodes (`Keybindings`, `Module Options`) already exist in `docs/jotain.texi`.
- Pure Texinfo metadata change; no Elisp or Nix build-graph changes. `nix/info-manual.nix` regenerates `jotain.info` + the `dir` entry from this source unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9UetVKcXqNXMb5wuAWMrB

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9UetVKcXqNXMb5wuAWMrB)_