### PR TITLE
completion: TAB indents, RET newlines, C-M-i completes

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -453,18 +453,24 @@ matches first.
 
 ### `emacs` *(built-in / Nix)*
 
-`tab-always-indent' = `complete' turns TAB into the single
-trigger for the whole completion stack: it indents the line when
-indentation is pending and otherwise summons corfu with every
-`completion-at-point-functions' entry — the major mode's own capf
-plus the cape fallbacks wired up below. Auto-completion still fires
-on its own, but this gives an explicit, muscle-memory trigger.
+`tab-always-indent' = t is the stock Emacs default, restored here
+deliberately: TAB indents the line and does nothing else.
+`indent-for-tab-command's only call to `completion-at-point' is
+guarded by (eq tab-always-indent 'complete), so with t that branch is
+unreachable and TAB provably cannot summon a capf. Completion lives on
+`C-M-i' instead (`jotain-completion-key'). `tab-first-completion' is
+inert unless `tab-always-indent' is `complete', so it is irrelevant
+here and is never set.
 
 ### `corfu`
 
 In-buffer completion popup — the corfu equivalent of company.
-Auto-triggered after 2 chars so it feels like a modern editor
-without a long delay.
+The popup appears on its own only in the modes listed by
+`jotain-completion-auto-modes' (default: programming modes), so prose
+stays quiet and completes only when asked via `C-M-i'. RET and TAB are
+unbound in `corfu-map', so Enter always inserts a newline and TAB
+always indents, even while the popup is showing. `M-n'/`M-p' move,
+`C-g' dismisses, `C-M-i' accepts.
 
 ### `corfu-history` *(built-in / Nix)*
 
@@ -1251,7 +1257,11 @@ format-on-save runs `zig fmt' through apheleia.
 Lightweight template/snippet engine from the corfu/cape author.
 Templates are read from `templates/*.eld' (keyed by major mode);
 `M-+' completes a snippet by name, `M-*' inserts one interactively,
-and once fields are active `TAB'/`S-TAB' move between them.
+and once fields are active `M-}'/`M-{' or `C-M-n'/`C-M-p' move
+between them, with `M-RET' to finish. TAB is deliberately not
+involved: in this configuration TAB indents and nothing else. Set
+`jotain-completion-snippets' to nil to keep snippet names out of the
+completion popup; `M-+' and `M-*' still work.
 
 ### `eglot-tempel`
 

--- a/docs/design/completion.md
+++ b/docs/design/completion.md
@@ -1,0 +1,359 @@
+# Completion and snippets — design specification
+
+**Date:** 2026-07-26
+**Status:** Specification. Not implemented; no Elisp in `lisp/` was changed in the
+round that produced this document.
+**Evidence base:** [`docs/reviews/2026-07-completion-research.md`](../reviews/2026-07-completion-research.md).
+Section references below of the form *(research §2.1)* point into that report.
+Claims marked **[unverified]** here are ones the research explicitly could not
+establish — they are design intent, not evidence.
+
+---
+
+## 1. Requirements
+
+These are the owner's stated requirements. They are inputs, not conclusions.
+
+| # | Requirement |
+| --- | --- |
+| R1 | Completion pops up **automatically in code**, and **only on request in prose** (text/org/markdown/commit buffers). |
+| R2 | **TAB indents. Only.** TAB never triggers completion. |
+| R3 | A **separate, explicit key** drives the snippet + completion chain. |
+| R4 | **RET never accepts a completion.** Enter inserts a newline, always. |
+| R5 | Sources that matter: **eglot (LSP)**, **dabbrev/file**, **tempel snippets**, **history/abbrev/spelling**. AI inline suggestions are **surveyed only** — no adoption decision. |
+| R6 | Every feature here has a **documented opt-out**. |
+
+Two prior decisions are settled and not revisited: **tempel** is the snippet
+engine, and the AI layer gets **no recommendation** either way.
+
+---
+
+## 2. Design
+
+### 2.1 Trigger model (R1)
+
+**Global default: no auto-popup.** `corfu-auto` stays `nil` — which is also
+corfu's own shipped default (research §4.1).
+
+**Code buffers opt in**, per-mode, before the mode activates:
+
+```elisp
+(add-hook 'prog-mode-hook (lambda () (setq-local corfu-auto t)))
+```
+
+This works with `global-corfu-mode` for a specific, verified reason: `corfu-auto`
+is read **exactly once**, in the `corfu-mode` body at enable time, and
+`global-corfu-mode` dispatches from `after-change-major-mode-hook`, which
+`run-mode-hooks` runs *after* major-mode hooks (research §4.1). The value latches;
+`corfu-auto--post-command` never re-reads it.
+
+Two failure modes this design must respect, both verified:
+
+1. **`corfu-mode-hook` is too late.** `define-minor-mode` runs the mode hook after
+   the body. Setting `corfu-auto` there does nothing.
+2. **Buffers already open when `global-corfu-mode` first enables keep their old
+   value** — they do not re-run major-mode hooks. Relevant at startup ordering and
+   after a config reload. A buffer opened before corfu initialised will not have
+   auto-popup until its mode is re-run.
+
+**Prose buffers get nothing extra.** They inherit the global `nil`, so completion
+there is manual-only via the key in §2.3. No `text-mode-hook` entry is needed —
+absence *is* the configuration.
+
+**Honest scoping:** upstream's own per-mode knob is `global-corfu-modes`, which
+toggles `corfu-mode` itself, not auto-vs-manual. The `setq-local`-in-a-hook
+technique is *a* mechanism the corfu README licenses ("setting `corfu-auto` to t
+locally … before enabling"), not one upstream presents as *the* prog/prose recipe
+(research §4.1).
+
+**Tuning.** `corfu-auto-delay` and `corfu-auto-prefix` keep their current values
+(`0.1` / `2`) pending measurement. The research found **no evidence** for any
+particular tuning — every number in circulation for this stack is folklore until
+measured (research §6.6). Do not present the current values as tuned.
+
+### 2.2 TAB (R2)
+
+**`tab-always-indent` = `t`.**
+
+This is not a customization that fights core — it is the **stock Emacs default** on
+both 30 and 31, and `indent-for-tab-command`'s only `completion-at-point` call is
+guarded by `(eq tab-always-indent 'complete)`, making that branch provably
+unreachable (research §2.1). The current config sets `'complete`
+(`lisp/init-completion.el`:276); this design reverts to the default.
+
+The claim that corfu recommends `'complete` — i.e. that this deviates from
+upstream — **was refuted 0-3** (research §2.1).
+
+**`tab-first-completion` is out of scope.** It was added in Emacs **28.1** (not 30),
+takes exactly five fixed symbols (not a predicate), and is **inert unless
+`tab-always-indent` is `complete`** (research §2.3). It should be documented as
+irrelevant here, never tuned. This retires the "guard" option considered during
+scoping.
+
+**TAB must also be freed inside the popup.** `corfu-map` binds `TAB` →
+`corfu-complete` (research §6.5). Setting `tab-always-indent` alone leaves TAB
+completing whenever the popup is open, which violates R2 in exactly the moment it
+matters most:
+
+```elisp
+(keymap-unset corfu-map "TAB" t)
+(keymap-unset corfu-map "<tab>" t)
+```
+
+**The one deliberate exception: `tempel-map`.** While a snippet session is live,
+`TAB` moves to the next field and `S-TAB` to the previous
+(`lisp/init-snippets.el`:41-43). This is a *transient, modal* keymap — it is active
+only between template insertion and `tempel-done`/`tempel-abort`, and in that
+window there is no indentation semantics to preserve. This is called out as an
+exception rather than silently kept, and it carries its own opt-out (§3).
+
+Other TAB consumers that bypass `tab-always-indent` entirely and are **not**
+touched by this design (research §2.2): `org-cycle`, `message-tab`, shell-mode's
+TAB, `c-tab-always-indent`, and the minibuffer.
+
+### 2.3 The keys (R3, R4)
+
+| Key | Role |
+| --- | --- |
+| `C-M-i` | **The chain key.** Opens completion; inside the popup, completes. |
+| `TAB` | Indent. Only. (Plus tempel field navigation during a live snippet.) |
+| `RET` | Newline. Only. Never accepts a candidate. |
+| `M-n` / `M-p` | Navigate candidates. |
+| `C-g` | Dismiss. |
+| `M-+` / `M-*` | tempel by name / interactive insert (unchanged). |
+
+**Why `C-M-i` and not `M-TAB`.** The Emacs manual directs users away from `M-TAB`
+because window managers reserve Alt+Tab, and recommends `C-M-i` or `ESC TAB`
+(research §2.4). On a TTY all three collapse to the same event, so `C-M-i` is the
+only choice that is safe on GUI *and* terminal — and this repo ships a terminal-only
+distribution.
+
+Binding a chain command to `C-M-i` **overrides a documented standard binding**
+(global `C-M-i` → `complete-symbol` → `completion-at-point`). That is a deliberate,
+documented choice, not a defect. Note `C-u C-M-i` currently runs
+`info-complete-symbol`; a custom command replaces that behavior.
+
+**RET (R4).** Upstream documents freeing it explicitly (research §6.5):
+
+```elisp
+(keymap-unset corfu-map "RET" t)
+```
+
+This is a supported configuration, not a workaround. If shell/comint buffers later
+need RET to send input, upstream's `menu-item` `:filter` form is the sanctioned
+pattern.
+
+> **Open item — needs a live Emacs to settle.** With both TAB and RET unbound in
+> `corfu-map`, the remaining accept path is `C-M-i` (`corfu-map` binds the
+> `completion-at-point` key to `corfu-complete`). Whether `corfu-complete` alone
+> gives an acceptable "accept the candidate I navigated to with `M-n`" gesture — or
+> whether a dedicated `corfu-insert` binding on a non-RET key is also wanted — was
+> **not verified** and must be checked in a running Emacs before implementation.
+> Do not implement §2.3 without resolving this.
+
+### 2.4 The chain (R3)
+
+The chain is **declarative, via capf ordering** — not a custom dwim command. This
+falls out of two verified facts:
+
+- `tempel-expand` returns **only the single exactly-matching template** and
+  presents no UI (research §6.1).
+- Both tempel capfs return `:exclusive 'no`, so they **fall through** when nothing
+  matches (research §1.3, §6.1).
+
+So ordering `tempel-expand` ahead of the semantic capf yields exactly the desired
+behavior — *expand a snippet if the text before point names one, otherwise
+complete normally* — with `C-M-i` bound to plain `completion-at-point`:
+
+```
+prog-mode buffer, buffer-local completion-at-point-functions:
+  tempel-expand           (depth -90)   exact template name → expand, else fall through
+  eglot-completion-at-point (depth 0)   semantic candidates
+  t                                     → global list: cape-dabbrev, cape-file, cape-keyword
+```
+
+`tempel-complete` (all templates, shown in the popup) remains available on `M-+`
+for browsing by name.
+
+**Prior art:** `make-hippie-expand-function` is the sanctioned way to build a
+bespoke chain bound to its own key, and hippie-exp's Commentary explicitly
+recommends several such functions "bound to different keys" (research §6.4). This
+design reaches the same end through the capf list instead, which keeps a single
+`completion-at-point` entry point and avoids a second, parallel expansion
+mechanism. `hippie-expand` is **not** adopted.
+
+> **Blocking open question — do not implement §2.4 without resolving it.**
+> **eglot's capf is exclusive** (it declares no `:exclusive` at all), so anything
+> ordered *after* it is shadowed — including the cape fallbacks (research §1.3).
+> Whether `cape-capf-nonexclusive` around `eglot-completion-at-point` is the
+> upstream-endorsed fix, and how it compares with the current `cape-capf-super`
+> merge, produced **zero verified claims across two research rounds** (research
+> §6.6). Separately, `completion--capf-wrapper`'s `:exclusive 'no` fallthrough is a
+> *prefix* `try-completion` test, and its own FIXME warns it "will not work (or not
+> right)" for non-prefix completion — **this config runs orderless**. Whether
+> tempel's fallthrough behaves correctly under orderless is **unverified** and
+> could silently break the chain.
+
+**Correction to the current config's stated rationale.** `lisp/init-snippets.el`:45-48
+says prepending `tempel-complete` would shadow LSP candidates. It would not —
+tempel is non-exclusive and falls through (research §1.3). The `cape-capf-super`
+merge is still defensible, but for a *different* reason than the comment gives:
+it makes snippet and server candidates appear in **one** popup simultaneously,
+rather than the server's list appearing only when no template matches. If that
+simultaneity is not wanted, the merge can be dropped in favour of plain ordering —
+which also sheds cape's documented whole-lifetime candidate cache, currently used
+with **no cache buster** (research §1.5).
+
+### 2.5 Prose completion (R1, R5)
+
+Manual-only, via `C-M-i`. Sources in a prose buffer:
+
+- `tempel-expand` / `tempel-complete` (text-mode hook, already configured).
+- `cape-dabbrev`, `cape-file`, `cape-keyword` from the global list.
+- **Not** `ispell-completion-at-point`: `init-writing.el`:42 sets
+  `text-mode-ispell-word-completion` to `nil`. The research confirms this removes
+  exactly two things — the (default-absent) `C-M-i` binding and the buffer-local
+  ispell capf — and nothing else (research §5.4). The existing rationale (the capf
+  throws "No plain word-list found" where `ispell-alternate-dictionary` is absent,
+  as on NixOS) stands, and jinx covers spell-checking.
+
+Worth recording: had that option been left at its default, the ispell capf sits at
+**depth 10** and would have been a harmless late fallback, not a shadow
+(research §5.1).
+
+**Documented hazard.** If `flyspell-mode` is ever enabled, `flyspell-mode-map`
+binds `M-TAB`/`ESC TAB`/`C-M-i` to `flyspell-auto-correct-word`, and as a
+minor-mode map it **outranks the global binding** — silently destroying the chain
+key in exactly the buffers prose completion is for (research §5.6). This config
+uses jinx, not flyspell, so it should not arise; the mitigation if it ever does is
+`(setopt flyspell-use-meta-tab nil)`.
+
+### 2.6 AI / LLM inline suggestions (R5)
+
+**No recommendation is made, per the stated constraint.**
+
+Both research rounds produced **zero verified claims** on the AI completion layer —
+copilot.el, minuet-ai, codeium/windsurf, aidermacs, gptel, eca-emacs — and on how
+ghost-text overlays interact with corfu's child frame or with core
+`completion-preview-mode` (research §6.6). Nothing in this document should be read
+as evidence for or against adoption.
+
+One structural note that *is* verified and would apply to any future adoption:
+Emacs 31's `completion-preview-inhibit-functions` is the sanctioned per-context
+suppression hook for core's ghost text (research §3.2), and core's preview binds
+TAB **only while a preview is displayed** (research §3.1) — which would conflict
+with R2 in that window. Core `completion-preview-mode` is **off by default** and
+this design does not enable it.
+
+---
+
+## 3. Opt-out design (R6)
+
+### 3.1 Idiom
+
+**Grounded in this repo's own convention, not external evidence.** The research
+gathered nothing on opt-out idioms across two rounds — neither the Elisp manual's
+normative guidance nor any real-world config (research §6.6). Rather than invent an
+evidence claim, this section follows the pattern already established in `lisp/`:
+
+- a `defgroup jotain-<area>` (`jotain-ui`, `jotain-writing`, `jotain-vc`,
+  `jotain-devops`);
+- boolean or list `defcustom jotain-<area>-<knob>` toggles with `:type` and
+  `:group` (`jotain-prog-warn-non-ts-mode`, `jotain-prog-enable-risky-js-lsp`,
+  `jotain-prog-warn-non-ts-exclude`);
+- set with `setopt`, per the repo rule.
+
+### 3.2 Proposed knobs
+
+All under a new `(defgroup jotain-completion nil … :group 'convenience)` in
+`lisp/init-completion.el`.
+
+| Option | Default | Disables |
+| --- | --- | --- |
+| `jotain-completion-auto-modes` | `'(prog-mode-hook)` | Auto-popup. `nil` ⇒ manual-only **everywhere**, including code. Add hooks to extend auto-popup to more modes. |
+| `jotain-completion-auto-delay` | `0.1` | — (tuning; see §2.1 on the absence of evidence) |
+| `jotain-completion-auto-prefix` | `2` | — (tuning) |
+| `jotain-completion-free-return` | `t` | `nil` ⇒ restore corfu's default `RET` = `corfu-insert`. |
+| `jotain-completion-free-tab` | `t` | `nil` ⇒ restore corfu's default `TAB` = `corfu-complete`. |
+| `jotain-completion-snippet-tab` | `t` | `nil` ⇒ drop `TAB`/`S-TAB` field navigation in `tempel-map` (the §2.2 exception). |
+| `jotain-completion-key` | `"C-M-i"` | The chain key. `nil` ⇒ bind nothing, leaving the stock global binding intact. |
+| `jotain-completion-fallbacks` | `t` | `nil` ⇒ omit `cape-dabbrev` / `cape-file` / `cape-keyword` from the global capf list. |
+| `jotain-completion-snippets` | `t` | `nil` ⇒ do not add any tempel capf (`M-+`/`M-*` still work). |
+
+**Granularity rule:** every knob disables exactly one mechanism, and `nil` always
+means "behave as stock Emacs/corfu would". No knob silently re-enables another.
+
+### 3.3 Timing semantics — stated, because it is not uniform
+
+This matters and cannot be papered over:
+
+- `jotain-completion-auto-modes`, `-snippets`, `-fallbacks` are read at **load
+  time** (they add/remove hooks). Changing them needs a **restart**, or manual
+  `remove-hook`.
+- `-auto-delay`, `-auto-prefix` are read **per keystroke** — immediate.
+- `-free-return`, `-free-tab`, `-snippet-tab`, `-key` modify keymaps at load time;
+  a `:set` function could make them immediate, at the cost of the `setopt`-only
+  caveat that pattern implies.
+
+**Recommendation:** do **not** add `:set` functions in the first implementation.
+Keep the knobs load-time and document the restart, rather than shipping
+half-reactive options. (The precedent is core's own
+`text-mode-ispell-word-completion`, whose `:set` covers the keymap half while the
+capf half is read at mode entry — a split that demonstrably confused this
+research, twice.)
+
+### 3.4 Escape hatches that need no knob
+
+Documented for the user, because they cost nothing to support:
+
+- **Per-buffer, right now:** `M-x corfu-mode` toggles the popup in the current
+  buffer.
+- **Auto-popup in one buffer:** `M-x eval-expression` →
+  `(setq-local corfu-auto nil)` then re-run the major mode (the value latches at
+  mode-enable time — §2.1).
+- **Everything off:** `M-x global-corfu-mode` toggles the whole stack.
+- **`var/custom.el` is write-only** in this config, so Customize-set values do not
+  persist across sessions by design. Opt-outs belong in the user's own init or in
+  a machine-local file, not in Customize.
+
+An environment-variable opt-out (precedent: `JOTAIN_NO_PACKAGE_REFRESH`) is
+**deliberately not proposed**. That precedent exists for a startup-path network
+action that must be suppressible before Lisp runs; completion behavior has no such
+constraint, and a defcustom is more discoverable.
+
+---
+
+## 4. Delta from the current configuration
+
+What implementing this would change. Nothing here is done yet.
+
+| File | Change |
+| --- | --- |
+| `lisp/init-completion.el`:276 | `tab-always-indent` `'complete` → `t`. |
+| `lisp/init-completion.el`:281-287 | `corfu-auto` `t` → `nil` globally; add `prog-mode-hook` opt-in. |
+| `lisp/init-completion.el` | New: `defgroup jotain-completion` + the §3.2 knobs; `keymap-unset` of `RET`/`TAB` in `corfu-map`; bind the chain key. |
+| `lisp/init-snippets.el`:45-48 | Correct the comment's rationale (research §1.3); decide whether to keep the `cape-capf-super` merge and, if kept, whether to add a cache buster. |
+| `lisp/init-snippets.el`:51 | Consider `tempel-expand` (exact-match, no UI) for the buffer-local prog-mode capf instead of `tempel-complete`, per §2.4. |
+| `docs/` | Document the chain key and the opt-out table; regenerate the package reference if any `@doc` block changes. |
+
+**Preconditions before any of it lands** — both are blocking:
+
+1. Resolve the **eglot-exclusivity / orderless-fallthrough** question in §2.4. The
+   chain's correctness depends on it and it is unverified.
+2. Resolve the **accept-key** question in §2.3 on a live Emacs.
+
+Neither can be settled from documentation; both need a running Emacs, which the
+dev shell deliberately does not provide (`just run-built` is the path).
+
+---
+
+## 5. Explicitly out of scope
+
+- **yasnippet migration** — tempel is settled.
+- **AI adoption** — surveyed only, no recommendation (§2.6).
+- **company-mode** — not evaluated; corfu is the incumbent and nothing in the
+  research challenged it.
+- **Minibuffer completion** (vertico/consult/orderless) — untouched. This document
+  covers the in-buffer side only.
+- **Performance tuning** — no evidence base exists (research §6.6). Any future
+  tuning should start by measuring, not by copying numbers.

--- a/docs/design/completion.md
+++ b/docs/design/completion.md
@@ -1,8 +1,12 @@
 # Completion and snippets — design specification
 
 **Date:** 2026-07-26
-**Status:** Specification. Not implemented; no Elisp in `lisp/` was changed in the
-round that produced this document.
+**Status:** Implemented 2026-07-27 in `lisp/init-completion.el` and
+`lisp/init-snippets.el`, with coverage in `test/completion-test.el`. Both items
+this document recorded as blocking were settled by measurement rather than
+deferred — see §2.3 and §2.4. Where the implementation departs from the
+specification as
+first written, the section says so instead of being quietly edited to match.
 **Evidence base:** [`docs/reviews/2026-07-completion-research.md`](../reviews/2026-07-completion-research.md).
 Section references below of the form *(research §2.1)* point into that report.
 Claims marked **[unverified]** here are ones the research explicitly could not
@@ -100,12 +104,22 @@ matters most:
 (keymap-unset corfu-map "<tab>" t)
 ```
 
-**The one deliberate exception: `tempel-map`.** While a snippet session is live,
-`TAB` moves to the next field and `S-TAB` to the previous
-(`lisp/init-snippets.el`:41-43). This is a *transient, modal* keymap — it is active
-only between template insertion and `tempel-done`/`tempel-abort`, and in that
-window there is no indentation semantics to preserve. This is called out as an
-exception rather than silently kept, and it carries its own opt-out (§3).
+**Superseded — there is no exception.** This section originally kept `TAB` for
+snippet field navigation as the one deliberate exception. That exception is gone:
+fields now move on `M-}`/`M-{` (tempel's own keys) or `C-M-n`/`C-M-p`, and `TAB`
+appears nowhere.
+
+The exception turned out to rest on a false premise. **Upstream `tempel-map`
+never bound `TAB` at all** — it ships `M-}`/`M-{`, `M-RET` (`tempel-done`),
+`M-<up>`/`M-<down>` and a set of command remaps. The `TAB`/`S-TAB` pair was this
+configuration's own addition in `init-snippets.el`'s `:bind` block. Removing it
+is a deletion, not a substitution, and tempel's own keys take over for free.
+
+`C-M-n`/`C-M-p` are added alongside as a mnemonic alias. No field key may
+collide with corfu's `M-n`/`M-p`: `tempel-map` is installed as an overlay
+`keymap` property, which is consulted *before* minor-mode maps, so a shared key
+would be stolen from the popup mid-snippet. `M-[` would have been actively
+hostile on a TTY — `ESC [` is the CSI introducer.
 
 Other TAB consumers that bypass `tab-always-indent` entirely and are **not**
 touched by this design (research §2.2): `org-cycle`, `message-tab`, shell-mode's
@@ -143,13 +157,21 @@ This is a supported configuration, not a workaround. If shell/comint buffers lat
 need RET to send input, upstream's `menu-item` `:filter` form is the sanctioned
 pattern.
 
-> **Open item — needs a live Emacs to settle.** With both TAB and RET unbound in
-> `corfu-map`, the remaining accept path is `C-M-i` (`corfu-map` binds the
-> `completion-at-point` key to `corfu-complete`). Whether `corfu-complete` alone
-> gives an acceptable "accept the candidate I navigated to with `M-n`" gesture — or
-> whether a dedicated `corfu-insert` binding on a non-RET key is also wanted — was
-> **not verified** and must be checked in a running Emacs before implementation.
-> Do not implement §2.3 without resolving this.
+**Resolved — and it turned on a mechanism, not a preference.** `corfu-map`
+contains a `<remap> <completion-at-point>` entry pointing at `corfu-complete`,
+and a remap fires only for the command the key actually *resolves to*. Binding
+`C-M-i` to `completion-at-point` — rather than leaving the stock global
+`complete-symbol`, which is not remapped — is therefore what makes the same key
+both open the popup and accept inside it. No second accept key is needed, and
+the choice of `completion-at-point` is load-bearing rather than cosmetic.
+
+Asserted in `completion-test-one-key-opens-and-accepts`.
+
+One thing this does *not* settle: whether `corfu-complete`'s behaviour after
+navigating with `M-n` (it extends the common prefix, and inserts when the
+selection is unambiguous) feels right in practice. That needs a live Emacs. If
+it disappoints, the lever is `corfu-preselect` / `corfu-on-exact-match`, not a
+second accept key.
 
 ### 2.4 The chain (R3)
 
@@ -182,17 +204,42 @@ design reaches the same end through the capf list instead, which keeps a single
 `completion-at-point` entry point and avoids a second, parallel expansion
 mechanism. `hippie-expand` is **not** adopted.
 
-> **Blocking open question — do not implement §2.4 without resolving it.**
-> **eglot's capf is exclusive** (it declares no `:exclusive` at all), so anything
-> ordered *after* it is shadowed — including the cape fallbacks (research §1.3).
-> Whether `cape-capf-nonexclusive` around `eglot-completion-at-point` is the
-> upstream-endorsed fix, and how it compares with the current `cape-capf-super`
-> merge, produced **zero verified claims across two research rounds** (research
-> §6.6). Separately, `completion--capf-wrapper`'s `:exclusive 'no` fallthrough is a
-> *prefix* `try-completion` test, and its own FIXME warns it "will not work (or not
-> right)" for non-prefix completion — **this config runs orderless**. Whether
-> tempel's fallthrough behaves correctly under orderless is **unverified** and
-> could silently break the chain.
+**Resolved by measurement — and it exposed a live bug.** All four facts below
+are asserted in `test/completion-test.el`; none came from documentation.
+
+1. **An exclusive capf shadows everything after it, unconditionally** — even
+   when nothing it offers matches the text at point.
+2. **`cape-capf-nonexclusive` is the fix.** Wrapping the exclusive capf restores
+   the fallthrough, while still keeping control when its own candidates match.
+3. **`cape-capf-super` propagates non-exclusivity only when *every* input is
+   non-exclusive.** One exclusive input makes the whole merge exclusive.
+4. **The `:exclusive no` fallthrough ignores `completion-styles`.** It is decided
+   by a bare `try-completion`, so `foo` is discarded against `barfoo` under
+   orderless exactly as under `basic` — even though orderless itself matches.
+   The `minibuffer.el` FIXME is real, not theoretical.
+
+**Facts 1 and 3 together were a live bug.** `init-snippets.el` merges the
+snippet capf with eglot's. Tempel is non-exclusive but eglot is not, so the
+merged capf inherited eglot's exclusivity — meaning **`cape-dabbrev`, `cape-file`
+and `cape-keyword` never ran in any LSP buffer.** They were configured and dead.
+The implementation wraps the merged capf in `cape-capf-nonexclusive`, gated by
+`jotain-completion-eglot-nonexclusive`.
+
+**Fact 4 bounds a residual weakness**, which the merge happens to mitigate. A
+non-exclusive capf loses candidates a non-prefix pattern would have matched. For
+`tempel-complete` alone that would mean snippet names vanishing whenever you type
+an orderless-style pattern. Inside the merge the collection also holds the
+server's candidates, so the prefix test generally succeeds and the merged capf is
+kept. This is a real argument for the merge that the original rationale never
+made — but it is mitigation, not a fix, and the underlying approximation is
+upstream's.
+
+**Departure from the specification as written.** §2.4 originally proposed
+replacing `tempel-complete` with `tempel-expand` (exact-match, no popup entry).
+The implementation keeps `tempel-complete` and the merge, on the owner's
+decision that snippet names should stay visible in the popup. `tempel-expand`
+would have been structurally immune to fact 4 — it never hands the wrapper a
+partial prefix — so that immunity was traded for discoverability, knowingly.
 
 **Correction to the current config's stated rationale.** `lisp/init-snippets.el`:45-48
 says prepending `tempel-complete` would shadow LSP candidates. It would not —
@@ -275,13 +322,22 @@ All under a new `(defgroup jotain-completion nil … :group 'convenience)` in
 | `jotain-completion-auto-prefix` | `2` | — (tuning) |
 | `jotain-completion-free-return` | `t` | `nil` ⇒ restore corfu's default `RET` = `corfu-insert`. |
 | `jotain-completion-free-tab` | `t` | `nil` ⇒ restore corfu's default `TAB` = `corfu-complete`. |
-| `jotain-completion-snippet-tab` | `t` | `nil` ⇒ drop `TAB`/`S-TAB` field navigation in `tempel-map` (the §2.2 exception). |
+| `jotain-completion-eglot-nonexclusive` | `t` | `nil` ⇒ leave the LSP capf exclusive, so the cape fallbacks stay suppressed in LSP buffers (see §2.4). |
 | `jotain-completion-key` | `"C-M-i"` | The chain key. `nil` ⇒ bind nothing, leaving the stock global binding intact. |
 | `jotain-completion-fallbacks` | `t` | `nil` ⇒ omit `cape-dabbrev` / `cape-file` / `cape-keyword` from the global capf list. |
 | `jotain-completion-snippets` | `t` | `nil` ⇒ do not add any tempel capf (`M-+`/`M-*` still work). |
 
 **Granularity rule:** every knob disables exactly one mechanism, and `nil` always
 means "behave as stock Emacs/corfu would". No knob silently re-enables another.
+
+**Substitution, recorded:** the ninth knob was originally
+`jotain-completion-snippet-tab`, gating the `TAB` field-navigation exception.
+That exception no longer exists (§2.2), so the knob would have gated nothing —
+and its `nil` branch would have meant "restore a binding upstream never had",
+violating the rule above. It is replaced by
+`jotain-completion-eglot-nonexclusive`, which gates a mechanism the
+implementation genuinely adds and which the original table omitted. The count is
+still nine.
 
 ### 3.3 Timing semantics — stated, because it is not uniform
 
@@ -336,14 +392,17 @@ What implementing this would change. Nothing here is done yet.
 | `lisp/init-snippets.el`:51 | Consider `tempel-expand` (exact-match, no UI) for the buffer-local prog-mode capf instead of `tempel-complete`, per §2.4. |
 | `docs/` | Document the chain key and the opt-out table; regenerate the package reference if any `@doc` block changes. |
 
-**Preconditions before any of it lands** — both are blocking:
+**Both preconditions are discharged.** They were recorded as needing a live
+Emacs, and they did — but a *batch* one, not an interactive one, which is
+cheaper than this document assumed. The `elisp-test` check already runs
+`emacs --batch` against the full package set, so capf dispatch and keymap state
+are both directly assertable. The lesson worth keeping: "needs a running Emacs"
+is not the same as "needs a human at a GUI".
 
-1. Resolve the **eglot-exclusivity / orderless-fallthrough** question in §2.4. The
-   chain's correctness depends on it and it is unverified.
-2. Resolve the **accept-key** question in §2.3 on a live Emacs.
-
-Neither can be settled from documentation; both need a running Emacs, which the
-dev shell deliberately does not provide (`just run-built` is the path).
+What still genuinely needs eyes on a screen is narrower than the original list:
+how `corfu-complete` *feels* as an accept gesture after `M-n` (§2.3), and
+whether the auto-popup delay is comfortable — the latter having no evidence base
+at all (§2.1).
 
 ---
 

--- a/docs/reviews/2026-07-completion-research.md
+++ b/docs/reviews/2026-07-completion-research.md
@@ -649,3 +649,367 @@ terminal" and never mentions Emacs 31. Stale silence, not a contradiction — bu
 a reader consulting only that page would be misled.
 
 ---
+
+## Part 5 — Prose-mode completion (the `M-TAB` question), resolved
+
+The first research round left this contradictory: one claim that "M-TAB in Text
+mode completes from the spell-checker's dictionary" was refuted 0-3, while a
+different verifier quoted the manual saying exactly that. A dedicated pass over
+source resolved it. **Both prior positions were partly right.**
+
+### 5.1 What text-mode actually installs [V]
+
+Since **Emacs 30.1**, the body of `(define-derived-mode text-mode …)` ends with —
+byte-identical on `emacs-30` (lines 157-158), `emacs-31` and `master` (155-156):
+
+```elisp
+(add-hook 'context-menu-functions 'text-mode-context-menu 10 t)
+(when (eq text-mode-ispell-word-completion 'completion-at-point)
+  (add-hook 'completion-at-point-functions #'ispell-completion-at-point 10 t))
+```
+
+Decoded against `add-hook`'s signature `(hook function &optional depth local)`:
+**depth 10, buffer-local**. This is the *only* executable reference to
+`completion-at-point-functions` in `text-mode.el` (the other two occurrences are
+inside a docstring).
+
+`ispell-completion-at-point` is a real capf (`ispell.el`:3718 on emacs-30, :3783
+on emacs-31), docstring "Word completion function for use in
+`completion-at-point-functions'", returning `(list beg end (cdr all) :exclusive 'no)`.
+
+**Consequence for this config [V]:** depth 10 appends **late**. Any capf added at
+default depth 0 — `tempel-complete`, `cape-dabbrev`, eglot — runs *before* it. The
+ispell capf is a **fallback, not a shadow**. ("Depth 10 = last" is a loose gloss:
+depths range −100..100, and with `LOCAL=t` the `t` sentinel sits at the very end
+of the buffer-local list.)
+
+### 5.2 The option [V]
+
+```elisp
+(defcustom text-mode-ispell-word-completion 'completion-at-point
+  "How Text mode provides Ispell word completion. …"
+  :group 'text
+  :type '(choice (const completion-at-point) boolean)
+  :version "30.1"
+  :set (lambda (sym val) …))
+```
+
+Three meaningful values: `completion-at-point` (capf — the default), any other
+non-nil (bind `C-M-i` directly to `ispell-complete-word`), `nil` (neither).
+
+Introduced via bug#67527 (patch by Eshel Yaron, installed 2024-01-27). Emacs 29
+has no such defcustom at all — only an unconditional
+`"C-M-i" #'ispell-complete-word` in `text-mode-map`.
+
+**Emacs 30 vs 31 doc-only delta [V]:** emacs-30's docstring carries the sentence
+"This user option only takes effect when you customize it in Custom or with
+`setopt', not with `setq'." — **deleted in 31 and master** while the `:set` lambda
+that motivated it was kept. Anyone citing that sentence for an Emacs 31 config is
+citing removed text.
+
+### 5.3 The key path — a correction worth propagating [V]
+
+By default `text-mode-map` has **no** `C-M-i` / `M-TAB` binding. The defcustom's
+`:set` lambda *removes* it via `(keymap-unset text-mode-map "C-M-i" t)` whenever
+the value is `nil` or `completion-at-point`. Because `text-mode.el` is preloaded
+(`loadup.el`:283), the dump-time `custom-initialize-reset` already ran that
+branch — C-M-i is unbound in `text-mode-map` out of the box.
+
+So `M-TAB` falls through to the **global** `esc-map` binding. And NEWS and the
+manual both say "completion-at-point, globally bound to M-TAB" — but the actual
+binding (`bindings.el`:952 on 30, :1061-1063 on 31) is:
+
+```elisp
+(define-key esc-map "\t" 'complete-symbol)
+```
+
+where `complete-symbol` is `(if arg (info-complete-symbol) (completion-at-point))`.
+Bare `C-M-i` is behaviorally identical; **`C-u C-M-i` runs `info-complete-symbol`
+instead**. Precise phrasing: *global `C-M-i` → `complete-symbol`, which calls
+`completion-at-point`.*
+
+### 5.4 What setting it to nil removes [V]
+
+Exactly two things: the (default-absent) `C-M-i` binding, and the buffer-local
+`ispell-completion-at-point` capf entry. Nothing else. Proven by grep, not
+inference: a tree-wide search for the option returns `total_count=3` —
+`text-mode.el`, `doc/emacs/text.texi`, `etc/NEWS.30`. No other Lisp file reads it;
+`ispell.el` never references it and has no `remove-hook` for the capf.
+
+It is read at **mode-entry** time, so `nil` does not retroactively strip the capf
+from already-live text-mode buffers.
+
+**A precision correction [V]:** the blanket "setq silently fails here" is an
+overreach. Only the *keymap* half lives in `:set`, and since text-mode.el is
+preloaded a `setq` can never update `text-mode-map`. But the *capf* half is read
+from the live variable inside the mode body, so `(setq text-mode-ispell-word-completion nil)`
+**does** stop the capf from being installed in newly-entered buffers — the
+practically decisive effect. `setq` genuinely fails only when moving to a non-nil,
+non-`completion-at-point` value. Given this repo's `setopt` rule the point is
+moot, but the mechanism should be stated correctly.
+
+**Bearing on `init-writing.el`:41-42 [V]:** the existing comment says the Emacs 30
+ispell capf throws "No plain word-list found" on NixOS where
+`ispell-alternate-dictionary` has no file. Setting the option to `nil` is a
+correct and sufficient fix for that, and it removes nothing else.
+
+### 5.5 The manual now agrees [V]
+
+`emacs-31 doc/emacs/fixit.texi` (Spelling node):
+
+```texinfo
+@item M-@key{TAB}
+@itemx @key{ESC} @key{TAB}
+@itemx C-M-i
+Complete the word before point based on the spelling dictionary and
+other completion sources (@code{completion-at-point}).
+```
+
+The Emacs **29** manual said the opposite — "(@code{ispell-complete-word})" —
+which is almost certainly what the first round's 0-3 refutation was reasoning
+from. `ispell-complete-word` itself is **not** obsolete: a live defun on both
+branches, with no `make-obsolete`.
+
+**Adjudication:** M-TAB in text modes *does* complete from the spell-checker's
+dictionary — but as **one capf among others**, at depth 10, reached via
+`complete-symbol` → `completion-at-point`, not via a dedicated key binding.
+
+### 5.6 A key-safety hazard the design must dodge [V]
+
+**With `flyspell-mode` enabled, `M-TAB` / `ESC TAB` / `C-M-i` is not a completion
+key at all.** `flyspell.el`:430-438:
+
+```elisp
+(defvar flyspell-mode-map
+  (let ((map (make-sparse-keymap)))
+    (if flyspell-use-meta-tab (define-key map "\M-\t" 'flyspell-auto-correct-word))
+    …))
+```
+
+`flyspell-use-meta-tab` defaults to `t` on both 30 and 31. As a **minor-mode**
+keymap it outranks the global `esc-map` binding — so the completion key is fully
+shadowed by spell correction in exactly the buffers where dictionary completion
+was supposed to help.
+
+**Opt-out:** set `flyspell-use-meta-tab` to `nil`; its `:set` lambda re-binds
+`"\M-\t"` to nil live, so it works both before and after flyspell loads.
+
+**Why this repo is *probably* already safe [I]:** `init-writing.el` uses **jinx**,
+not flyspell (`global-jinx-mode` "replaces both `flyspell-mode` and
+`flyspell-prog-mode` in one shot"). So `flyspell-mode-map` should never be active.
+This is inference from the config, not a verified runtime check — any future move
+back to flyspell, or any package enabling it transitively, silently breaks the
+dwim key. The design document treats this as a documented risk.
+
+---
+
+## Part 6 — tempel, hippie-expand, and what remains unknown
+
+### 6.1 tempel's capf surface [V]
+
+Verified against `tempel.el` v1.14 (939 lines) on `main`; the emacs-straight
+released mirror `diff -q`s **identical**, so `main` == what a NixOS user installs.
+
+| Symbol | Kind | Returns |
+| --- | --- | --- |
+| `tempel-complete` | capf | **all** templates for the buffer |
+| `tempel-expand` | capf | **single** exactly-matching template |
+| `tempel-insert` | command (`completing-read`) | — |
+
+Both capfs return `:category 'tempel`, `:exclusive 'no`, and an `:exit-function`
+of `tempel--exit`. `tempel-expand`'s docstring: "returns only the single exactly
+matching template name. As a consequence the completion UI (e.g. Corfu) does not
+present the candidates for selection." `tempel-complete`'s: "returns a list of all
+possible template names, which are then displayed in the completion UI."
+
+Only `tempel-complete` emits `:company-kind` (`(lambda (_) 'snippet)`),
+`:company-doc-buffer`, `:company-location`, and a **conditional**
+`:annotation-function` — nil if `tempel-complete-annotation` (default 20) is nil.
+`tempel-expand` emits none of these.
+
+### 6.2 `tempel-trigger-prefix` does not exist [V]
+
+A scope correction: **`tempel-trigger-prefix` is not in tempel 1.14.** `grep` for
+`trigger-prefix` returns zero matches on both `main` and the released mirror.
+Prefix detection is the internal `tempel--prefix-bounds` (lines 770-780), which
+walks back over non-whitespace and accepts that span only if `try-completion`
+against the template list succeeds, else falls back to
+`(bounds-of-thing-at-point 'symbol)`.
+
+The complete defcustom set is **nine**: `tempel-path`, `tempel-mark`,
+`tempel-insert-annotation` (40), `tempel-complete-annotation` (20),
+`tempel-user-elements` (nil), `tempel-template-sources`, `tempel-done-on-region`
+(t), `tempel-done-on-next` (t), `tempel-auto-reload` (t). `tempel-map` is a
+`defvar-keymap`, not a defcustom, but is still user-configurable.
+
+**[?]** The suggested modern equivalent — `cape-capf-trigger` wrapped around
+`tempel-complete` — was *not* itself verified. Treat as unverified.
+
+### 6.3 Template and file format [V]
+
+`.eld` files are a flat sequence `(MODES PLIST TEMPLATES MODES PLIST TEMPLATES…)`.
+Leading non-keyword symbols are mode names; keyword/value pairs form a per-section
+plist whose `:when` supplies a condition (defaulting to `t`); remaining conses are
+templates. Mode matching is `derived-mode-p` plus `major-mode-remap-alist`
+indirection, with `fundamental-mode` sections always matching.
+
+Only `:when` is consumed from the *section* plist — any other section-level
+keyword is **silently discarded**. Per-template `:pre`/`:post` are a separate
+mechanism: a trailing plist on each template cons.
+
+- `:pre` — a Lisp form evaluated **first** in `tempel--insert`, before the element
+  loop.
+- `:post` — stashed on the range overlay, evaluated by the finalizer
+  `tempel--done` in the lexical scope of the named fields. **Not evaluated on
+  `tempel-abort`.**
+
+Element syntax (from `tempel--element`'s docstring): strings, `nil`, `p`, `r`,
+`r>`, `n`, `n>`, `>`, `&`, `%`, `o`, `q`, `(s NAME)`, `(p PROMPT <NAME> <NOINSERT>)`,
+`(r PROMPT …)`, `(r> PROMPT …)`, `(l ELEMENTS…)`, and arbitrary Lisp forms
+dispatched first through `tempel-user-elements`, with string results dynamically
+updated. Upstream's own warning: "Use caution with templates which execute
+arbitrary code!"
+
+`tempel-auto-reload` compares a whole `(file . mtime)` alist with `equal`, so file
+**addition and removal** also trigger a reload, not just mtime bumps.
+
+**Bearing on this repo [I]:** `templates/jotain.eld` uses exactly the documented
+shape — bare mode symbols as section headers, `p`/`n`/`n>`/`r>`/`q` elements — and
+`tempel-path` is set to `templates/*.eld`, which the wildcard support covers.
+
+### 6.4 hippie-expand — the prior art for a dwim chain key [V]
+
+This is the most directly applicable finding for the "separate chain key" design.
+
+**Default `hippie-expand-try-functions-list`** (byte-identical on emacs-30,
+emacs-31 and master; `hippie-exp.el`:204-218):
+
+```elisp
+'(try-complete-file-name-partially
+  try-complete-file-name
+  try-expand-all-abbrevs
+  try-expand-list
+  try-expand-line
+  try-expand-dabbrev
+  try-expand-dabbrev-all-buffers
+  try-expand-dabbrev-from-kill
+  try-complete-lisp-symbol-partially
+  try-complete-lisp-symbol)
+```
+
+`:type '(repeat function)`, autoloaded, no `:version`/`:group`/`:set`. Note the
+default is a **proper subset** of what the file defines — `try-expand-line-all-buffers`,
+`try-expand-list-all-buffers` and `try-expand-whole-kill` are deliberately excluded.
+
+**The sanctioned way to build a bespoke chain key [V]** —
+`make-hippie-expand-function`, autoloaded, `(TRY-LIST &optional VERBOSE)`,
+returning an interactive closure that dynamically binds
+`hippie-expand-try-functions-list` to TRY-LIST and calls `hippie-expand`:
+
+> "instead of loading the variable with all kinds of try-functions above, it might
+> be an idea to use `make-hippie-expand-function' to construct different
+> `hippie-expand'-like functions, with different try-lists and **bound to different
+> keys**."
+>
+> — `hippie-exp.el` Commentary, lines 114-118
+
+with `fset` examples at lines 394-400. Nothing in the file is marked obsolete
+(`grep -n obsolete` → zero hits). It is a **defun returning a closure**, not a
+macro — the file's own preceding comment calls it "a macro" sloppily.
+
+**Cycling semantics [V]:** repeated invocation steps through candidates and then
+forward through the try-list. A positive numeric ARG jumps ARG functions forward;
+a negative arg, `C-u 0`, or plain `C-u` **undoes** the tried expansion. Three
+precisions: (a) it does **not** wrap around — on exhaustion it messages "No further
+expansions found" and `(ding)`; (b) with no ARG a repeat re-invokes the *same*
+try-function with `old=t` to get its next candidate, advancing only once that
+function returns nil — candidate-by-candidate, not one function per keypress;
+(c) `C-u 0` also reaches the undo branch, which the manual wording omits.
+
+**[R] Refuted 0-3:** the claim that the Commentary "explicitly sanctions" the
+buffer-local/mode-hook pattern as *the* documented pattern for prose-vs-code
+chains. The text at lines 118-120 does offer that path — "It is also possible to
+make `hippie-expand-try-functions-list' a buffer local variable, and let it depend
+on the mode (by setting it in the mode-hooks)" — but it carries no such normative
+weight.
+
+### 6.5 corfu's keymap — the RET and TAB question [V]
+
+Default `corfu-map`, from the corfu README:
+
+| Binding | Command |
+| --- | --- |
+| `completion-at-point`, `TAB` | `corfu-complete` |
+| `M-TAB` | `corfu-expand` |
+| `RET` | `corfu-insert` |
+| `next-line`, `down`, `M-n` | `corfu-next` |
+| `previous-line`, `up`, `M-p` | `corfu-previous` |
+| `C-g` | `corfu-quit` |
+| `M-SPC` | `corfu-insert-separator` |
+| `M-h` | `corfu-info-documentation` |
+| `M-g` | `corfu-info-location` |
+
+> "The current candidate is inserted with `TAB` and selected with `RET`."
+
+Upstream documents freeing RET explicitly:
+
+```elisp
+;; Free the RET key for less intrusive behavior.
+;; Option 1: Unbind RET completely
+(keymap-unset corfu-map "RET")
+;; Option 2: Use RET only in shell modes
+(keymap-set corfu-map "RET" `( menu-item "" nil :filter
+                               ,(lambda (&optional _)
+                                  (and (derived-mode-p 'eshell-mode 'comint-mode)
+                                       #'corfu-send))))
+```
+
+This is decisive for the "Enter must never accept a completion" requirement: it is
+a **supported, upstream-documented configuration**, not a hack. The `menu-item`
+`:filter` form is also the general pattern for making a corfu binding
+context-conditional.
+
+**Not established this round:** exhaustive accepted-value lists for
+`corfu-preselect`, `corfu-on-exact-match`, and `corfu-quit-no-match`. The README
+shows `corfu-preselect` values `prompt` and `directory` by example only, and
+`corfu-on-exact-match` via `'insert` by example. `corfu-quit-no-match` is
+described with `separator` (default) and `t`. **Do not reproduce a complete value
+table from this report** — read the docstrings before relying on any value not
+listed here.
+
+### 6.6 What remains unresearched
+
+Reported as **not found** rather than inferred. Two rounds produced zero verified
+claims on these, so the design document must not present them as evidence-backed:
+
+- **Capf ordering, concretely (GAP 3).** Whether `cape-capf-nonexclusive` around
+  `eglot-completion-at-point` is upstream-endorsed; how it compares with
+  `cape-capf-super` merging; whether `completion--capf-wrapper`'s prefix-
+  `try-completion` approximation for `:exclusive 'no` **misfires under orderless**
+  (the `minibuffer.el` FIXME says non-prefix completion "will not work (or not
+  right) for completion functions that are non-exclusive" — and this config runs
+  orderless); and the behavior of `eglot--capf-session` / `eglot--capf-session-flush`,
+  including whether `cape-capf-buster` is needed around eglot.
+
+  The two things GAP 3 *can* lean on from verified findings: tempel's capfs are
+  both `:exclusive 'no`, and the ispell capf sits at depth 10 — so tempel and
+  ispell both fall through, and neither shadows eglot.
+
+- **Opt-out / kill-switch idiom (GAP 5).** Neither the normative half (Elisp manual
+  Defining Variables / Customization / Minor Mode Conventions on `defcustom` vs
+  `defvar`, `:set`/`:initialize`, load-time vs runtime togglability) nor the
+  descriptive half (Doom module flags, Prelude, Crafted, purcell, Prot, karthink,
+  minimal-emacs.d) was gathered. **The design document's opt-out section is
+  therefore grounded in this repo's own established convention**, which is
+  verifiable locally, rather than in external evidence.
+
+- **Performance (GAP 6).** Nothing on `corfu-auto-delay`/`-prefix` tuning guidance,
+  the per-keystroke cost of `corfu-auto--post-command`, `eglot-send-changes-idle-time`
+  or capf latency reports, `cape-dabbrev-check-other-buffers` cost, `corfu-history`
+  + savehist boundedness, or native-comp's effect on completion responsiveness.
+  Every performance number in circulation for this stack should be treated as
+  folklore until measured.
+
+- **The rest of the built-in layer.** `dabbrev` internals and cache invalidation,
+  `abbrev`/`abbrev-suggest`, `skeleton`/`tempo`, and the exact accepted values of
+  `completion-auto-help` and `completion-auto-select`.

--- a/docs/reviews/2026-07-completion-research.md
+++ b/docs/reviews/2026-07-completion-research.md
@@ -1,0 +1,651 @@
+# Completion, snippets, and input assist — research report
+
+**Date:** 2026-07-26
+**Scope:** In-buffer completion, snippet expansion, and adjacent input-assist
+facilities for this configuration — built-in Emacs 30/31, the third-party
+corfu/cape/tempel stack, and the surrounding landscape.
+**Status:** Research only. The companion design document is
+[`docs/design/completion.md`](../design/completion.md); no Elisp was changed in
+the round that produced this report.
+
+## How to read this
+
+Every claim below carries a source. Claims are marked:
+
+- **[V]** — verified against a primary source (GNU manual, NEWS, or package
+  source), and adversarially re-checked.
+- **[I]** — a sound inference *from* a verified source, but not something the
+  source states in those words. Flagged because the distinction matters when
+  someone later quotes this document as authority.
+- **[R]** — a claim that was investigated and **refuted**. Recorded so it is not
+  re-proposed.
+- **[?]** — investigated, unresolved. Do not build on it.
+
+Where Emacs 30 and 31 differ, the difference is called out explicitly. NEWS
+files reset per release: `master/etc/NEWS` is Emacs 32 NEWS as of this writing,
+so all NEWS citations pin a branch (`emacs-30`, `emacs-31`) or a versioned file
+(`etc/NEWS.28`, `etc/NEWS.31`).
+
+---
+
+## Part 1 — The capf protocol
+
+### 1.1 The contract [V]
+
+A function on `completion-at-point-functions` returns either `nil`, or a list
+`(START END COLLECTION . PROPS)`. `START`/`END` delimit the text being completed
+and must enclose point; `COLLECTION` must be usable as `try-completion`'s second
+argument; `PROPS` accepts any property from `completion-extra-properties` plus
+the capf-specific `:predicate` and `:exclusive`.
+
+> "Each function should return nil unless it can and wants to take
+> responsibility for the completion data for the text at point. Otherwise it
+> should return a list of the following form: `(start end collection . props)`"
+>
+> — *GNU Emacs Lisp Reference Manual*, [Completion in Buffers](https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-in-Buffers.html)
+
+A third return form exists and is discouraged: a function of no arguments,
+"only intended to help convert old code". A fourth, undocumented category is
+tracked internally — `completion--capf-misbehave-funs` (`lisp/minibuffer.el`
+:3256-3263) records capfs that complete immediately.
+
+**Why this matters here:** `cape-capf-super` and corfu's wrappers only handle
+the list form. A capf returning the legacy function form will not compose.
+
+Two further specifics from the same `@defvar`, both directly relevant to
+auto-popup tuning:
+
+- Capfs "should generally return quickly, since they may be called very often
+  (e.g., from `post-command-hook`)" — expensive collections should use
+  `completion-table-dynamic`.
+- "the collection should generally not be pre-filtered based on the current text
+  between start and end, because that is the responsibility of the caller …
+  according to the completion styles it decides to use" — i.e. a capf must not
+  do orderless's job.
+
+The manual text was diffed between the Emacs 31 tree and published Emacs 30:
+byte-for-byte identical. **No 30-vs-31 drift.**
+
+### 1.2 Chaining terminates at the first non-nil return [V]
+
+> "The first function in `completion-at-point-functions` to return a non-nil
+> value is used by `completion-at-point`. The remaining functions are not
+> called. The exception to this is when there is an `:exclusive`
+> specification."
+>
+> — *Elisp manual*, Completion in Buffers (minbuf.texi:2223-2226)
+
+The only documented escape is `:exclusive` with the value **`no`** — the manual
+documents no other value:
+
+> ":exclusive — If the value is `no`, then if the completion table fails to
+> match the text at point, `completion-at-point` moves on to the next function."
+
+Implementation: `completion-at-point` runs
+`(run-hook-wrapped 'completion-at-point-functions #'completion--capf-wrapper 'all)`,
+and the wrapper's sole fallthrough is
+
+```elisp
+(and (eq 'no (plist-get (nthcdr 3 res) :exclusive))
+     (null (try-completion ... (nth 2 res) ...))
+     (setq res nil))
+```
+
+### 1.3 The shadowing folklore is close to inverted [V]
+
+This is the single most consequential correction in this report for the current
+configuration.
+
+The common framing — "prepending tempel shadows the LSP" — does not hold:
+
+- **tempel is non-exclusive.** `tempel.el` (main, lines 806 and 833) returns
+  `:exclusive 'no` from **both** `tempel-expand` and `tempel-complete`. Prepended
+  tempel is precisely the case the `:exclusive no` exception rescues: it falls
+  through to eglot unless a template name actually prefix-matches.
+- **eglot is exclusive.** `lisp/progmodes/eglot.el` on master contains **no
+  occurrence of the string `exclusive` at all**, so eglot's capf is exclusive by
+  default.
+
+The real-world shadowing is therefore **eglot suppressing capfs placed *after*
+it** — which is exactly why cape ships `cape-capf-nonexclusive` /
+`cape-wrap-nonexclusive` (`cape.el`:1173, README:264).
+
+**Caveat on the fallthrough [V]:** it is approximate by design.
+`completion--capf-wrapper` carries its own FIXME —
+
+> "depends on the actual completion UI … We approximate this result by checking
+> whether prefix completion might work, which means that non-prefix completion
+> will not work (or not right) for completion functions that are non-exclusive."
+
+cape mirrors this in `cape-wrap-choose`. Since this config runs orderless (a
+non-prefix style), whether the approximation misfires here is a live question —
+see the gap-pass findings in Part 6.
+
+A grep of `etc/NEWS` (31 dev) and `etc/NEWS.30` shows **zero** changes to
+`completion-at-point-functions` or `:exclusive` semantics: 30 and 31 behave
+identically.
+
+### 1.4 Hook ordering: buffer-local, global, and the `t` element [V]
+
+> "the Capfs which occur earlier in the list take precedence, such that the
+> first Capf returning a result will win and the later Capfs may not get a
+> chance to run. In order to merge Capfs you can try the function
+> `cape-capf-super`."
+>
+> "The buffer-local value of the list takes precedence, but if the buffer-local
+> list contains the symbol `t` at the end, it means that the functions specified
+> in the global list should be executed afterwards. The special meaning of the
+> value `t` is a feature of the `run-hooks` function."
+>
+> — [cape README](https://github.com/minad/cape/blob/main/README.org)
+
+Independently corroborated by the Elisp manual's
+[Running Hooks](https://www.gnu.org/software/emacs/manual/html_node/elisp/Running-Hooks.html)
+node: "if the buffer-local variable contains the element `t`, the global hook
+variable will be run as well."
+
+**Precision [V]:** the `t` semantics are *positional* — global capfs run where
+`t` appears in the list, not necessarily last. cape says "at the end" because
+that is what `add-hook` produces. `completion-at-point` iterates via
+`run-hook-wrapped`, which honors the same convention.
+
+### 1.5 Merging vs. trying in turn [V]
+
+`cape-capf-super` is **not** the tool for sequential fallback:
+
+> "`cape-capf-super` is not needed if multiple Capfs should be tried one after
+> another … only necessary if you want to combine multiple Capfs, such that the
+> candidates from multiple sources appear *together* in the completion list at
+> the same time."
+
+The try-in-turn combinator is `cape-capf-choose` (`defalias` of
+`cape-wrap-choose`), whose docstring reads "Call each of CAPFS in turn and
+return first non-nil result."
+
+`cape-capf-super`'s documented restrictions:
+
+> "Capf merging requires completion functions which are sufficiently well-behaved
+> and completion functions which do not define completion boundaries.
+> `cape-capf-super` has the same restrictions as `completion-table-merge` and
+> `completion-table-in-turn`. As a simple rule of thumb, `cape-capf-super` works
+> for static completion functions like `cape-dabbrev`, `cape-keyword`,
+> `cape-dict`, etc., but not for multi-step completions like `cape-file`."
+
+And on caching:
+
+> "`cape-capf-super` creates a Capf, which caches the candidates for the whole
+> lifetime of the Capf. Therefore you may want to combine a merged Capf with a
+> cache buster."
+
+`cape.el`:930 adds: "cape-capf-super currently cannot merge Capfs which trigger
+at different beginning positions." `cape-wrap-super` also accepts a `:with`
+keyword marking auxiliary capfs.
+
+**Bearing on the current config:** `lisp/init-snippets.el`:70 merges
+`tempel-complete` with `eglot-completion-at-point` via `cape-capf-super`. Given
+1.3, the *shadowing* rationale for that merge is weaker than the comment in the
+file states — but the merge still buys a genuine benefit the fallthrough does
+not: snippet and server candidates appear in **one** popup simultaneously rather
+than the server's list only appearing when no template matches. The caching
+caveat above applies and is unaddressed (no cache buster).
+
+### 1.6 `:exit-function` — what a composed capf must preserve [V]
+
+`:exit-function` takes two arguments `(STRING STATUS)`, where STATUS is exactly
+one of `finished`, `sole`, `exact`:
+
+> "The function should accept two arguments, string and status … `finished` if
+> text is now complete, `sole` if the text cannot be further completed but
+> completion is not finished, or `exact` if the text is a valid completion but
+> may be further completed."
+>
+> — *Elisp manual*, [Completion Variables](https://www.gnu.org/software/emacs/manual/html_node/elisp/Completion-Variables.html)
+
+This is the mechanism by which **eglot expands LSP snippets and applies
+`textEdit`/`additionalTextEdits`**, and by which **tempel expands a template**.
+Concretely:
+
+```elisp
+;; eglot.el:4068ff
+:exit-function (lambda (proxy status)
+                 (eglot--capf-session-flush)
+                 (when (memq status '(finished exact)) …))
+```
+
+Note eglot does **nothing** on `sole`. tempel returns
+`:exit-function (apply-partially #'tempel--exit templates nil)` from
+`tempel-complete`, and `(… templates region)` from `tempel-expand`.
+
+cape re-splices these per-candidate. `cape--super-functions` is
+
+```elisp
+'(:company-docsig :company-location :company-kind :company-doc-buffer
+  :company-deprecated :annotation-function :exit-function)
+```
+
+dispatching back to the originating capf via a `cape--super` text property.
+`cape.el`:528 and :734 carry the comment "No cycling since it breaks the
+`:exit-function`."
+
+corfu's `corfu--exit-function` restores text properties precisely because eglot
+reads `(get-text-property 0 'eglot--lsp-item proxy)`.
+
+**Design rule [I]:** a custom dwim command that wraps or re-implements
+`completion-at-point` must preserve `:exit-function` and should guard on
+`(memq status '(finished exact))` as eglot does. `unknown` exists only as an
+internal pre-normalization sentinel in `completion--done` and never reaches an
+exit-function.
+
+### 1.7 `completion-styles` is a fallback chain, not a union [V]
+
+> "Emacs looks for the first style listed in `completion-styles` and calls its
+> `try-completion` function. If this function returns nil, Emacs moves to the
+> next listed completion style … until one of the try-completion functions
+> successfully performs completion and returns a non-nil value. A similar
+> procedure is used for listing completions, via the `all-completions`
+> functions."
+
+Implementation: `completion--nth-completion` dispatches with
+`(seq-some (lambda (style) …) (completion--styles md))` — `seq-some` stops at the
+first non-nil — and is the shared entry point for both `completion-try-completion`
+and `completion-all-completions`.
+
+Candidate sets from different styles are therefore **never merged**. This is the
+documented reason the position of `orderless` relative to `basic` /
+`partial-completion` / `flex` matters. The orderless README's own note that
+"the basic completion style needs to be tried *first* (not as a fallback) for
+TRAMP hostname completion to work" would be meaningless under a union model.
+
+**Refinements [V]:** the per-category escape hatch is
+`completion-category-overrides` / `completion-category-defaults`, so ordering
+must be reasoned about per category (`file`, `buffer`, `eglot-capf`, …), not
+globally. Elements may take the form `(STYLE ((VARIABLE VALUE) …))` to bind
+variables only while that style runs.
+
+**Scope note [I]:** the manual paragraph is framed around minibuffer commands.
+It applies to in-buffer corfu completion because corfu routes through
+`completion-all-completions` — that last step is inference, not manual text.
+
+---
+
+## Part 2 — TAB
+
+### 2.1 "TAB indents only" is the stock default, not a deviation [V]
+
+`tab-always-indent` defaults to **`t`** in both Emacs 30 and Emacs 31:
+
+```elisp
+;; indent.el (master)
+(defcustom tab-always-indent t
+  "Controls the operation of the TAB key.
+If t, hitting TAB always just indents the current line. …
+Some programming language modes have their own variable to control this,
+e.g., `c-tab-always-indent', and do not respect this variable.")
+```
+
+`indent-for-tab-command`'s **only** call to `completion-at-point` sits in a cond
+arm whose first conjunct is `(eq tab-always-indent 'complete)`. With the default
+`t` that branch is provably unreachable: TAB cannot invoke a capf.
+
+A verifier diffed master's `indent.el` against the `emacs-30` branch: byte-identical
+except the copyright year. **No 30-vs-31 drift.**
+
+The strongest available counter-evidence cuts the same way: Emacs 31 NEWS
+announces a new **opt-in** theme `newcomers-presets` whose body contains
+`'(tab-always-indent 'complete)` — i.e. 31 still defaults to `t` and needs an
+explicit theme to put completion on TAB.
+
+**[R] Refuted 0-3:** the claim that corfu's README recommends
+`tab-always-indent` = `complete`, i.e. that moving completion off TAB deviates
+from upstream corfu guidance. There is no evidence of such a recommendation.
+
+**[R] Refuted 0-3:** the claim that `tab-always-indent` = `complete` is the
+*only* documented way TAB invokes completion. Modes that rebind TAB in their own
+keymap are a counterexample — see 2.2.
+
+### 2.2 What "TAB never completes" still requires [V]
+
+The claim in 2.1 is scoped to `indent-for-tab-command`. End-to-end, four things
+bypass the variable:
+
+1. **corfu's own keymap.** `corfu-map` binds `"TAB"` → `corfu-complete` (plus
+   `"M-TAB"` → `corfu-expand`, `"RET"` → `corfu-insert`). A literal
+   "TAB never completes" therefore requires unbinding TAB in `corfu-map`.
+   *This is a live decision for the design document.*
+2. **Modes that rebind TAB in their keymap** bypass the variable entirely:
+   `org-cycle`, message-mode's `message-tab`, shell-mode's
+   `(keymap-set shell-mode-map "TAB" 'completion-at-point)`.
+3. **Modes with their own variable**: `c-tab-always-indent` (also default `t`),
+   `cperl-tab-always-indent`. Some modes `setq-local tab-always-indent nil`
+   (asm-mode, change-log-mode, snmp-mode) — that inserts a literal tab past the
+   indentation, still not completion.
+4. **Minibuffer and comint** TAB never routes through `tab-always-indent`.
+
+Additionally, this repo's `lisp/init-snippets.el`:42 binds `TAB` → `tempel-next`
+in `tempel-map`, which is active only while a template session is live. That is
+a fifth TAB consumer, and an intentional one.
+
+### 2.3 `tab-first-completion` — scope correction [V]
+
+**The variable was added in Emacs 28.1, not Emacs 30.** It carries
+`:version "28.1"`, is announced in `etc/NEWS.28` ("New user option
+'tab-first-completion'"), and is **absent from `etc/NEWS.30`**. Its defcustom
+body is byte-identical across the `emacs-30`, `emacs-31`, and `master` branches.
+
+**It is not a predicate option.** The `:type` is a closed choice of exactly five
+symbols:
+
+```elisp
+(choice (const :tag "Always complete" nil)
+        (const :tag "Only complete at the end of a line" eol)
+        (const :tag "Unless looking at a word" word)
+        (const :tag "Unless at a word or parenthesis" word-or-paren)
+        (const :tag "Unless at a word, parenthesis, or punctuation." word-or-paren-or-punct))
+```
+
+Dispatch is a `pcase` on a syntax class, not a `funcall` (indent.el ~189-194):
+
+```elisp
+(let ((syn (syntax-class (syntax-after (point)))))
+  (pcase tab-first-completion
+    ('nil t)
+    ('eol (eolp))
+    ('word (not (eql 2 syn)))
+    ('word-or-paren (not (memq syn '(2 4 5))))
+    ('word-or-paren-or-punct (not (memq syn '(2 4 5 1))))))
+```
+
+A lambda would match no arm and silently degrade to "never complete on first
+TAB". The predicate reading is not merely undocumented — it is *unimplemented*.
+
+**It is inert unless `tab-always-indent` is `complete`.** That pcase sits inside
+a cond clause guarded by `(eq tab-always-indent 'complete)`, and a repo-wide code
+search finds only four references (indent.el, doc/emacs/indent.texi,
+doc/lispref/text.texi, etc/NEWS.28). There is no second code path. The docstring
+closes: "This variable has no effect unless `tab-always-indent' is `complete'."
+
+**Consequence for this configuration:** with TAB on indent-only,
+`tab-first-completion` is irrelevant and should be documented as such rather than
+tuned. (This retires the "'complete + tab-first-completion guard" option that was
+on the table during scoping.)
+
+Note also that the Emacs *user* manual documents only one of the five values
+(`eol`) and defers to the Elisp node Mode-Specific Indent — that page alone
+cannot enumerate the option.
+
+### 2.4 The explicit key: `C-M-i` / `ESC TAB`, never `M-TAB` [V]
+
+> "In most programming language modes, `C-M-i` (or `M-TAB`) invokes the command
+> `completion-at-point` …"
+>
+> "On graphical displays, the `M-TAB` key is usually reserved by the window
+> manager for switching graphical windows, so you should type `C-M-i` or
+> `ESC TAB` instead."
+>
+> — *Emacs manual*, [Symbol Completion](https://www.gnu.org/software/emacs/manual/html_node/emacs/Symbol-Completion.html)
+
+The Elisp manual independently states "In many major modes, in-buffer completion
+is performed by the `C-M-i` or `M-TAB` command, bound to `completion-at-point`."
+Two primary manuals agree.
+
+**Mechanism [V]:** the window manager steals the *function-key event* `<M-tab>`
+(Alt+Tab). `C-M-i` is the ASCII meta-C-i event, which is why Emacs still sees it.
+They are distinct events **only on window systems** — on a TTY the terminal
+cannot distinguish TAB from C-i, so `C-M-i`, `M-TAB` and `ESC TAB` all arrive as
+the same ESC+C-i sequence.
+
+**Consequences for the design:**
+
+- Binding a dwim command to `C-M-i` is safe on GUI **and** TTY.
+- It cannot be made *distinct* from `ESC TAB` in a terminal.
+- Doing so **overrides a documented standard binding** (the global binding is
+  historically `complete-symbol` in `esc-map`, delegating to
+  `completion-at-point`). That is a deliberate choice to document, not a
+  correctness problem.
+- The manual's "in many/most major modes" is a real hedge — modes do rebind
+  these.
+
+**Existence proof [I]:** vanilla Emacs — `tab-always-indent` = `t`, completion on
+`C-M-i` — *is* the configuration this design wants, minus the snippet chaining.
+
+---
+
+## Part 3 — Core completion preview (Emacs 30/31)
+
+### 3.1 What it is, and the conditional TAB conflict [V]
+
+Completion Preview mode is core inline ghost text, new in Emacs 30. Both
+`completion-preview-mode` and `global-completion-preview-mode` are **off by
+default**.
+
+> "Completion Preview mode is a minor mode that shows completion suggestions as
+> you type. … Emacs automatically displays the suggested completion for text
+> around point as an in-line preview right after point; type TAB to accept the
+> suggestion."
+
+The TAB binding lives in the **transient** `completion-preview-active-mode-map`
+(binds `"C-i"` → `completion-preview-insert`, `"M-i"` →
+`completion-preview-complete`), active only while a preview overlay is displayed.
+
+Eshel Yaron, the implementer:
+
+> "Crucially, whenever the preview is shown, TAB inserts its contents.
+> Otherwise, Completion Preview mode doesn't bind any keys."
+
+**So [I]:** with `tab-always-indent` = `t`, TAB still indents normally; it is
+hijacked only during the preview window, via minor-mode keymap precedence over
+`indent-for-tab-command`. This is a genuine conflict for a TAB-indents-only
+design, but *conditional* and *only if opted into*. The manual documents the
+binding; the conflict is a mechanically verifiable inference, not manual text.
+
+Defcustoms present: `completion-preview-minimum-symbol-length` (default **3**),
+`completion-preview-idle-delay` (default **nil**), `completion-preview-commands`,
+`completion-preview-exact-match-only`, `completion-preview-ignore-case`,
+`completion-preview-adapt-background-color`, `completion-preview-sort-function`.
+
+`global-completion-preview-mode` carries a `:predicate` excluding archive-mode,
+calc-mode, compilation-mode, diff-mode, dired-mode, image-mode, minibuffer-mode,
+minibuffer-inactive-mode, org-agenda-mode, special-mode, wdired-mode.
+
+Documented escapes from the TAB binding: rebind inside
+`completion-preview-active-mode-map`, or (on 31) use
+`completion-preview-inhibit-functions`.
+
+### 3.2 Emacs 31 adds the sanctioned per-context gate [V]
+
+`etc/NEWS.31` line 309:
+
+> "*** New user option 'completion-preview-inhibit-functions'. This option
+> provides fine-grained control over Completion Preview mode activation. You can
+> use it to specify arbitrary conditions in which to inhibit the mode's
+> operation."
+
+The defcustom (`completion-preview.el`:179-185) carries `:version "31.1"`:
+
+> "Completion Preview mode calls the functions on this hook without arguments
+> during `post-command-hook'. If any of these functions returns non-nil, it
+> inhibits the preview display."
+
+Wired in at line 648:
+`(not (run-hook-with-args-until-success 'completion-preview-inhibit-functions))`
+short-circuits `completion-preview--show`.
+
+**Absent in Emacs 30 [V]:** a grep of the `emacs-30` branch finds only internal
+`completion-preview--inhibit-update-p` / `--inhibit-update`. Emacs 30 NEWS
+mentions completion-preview exactly once ("** New minor mode
+'completion-preview-mode'.").
+
+Upstream's own Commentary shows the intended pattern:
+`(add-hook 'completion-preview-inhibit-functions (lambda () executing-kbd-macro))`.
+A `(nth 4 (syntax-ppss))` comment/string predicate is a straightforward
+application — **[I]**, that specific recipe is inference, not upstream wording.
+
+**Precision [V]:** it inhibits the preview *display* per command; it does not
+toggle the mode off. An already-shown preview is torn down via
+`(completion-preview-active-mode -1)`.
+
+### 3.3 `completion-preview-sort-function` and the eglot no-op [V]
+
+`etc/NEWS.31`:
+
+> "If you use this mode together with an in-buffer completion popup interface,
+> such as the interfaces that the GNU ELPA packages Corfu and Company provide,
+> you can set this option to the same sort function that your popup interface
+> uses for a more integrated experience. ('completion-preview-sort-function' was
+> already present in Emacs 30.1, but as a plain Lisp variable, not a user
+> option.)"
+
+Confirmed by commit `8b9194ae` (Eshel Yaron, 2025-02-28), whose diff shows
+`defvar` → `defcustom` with `:version "31.1"`.
+
+**Decision-relevant caveat [V]:** the docstring adds "If the completion table
+that produces the candidates already specifies a sort function, it takes
+precedence over this option." Since eglot's capf supplies
+`:display-sort-function`, aligning this option with corfu's sorting is a **no-op
+in eglot-driven buffers**.
+
+**[I]** NEWS never contrasts coexistence with replacement. "Completion preview is
+intended to coexist with, rather than replace, corfu" is a fair reading of the
+Corfu/Company sentence above, but it is an editorial gloss, not upstream wording.
+
+---
+
+## Part 4 — corfu
+
+### 4.1 `corfu-auto` latches at mode-enable time [V]
+
+This is the mechanism the "auto in code, manual in prose" requirement depends on.
+
+> "Auto completion is disabled by default in Corfu. … Auto completion can be
+> enabled by setting `corfu-auto` to t locally or globally **before enabling**
+> the local `corfu-mode` or the `global-corfu-mode`."
+>
+> — [corfu README](https://raw.githubusercontent.com/minad/corfu/main/README.org)
+
+A verifier grepped `corfu.el` for `corfu-auto` and found exactly **two** sites:
+the defcustom, and **one** runtime read in the mode body —
+
+```elisp
+(when corfu-auto
+  (require 'corfu-auto)
+  (add-hook 'post-command-hook 'corfu-auto--post-command 10 'local))
+```
+
+The verifier specifically hunted for a runtime re-check that would refute the
+ordering requirement. `corfu-auto--post-command` gates on
+`completion-in-region-mode`, `defining-kbd-macro`, `buffer-read-only`,
+`(corfu--match-symbol-p corfu-auto-commands this-command)`,
+`corfu--popup-support-p`, then `corfu-auto-delay` / `corfu-auto-trigger` — it
+**never examines `corfu-auto`**. The value genuinely latches at mode-enable time.
+The ordering requirement is real, not folklore.
+
+**Why the `prog-mode-hook` pattern works [V]:** `global-corfu-mode` is a
+`define-globalized-minor-mode` dispatching through `corfu--on` from
+`after-change-major-mode-hook`, which `run-mode-hooks` runs **after** major-mode
+hooks. So:
+
+```elisp
+(add-hook 'prog-mode-hook (lambda () (setq-local corfu-auto t)))
+```
+
+is correctly ordered against `global-corfu-mode`.
+
+**Two failure modes [V]:**
+
+1. `define-minor-mode` runs the mode hook *after* the body, so setting
+   `corfu-auto` in `corfu-mode-hook` is **too late**.
+2. Buffers already open when `global-corfu-mode` is first enabled do not re-run
+   their major-mode hooks and keep whatever `corfu-auto` value they had. Relevant
+   at startup ordering and after a config reload.
+
+**Honest scoping [I]:** calling this "*the* prog/prose mechanism" is
+editorializing. Upstream's own documented per-mode knob is `global-corfu-modes`
+(the `:predicate`-generated defcustom), which is an **on/off knob for corfu-mode
+itself, not an auto/manual knob**. The README also documents enabling
+`corfu-mode` per-mode via hooks instead of globally. The setq-local-in-hook
+technique is *a* mechanism licensed by the README sentence quoted above, not
+presented upstream as *the* recipe.
+
+corfu 2.x moved auto-completion into `extensions/corfu-auto.el`, which makes the
+latch behavior stronger, not weaker.
+
+### 4.2 Trigger-character gating — upstream prior art [V]
+
+Upstream ships a first-party recipe for gating a merged snippet capf behind a
+**trigger character**. From the cape README (appears twice — in the
+`cape-capf-super` section and as "Example 1: Configure a merged Capf with a
+trigger prefix character"):
+
+```elisp
+;; Trigger completion only after trigger character.
+(setq-local corfu-auto-trigger "/"
+            completion-at-point-functions
+            (list (cape-capf-trigger
+                   (cape-capf-super #'cape-abbrev #'tempel-complete) ?/)))
+```
+
+Both APIs exist in shipped code, not just README prose:
+
+- `cape.el`:1286 — `(defun cape-wrap-trigger (capf trigger) "Ensure that TRIGGER
+  character occurs before point and then call CAPF. See also
+  `corfu-auto-trigger'.")`. It searches back to `pos-bol` for the trigger char,
+  requires no whitespace between it and point, treats the trigger as punctuation
+  syntax, and rewrites `beg` to `(1+ pos)` with `:company-prefix-length t`.
+- `corfu-auto.el`:35 — `(defcustom corfu-auto-trigger "" "Characters which
+  trigger auto completion. If a trigger character is detected `corfu-auto-prefix'
+  is ignored." :type 'string)`, consumed via `seq-contains-p` on
+  `last-command-event`, bypassing **both** `corfu-auto-prefix` and
+  `corfu-auto-delay`.
+
+**Version floors [V]:** cape ≥ 2.3 and corfu ≥ 2.5 (both changelogs dated
+2025-11-15); still present in cape 2.7 / corfu 2.11. corfu 2.x requires
+`extensions/corfu-auto.el` to be loaded.
+
+**Two qualifications [V]:**
+
+- This is a **gated auto-popup** recipe, **not a keybinding recipe** — the README
+  proposes no key. Do not cite it as prior art for a dwim keybinding; cite it
+  only for trigger-character gating.
+- It replaces `completion-at-point-functions` buffer-locally with a **single**
+  capf. **No eglot coexistence is demonstrated.**
+
+### 4.3 TTY child frames — a live 30-vs-31 split for this repo [V]
+
+corfu's child-frame popup renders natively in terminal Emacs starting with
+**Emacs 31**; the separate `corfu-terminal` package is needed only on 30 and
+below.
+
+corfu README, twice: "Corfu relies on child frames to show the popup. On Emacs
+31 this works for terminal Emacs. Use the `corfu-terminal` package on older Emacs
+versions."
+
+Decisive upstream corroboration — `etc/NEWS.31`:
+
+> "Child frames are now supported on TTY frames. This supports use-cases like
+> Posframe, Corfu, and child frames acting like tooltips."
+
+NEWS names Corfu explicitly and documents the feature-detection predicate
+`(featurep 'tty-child-frames)`. No opt-in variable gates general child-frame
+support (`tty-tip-mode` is tooltip-specific). Further confirmed by corfu commit
+`f17fe365d2` "Emacs 31 supports child frames on TTY 🎉", which removed the old
+README text about falling back on non-graphical terminals.
+
+**Relevance to this repo [V]:** per `CLAUDE.md` the default build is the
+emacs-overlay `unstable` variant — the Emacs 31 release branch, currently the
+**31.0.90 pretest** — while the declared floor is **30.1**. This split is live
+here. Because the pretest is 31.0.90 rather than 31.1, **a
+`(featurep 'tty-child-frames)` gate is correct where a version comparison would
+be wrong.** The repo ships a terminal-only distribution
+(`jotainEmacsPackagesNoGui`, used by the nix-on-droid module), so this is not
+hypothetical.
+
+Adjacent known bug: [bug#76052](https://debbugs.gnu.org/76052), TTY child frames
+for Corfu offset upward at the bottom of a window — a polish issue that confirms
+rather than contradicts the mechanism.
+
+**Stale-source warning:** corfu-terminal's NonGNU ELPA page (v0.7, 2024-03-31)
+still says flatly "Corfu uses child frames … This makes Corfu unusable on
+terminal" and never mentions Emacs 31. Stale silence, not a contradiction — but
+a reader consulting only that page would be misled.
+
+---

--- a/lisp/init-completion.el
+++ b/lisp/init-completion.el
@@ -13,6 +13,109 @@
 
 ;;; Code:
 
+;;;; User options
+;;
+;; Every knob below is read once, at load time, and needs a restart to take
+;; effect -- there are deliberately no `:set' functions.  Half-reactive
+;; options are worse than clearly static ones: core's own
+;; `text-mode-ispell-word-completion' splits its `:set' across a keymap and a
+;; mode-entry read, and that split is a documented source of confusion.
+;;
+;; For a one-off change without a restart, `M-x corfu-mode' toggles the popup
+;; in the current buffer and `M-x global-corfu-mode' toggles the whole stack.
+
+(defgroup jotain-completion nil
+  "In-buffer completion behaviour for the Jotain configuration."
+  :group 'convenience)
+
+(defcustom jotain-completion-auto-modes '(prog-mode-hook)
+  "Hooks whose buffers get the corfu popup automatically.
+Everywhere else completion happens only when asked for, via
+`jotain-completion-key'.  Set to nil for manual-only completion
+everywhere, including code.
+
+`corfu-auto' is read once when `corfu-mode' turns on, so these must be
+mode hooks that run before it: `global-corfu-mode' dispatches from
+`after-change-major-mode-hook', which runs after major-mode hooks.
+Buffers already open when corfu first starts keep their old value."
+  :type '(repeat symbol)
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-auto-delay 0.1
+  "Idle seconds before the automatic popup appears.
+Applies only in `jotain-completion-auto-modes' buffers.  This value is
+not tuned -- no measurement backs it."
+  :type 'number
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-auto-prefix 2
+  "Characters typed before the automatic popup appears.
+Applies only in `jotain-completion-auto-modes' buffers."
+  :type 'integer
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-key "C-M-i"
+  "Key bound to `completion-at-point', or nil to bind nothing.
+`C-M-i' is the binding the Emacs manual recommends, which also steers
+users away from `M-TAB' because window managers reserve Alt+Tab.  Note
+that binding it here replaces the stock global `complete-symbol', so
+`C-u C-M-i' no longer runs `info-complete-symbol'.
+
+On a terminal `C-M-i', `M-TAB' and `ESC TAB' are the same event and
+cannot be told apart."
+  :type '(choice (string :tag "Key sequence") (const :tag "Do not bind" nil))
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-free-return t
+  "When non-nil, RET never accepts a completion candidate.
+Corfu binds RET to `corfu-insert' by default; this unbinds it so RET is
+always a newline.  Freeing RET is an upstream-documented configuration.
+Set to nil to restore corfu's default."
+  :type 'boolean
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-free-tab t
+  "When non-nil, TAB never completes -- it only indents.
+Two things are needed for that: `tab-always-indent' set to t (the stock
+Emacs default), and corfu's own TAB binding removed, since the popup's
+keymap would otherwise take precedence while it is open.  This option
+covers the second.  Set to nil to restore corfu's default."
+  :type 'boolean
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-fallbacks t
+  "When non-nil, add the cape fallback capfs to the global capf list.
+These are `cape-dabbrev', `cape-file' and `cape-keyword' -- the generic
+sources that run when a buffer has nothing better to offer."
+  :type 'boolean
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-snippets t
+  "When non-nil, snippet names appear as candidates in the popup.
+`tempel-complete' is added to the buffer-local capf list, and in
+eglot-managed buffers it is merged with the server's capf so snippet and
+server candidates share one popup.  nil adds no tempel capf; `M-+' and
+`M-*' keep working.
+
+Read at load time by `init-snippets.el'."
+  :type 'boolean
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-eglot-nonexclusive t
+  "When non-nil, stop the LSP capf suppressing the cape fallbacks.
+`eglot.el' declares no `:exclusive' property, so its capf is exclusive
+and every capf ordered after it is skipped -- and `cape-capf-super'
+propagates non-exclusivity only when *every* input is non-exclusive, so
+merging a snippet capf into it does not help.  The upshot is that
+`cape-dabbrev', `cape-file' and `cape-keyword' never run in an LSP
+buffer.  Wrapping the merged capf in `cape-capf-nonexclusive' lets them
+run when the server offers nothing for the text at point.
+
+Both halves of that are measured in `test/completion-test.el'.  nil
+leaves the capf exactly as eglot installs it."
+  :type 'boolean
+  :group 'jotain-completion)
+
 ;;;; Minibuffer defaults
 
 ;;; @doc Built-in minibuffer customisation: detailed annotations and
@@ -264,27 +367,67 @@
 
 ;;;; In-buffer completion
 
-;;; @doc `tab-always-indent' = `complete' turns TAB into the single
-;;; trigger for the whole completion stack: it indents the line when
-;;; indentation is pending and otherwise summons corfu with every
-;;; `completion-at-point-functions' entry — the major mode's own capf
-;;; plus the cape fallbacks wired up below. Auto-completion still fires
-;;; on its own, but this gives an explicit, muscle-memory trigger.
+;;; @doc `tab-always-indent' = t is the stock Emacs default, restored here
+;;; deliberately: TAB indents the line and does nothing else.
+;;; `indent-for-tab-command's only call to `completion-at-point' is
+;;; guarded by (eq tab-always-indent 'complete), so with t that branch is
+;;; unreachable and TAB provably cannot summon a capf. Completion lives on
+;;; `C-M-i' instead (`jotain-completion-key'). `tab-first-completion' is
+;;; inert unless `tab-always-indent' is `complete', so it is irrelevant
+;;; here and is never set.
 (use-package emacs
   :ensure nil
   :custom
-  (tab-always-indent 'complete))
+  (tab-always-indent t))
+
+;; The one completion gesture.  `completion-at-point' rather than the stock
+;; `complete-symbol' is load-bearing: `corfu-map' contains a
+;; `<remap> <completion-at-point>' entry, and a remap only fires for the
+;; command the key actually resolves to.  Binding the command itself is
+;; therefore what makes the same key accept the selected candidate while the
+;; popup is open, so no second accept key is needed.
+(when jotain-completion-key
+  (keymap-global-set jotain-completion-key #'completion-at-point))
 
 ;;; @doc In-buffer completion popup — the corfu equivalent of company.
-;;; Auto-triggered after 2 chars so it feels like a modern editor
-;;; without a long delay.
+;;; The popup appears on its own only in the modes listed by
+;;; `jotain-completion-auto-modes' (default: programming modes), so prose
+;;; stays quiet and completes only when asked via `C-M-i'. RET and TAB are
+;;; unbound in `corfu-map', so Enter always inserts a newline and TAB
+;;; always indents, even while the popup is showing. `M-n'/`M-p' move,
+;;; `C-g' dismisses, `C-M-i' accepts.
 (use-package corfu
   :hook (after-init . global-corfu-mode)
+  :preface
+  ;; `corfu-map' is a `defvar-keymap' inside corfu.el, which is not loaded
+  ;; when this file is byte-compiled; declare it so the `:config' keymap
+  ;; edits below compile clean under `byte-compile-error-on-warn'.
+  (defvar corfu-map)
+  (defun jotain-completion--enable-auto ()
+    "Turn on corfu's auto-popup in the current buffer.
+Must run before `corfu-mode' is enabled: `corfu-auto' is read exactly
+once, in the `corfu-mode' body, and nothing re-reads it afterwards.
+Major-mode hooks satisfy that because `global-corfu-mode' dispatches from
+`after-change-major-mode-hook', which `run-mode-hooks' runs after them.
+Setting `corfu-auto' from `corfu-mode-hook' would be too late, since
+`define-minor-mode' runs the mode hook after the body."
+    (setq-local corfu-auto t))
+  :init
+  (dolist (hook jotain-completion-auto-modes)
+    (add-hook hook #'jotain-completion--enable-auto))
   :custom
   (corfu-cycle t)
-  (corfu-auto t)
-  (corfu-auto-prefix 2)
-  (corfu-auto-delay 0.1))
+  (corfu-auto nil)
+  (corfu-auto-prefix jotain-completion-auto-prefix)
+  (corfu-auto-delay jotain-completion-auto-delay)
+  :config
+  ;; REMOVE = t genuinely deletes the entry rather than binding it to nil,
+  ;; so the key falls through to the buffer and global maps.
+  (when jotain-completion-free-return
+    (keymap-unset corfu-map "RET" t))
+  (when jotain-completion-free-tab
+    (keymap-unset corfu-map "TAB" t)
+    (keymap-unset corfu-map "<tab>" t)))
 
 ;;; @doc Persists corfu's pick history into savehist so frequent
 ;;; completions float to the top across sessions. Bundled with
@@ -311,9 +454,10 @@
   (cape-file-directory-must-exist t)
   (cape-file-prefix '("~" "/" "./" "../"))
   :init
-  (add-hook 'completion-at-point-functions #'cape-dabbrev)
-  (add-hook 'completion-at-point-functions #'cape-file)
-  (add-hook 'completion-at-point-functions #'cape-keyword)
+  (when jotain-completion-fallbacks
+    (add-hook 'completion-at-point-functions #'cape-dabbrev)
+    (add-hook 'completion-at-point-functions #'cape-file)
+    (add-hook 'completion-at-point-functions #'cape-keyword))
   (defun jotain-cape-setup-elisp ()
     "Add `cape-elisp-symbol' as an Elisp fallback capf.
 The positive depth appends it after the mode's own

--- a/lisp/init-snippets.el
+++ b/lisp/init-snippets.el
@@ -7,8 +7,10 @@
 ;; the heavier `yasnippet': Tempel is by the same author as the
 ;; corfu/cape/vertico stack this config already runs, so it plugs
 ;; straight into `completion-at-point-functions' (snippet names surface
-;; in the corfu popup) and adds TextMate-style tab-stop field navigation
-;; that the built-ins lack.
+;; in the corfu popup) and adds tab-stop field navigation that the
+;; built-ins lack.  Those fields move on `M-}'/`M-{' (tempel's own keys)
+;; or `C-M-n'/`C-M-p'; TAB is not involved anywhere, because in this
+;; configuration TAB indents and nothing else.
 ;;
 ;; The curated templates themselves live in `templates/jotain.eld', keyed
 ;; by major mode -- not in this file -- so adding a snippet never means
@@ -27,36 +29,61 @@
 (defvar-local jotain-tempel--eglot-merged nil
   "Merged tempel+eglot capf installed in this buffer, or nil.")
 
+;; Both are defined in `init-completion.el', which `init.el' loads first.
+(defvar jotain-completion-snippets)
+(defvar jotain-completion-eglot-nonexclusive)
+
 ;;; @doc Lightweight template/snippet engine from the corfu/cape author.
 ;;; Templates are read from `templates/*.eld' (keyed by major mode);
 ;;; `M-+' completes a snippet by name, `M-*' inserts one interactively,
-;;; and once fields are active `TAB'/`S-TAB' move between them.
+;;; and once fields are active `M-}'/`M-{' or `C-M-n'/`C-M-p' move
+;;; between them, with `M-RET' to finish. TAB is deliberately not
+;;; involved: in this configuration TAB indents and nothing else. Set
+;;; `jotain-completion-snippets' to nil to keep snippet names out of the
+;;; completion popup; `M-+' and `M-*' still work.
 (use-package tempel
-  :functions (tempel-complete cape-capf-super eglot-completion-at-point eglot-managed-p)
+  :functions (tempel-complete cape-capf-super cape-capf-buster
+              cape-capf-nonexclusive eglot-completion-at-point eglot-managed-p)
   :custom
   (tempel-path (expand-file-name "templates/*.eld" user-emacs-directory))
   :bind
   (("M-+" . tempel-complete)
    ("M-*" . tempel-insert)
    :map tempel-map
-   ("TAB" . tempel-next)
-   ("<backtab>" . tempel-previous))
+   ;; TAB is deliberately absent: it indents, always.  Upstream `tempel-map'
+   ;; never bound it either -- the TAB/S-TAB pair that used to live here was
+   ;; this config's own addition.  Removing it restores tempel's own
+   ;; `M-}'/`M-{' (plus `M-RET' to finish and `M-<up>'/`M-<down>'), and the
+   ;; two below are added as a mnemonic alias.  Neither collides with
+   ;; corfu's `M-n'/`M-p', which matters because `tempel-map' rides on an
+   ;; overlay `keymap' property and so outranks corfu's minor-mode map while
+   ;; a snippet is live.
+   ("C-M-n" . tempel-next)
+   ("C-M-p" . tempel-previous))
   :init
   ;; Prepend `tempel-complete' to the buffer-local capf list so snippet
   ;; names appear in the corfu popup ahead of dabbrev/keyword candidates
-  ;; (cf. the cape capfs in `init-completion.el').  Outside LSP buffers
-  ;; this only ever shadows the low-value dabbrev/keyword fallbacks.
+  ;; (cf. the cape capfs in `init-completion.el').
   (defun jotain-tempel-setup-capf ()
     "Add `tempel-complete' to the front of the buffer-local capfs."
     (add-hook 'completion-at-point-functions #'tempel-complete -90 t))
-  (add-hook 'prog-mode-hook #'jotain-tempel-setup-capf)
-  (add-hook 'text-mode-hook #'jotain-tempel-setup-capf)
-  ;; In eglot-managed buffers, prepending `tempel-complete' would hide LSP
-  ;; candidates for prefixes that match a snippet name (f, if, class...).
-  ;; Merge the two into a single capf with `cape-capf-super' so snippet and
-  ;; server candidates share one corfu popup instead of shadowing.  The
-  ;; `jotain-tempel--eglot-merged' guard is declared at top level above and
-  ;; stores the merged capf itself so teardown can remove it again.
+  (when jotain-completion-snippets
+    (add-hook 'prog-mode-hook #'jotain-tempel-setup-capf)
+    (add-hook 'text-mode-hook #'jotain-tempel-setup-capf))
+  ;; Merge the snippet capf with eglot's so both sets of candidates share
+  ;; one popup, rather than the server's list only appearing when no
+  ;; template name matches.
+  ;;
+  ;; Note this is NOT about tempel shadowing the LSP -- it cannot.  Both
+  ;; tempel capfs return `:exclusive no' and fall through when nothing
+  ;; matches.  Eglot is the exclusive one (eglot.el declares no
+  ;; `:exclusive' at all), so it suppresses whatever follows it, and
+  ;; `cape-capf-super' propagates non-exclusivity only when *every* input
+  ;; is non-exclusive -- so the merge inherits eglot's exclusivity and
+  ;; would silently kill the global cape fallbacks.  Hence the
+  ;; `cape-capf-nonexclusive' wrapper; `test/completion-test.el' measures
+  ;; both halves.  `cape-capf-buster' invalidates the candidate cache that
+  ;; `cape-capf-super' otherwise holds for the whole lifetime of the capf.
   (defun jotain-tempel-eglot-capf ()
     "Merge `tempel-complete' with eglot's capf in managed buffers.
 `eglot-managed-mode-hook' also runs on server shutdown; in that
@@ -67,7 +94,12 @@ and re-arm the merge for a later reconnect."
         (unless jotain-tempel--eglot-merged
           (remove-hook 'completion-at-point-functions #'tempel-complete t)
           (setq jotain-tempel--eglot-merged
-                (cape-capf-super #'tempel-complete #'eglot-completion-at-point))
+                (let ((merged (cape-capf-buster
+                               (cape-capf-super #'tempel-complete
+                                                #'eglot-completion-at-point))))
+                  (if jotain-completion-eglot-nonexclusive
+                      (cape-capf-nonexclusive merged)
+                    merged)))
           (setq-local completion-at-point-functions
                       (cons jotain-tempel--eglot-merged
                             (remq #'eglot-completion-at-point
@@ -80,7 +112,8 @@ and re-arm the merge for a later reconnect."
                           completion-at-point-functions))
         (setq jotain-tempel--eglot-merged nil)
         (add-hook 'completion-at-point-functions #'tempel-complete -90 t))))
-  (add-hook 'eglot-managed-mode-hook #'jotain-tempel-eglot-capf))
+  (when jotain-completion-snippets
+    (add-hook 'eglot-managed-mode-hook #'jotain-tempel-eglot-capf)))
 
 ;;; @doc Lets Tempel expand the snippets language servers send back
 ;;; (e.g. function-argument placeholders from rust-analyzer / pyright).

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -66,9 +66,6 @@ and the result is a face-attribute soup."
 
 ;;;; Modeline
 
-;;; @doc A dense, IDE-style modeline with LSP/eglot status, project
-;;; buffer info, and Nerd Font glyphs. Loaded after init so the
-;;; primary frame doesn't redraw before fonts are ready.
 (defun jotain-ui--apply-modeline-icons (&optional frame)
   "Enable doom-modeline glyphs only on a graphical FRAME.
 Terminal frames have no Nerd Font, so the icons render as tofu; gate
@@ -80,6 +77,9 @@ glyphs even though no graphical frame exists at daemon start (mirrors
     (setopt doom-modeline-icon (and (display-graphic-p frame) t))
     (force-mode-line-update t)))
 
+;;; @doc A dense, IDE-style modeline with LSP/eglot status, project
+;;; buffer info, and Nerd Font glyphs. Loaded after init so the
+;;; primary frame doesn't redraw before fonts are ready.
 (use-package doom-modeline
   :hook (after-init . doom-modeline-mode)
   :custom

--- a/test/completion-test.el
+++ b/test/completion-test.el
@@ -1,0 +1,275 @@
+;;; completion-test.el --- Tests for the in-buffer completion wiring -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Batch-safe tests for the capf layer that `lisp/init-completion.el' and
+;; `lisp/init-snippets.el' build on.  No network, no subprocesses, no writes
+;; outside a temp buffer -- safe inside the Nix sandbox.
+;;
+;; The first section pins down two behaviours of the core capf protocol that
+;; the design in `docs/design/completion.md' depends on and that could not be
+;; settled from documentation:
+;;
+;;   1. An exclusive capf (one that declares no `:exclusive' at all, which is
+;;      how eglot's capf is written) suppresses every capf after it, and
+;;      whether `cape-capf-nonexclusive' is the documented escape.
+;;
+;;   2. Whether the `:exclusive no' fallthrough honours `completion-styles'.
+;;      `completion--capf-wrapper' decides it with a bare `try-completion',
+;;      and its own FIXME warns that "non-prefix completion will not work (or
+;;      not right) for completion functions that are non-exclusive".
+;;
+;; Run with:
+;;   emacs --batch -L lisp -L test -l ert -l test/completion-test.el \
+;;         -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+(require 'cape)
+(require 'orderless)
+
+;;;; Helpers
+
+;; Three capfs covering the shapes that matter.  Each reports bounds spanning
+;; the text already in the buffer, so the wrapper's prefix test sees a real
+;; prefix rather than the empty string.
+
+(defun completion-test--capf-exclusive ()
+  "Capf shaped like eglot's: no `:exclusive' key at all, so exclusive."
+  (list (line-beginning-position) (point) '("alpha" "beta")))
+
+(defun completion-test--capf-nonexclusive ()
+  "Capf shaped like tempel's: explicitly `:exclusive no'."
+  (list (line-beginning-position) (point) '("alpha" "beta") :exclusive 'no))
+
+(defun completion-test--capf-substring ()
+  "Non-exclusive capf whose candidate matches under orderless but not by prefix."
+  (list (line-beginning-position) (point) '("barfoo") :exclusive 'no))
+
+(defun completion-test--capf-later ()
+  "Capf standing in for the cape fallbacks placed after the semantic one."
+  (list (line-beginning-position) (point) '("later-capf-ran")))
+
+(defun completion-test--winning-collection (capfs)
+  "Return the candidate list `completion-at-point' would use from CAPFS.
+Runs the same `run-hook-wrapped' dispatch that `completion-at-point'
+uses, so the `:exclusive' handling under test is the real one."
+  (let* ((completion-at-point-functions capfs)
+         (res (run-hook-wrapped 'completion-at-point-functions
+                                #'completion--capf-wrapper 'all)))
+    (and (consp res) (nth 2 (cdr res)))))
+
+;;;; 1. Exclusivity and cape-capf-nonexclusive
+
+(ert-deftest completion-test-exclusive-capf-shadows-later-capfs ()
+  "A capf declaring no `:exclusive' wins even when nothing it offers matches.
+This is why eglot suppresses the cape fallbacks placed after it."
+  (with-temp-buffer
+    (insert "zzz")
+    (should (equal (completion-test--winning-collection
+                    (list #'completion-test--capf-exclusive
+                          #'completion-test--capf-later))
+                   '("alpha" "beta")))))
+
+(ert-deftest completion-test-nonexclusive-capf-falls-through ()
+  "An `:exclusive no' capf yields to the next capf when its prefix misses."
+  (with-temp-buffer
+    (insert "zzz")
+    (should (equal (completion-test--winning-collection
+                    (list #'completion-test--capf-nonexclusive
+                          #'completion-test--capf-later))
+                   '("later-capf-ran")))))
+
+(ert-deftest completion-test-cape-nonexclusive-unshadows ()
+  "`cape-capf-nonexclusive' turns an exclusive capf into one that yields.
+This is the fix for eglot suppressing capfs ordered after it."
+  (with-temp-buffer
+    (insert "zzz")
+    (should (equal (completion-test--winning-collection
+                    (list (cape-capf-nonexclusive
+                           #'completion-test--capf-exclusive)
+                          #'completion-test--capf-later))
+                   '("later-capf-ran")))))
+
+(ert-deftest completion-test-nonexclusive-capf-kept-when-prefix-matches ()
+  "The fallthrough is conditional: a matching prefix keeps the first capf."
+  (with-temp-buffer
+    (insert "al")
+    (should (equal (completion-test--winning-collection
+                    (list #'completion-test--capf-nonexclusive
+                          #'completion-test--capf-later))
+                   '("alpha" "beta")))))
+
+;;;; 2. The fallthrough versus completion-styles
+
+(ert-deftest completion-test-fallthrough-ignores-completion-styles ()
+  "The `:exclusive no' fallthrough is prefix-only and ignores `completion-styles'.
+\"foo\" matches \"barfoo\" under orderless but not by prefix, yet the capf
+is discarded under both style settings -- the wrapper decides with a bare
+`try-completion' before any style runs.  Consequence for this config: a
+non-exclusive capf loses candidates a non-prefix style would have matched."
+  (with-temp-buffer
+    (insert "foo")
+    (dolist (styles '((orderless basic) (basic)))
+      (let ((completion-styles styles))
+        (should (equal (completion-test--winning-collection
+                        (list #'completion-test--capf-substring
+                              #'completion-test--capf-later))
+                       '("later-capf-ran")))))))
+
+(ert-deftest completion-test-orderless-itself-matches-substring ()
+  "Orderless does match \"foo\" against \"barfoo\" -- the style is not at fault.
+Pairs with the test above: the candidate is reachable by the style but the
+capf carrying it was already discarded by the prefix-only fallthrough."
+  (let ((completion-styles '(orderless)))
+    (should (member "barfoo" (completion-all-completions
+                              "foo" '("barfoo" "unrelated") nil 3)))))
+
+;;;; 3. What the merged capf reports
+
+;; `lisp/init-snippets.el' merges the snippet capf with eglot's via
+;; `cape-capf-super' in LSP buffers.  Whether that merged capf is exclusive
+;; decides two things: whether the cape fallbacks after it ever run, and
+;; whether the prefix-only fallthrough of section 2 can discard the snippet
+;; names it carries.
+
+(ert-deftest completion-test-super-merges-both-collections ()
+  "`cape-capf-super' yields one collection holding both sources' candidates."
+  (with-temp-buffer
+    (insert "al")
+    (let ((collection (completion-test--winning-collection
+                       (list (cape-capf-super
+                              #'completion-test--capf-nonexclusive
+                              #'completion-test--capf-later)))))
+      (should collection)
+      (let ((all (all-completions "" collection)))
+        (should (member "alpha" all))
+        (should (member "later-capf-ran" all))))))
+
+(ert-deftest completion-test-super-propagates-exclusivity ()
+  "`cape-capf-super' is non-exclusive only when EVERY input is non-exclusive.
+One exclusive input makes the merge exclusive.  This is the config's
+actual shape: `init-snippets.el' merges the snippet capf (`:exclusive
+no') with eglot's (no `:exclusive' key, hence exclusive), so the merged
+capf is exclusive and suppresses the cape fallbacks after it."
+  (with-temp-buffer
+    (insert "zzz")
+    (should (eq 'no (plist-get
+                     (nthcdr 3 (funcall (cape-capf-super
+                                         #'completion-test--capf-nonexclusive
+                                         #'completion-test--capf-substring)))
+                     :exclusive)))
+    (should-not (plist-get
+                 (nthcdr 3 (funcall (cape-capf-super
+                                     #'completion-test--capf-nonexclusive
+                                     #'completion-test--capf-exclusive)))
+                 :exclusive))))
+
+(ert-deftest completion-test-super-with-exclusive-input-shadows ()
+  "A merge containing an exclusive input suppresses later capfs...
+...and wrapping it in `cape-capf-nonexclusive' lets them run again.
+This is why `init-snippets.el' wraps its eglot merge."
+  (with-temp-buffer
+    (insert "zzz")
+    (let ((merged (cape-capf-super #'completion-test--capf-nonexclusive
+                                   #'completion-test--capf-exclusive)))
+      (should-not (equal (completion-test--winning-collection
+                          (list merged #'completion-test--capf-later))
+                         '("later-capf-ran")))
+      (should (equal (completion-test--winning-collection
+                      (list (cape-capf-nonexclusive merged)
+                            #'completion-test--capf-later))
+                     '("later-capf-ran"))))))
+
+;;;; 4. This configuration
+
+;; Loading the two modules executes their `:init'/`:custom'/`:bind' side
+;; effects in this batch process, which is how the assertions below observe
+;; real state.  `after-init-hook' never runs in batch, so `global-corfu-mode'
+;; stays off and no popup can appear.
+
+(require 'corfu)
+(require 'tempel)
+(require 'init-completion)
+(require 'init-snippets)
+
+(ert-deftest completion-test-defcustom-defaults ()
+  "The opt-out knobs carry their documented defaults."
+  (should (equal jotain-completion-auto-modes '(prog-mode-hook)))
+  (should (equal jotain-completion-auto-delay 0.1))
+  (should (equal jotain-completion-auto-prefix 2))
+  (should (equal jotain-completion-key "C-M-i"))
+  (should (eq jotain-completion-free-return t))
+  (should (eq jotain-completion-free-tab t))
+  (should (eq jotain-completion-fallbacks t))
+  (should (eq jotain-completion-snippets t))
+  (should (eq jotain-completion-eglot-nonexclusive t))
+  (should (key-valid-p jotain-completion-key)))
+
+(ert-deftest completion-test-tab-indents-only ()
+  "TAB is on the stock default, so `indent-for-tab-command' cannot complete."
+  (should (eq tab-always-indent t)))
+
+(ert-deftest completion-test-auto-popup-is-opt-in-per-mode ()
+  "Auto-popup is off globally and opted into per mode hook, buffer-locally."
+  (should (eq (default-value 'corfu-auto) nil))
+  (should (memq #'jotain-completion--enable-auto prog-mode-hook))
+  (should-not (memq #'jotain-completion--enable-auto text-mode-hook))
+  (with-temp-buffer
+    (jotain-completion--enable-auto)
+    (should (local-variable-p 'corfu-auto))
+    (should (eq corfu-auto t)))
+  ;; The opt-in never touches the global value.
+  (should (eq (default-value 'corfu-auto) nil)))
+
+(ert-deftest completion-test-corfu-map-frees-return-and-tab ()
+  "RET and TAB are removed from `corfu-map', and navigation still works."
+  (should-not (lookup-key corfu-map (kbd "RET")))
+  (should-not (lookup-key corfu-map (kbd "TAB")))
+  (should-not (lookup-key corfu-map [tab]))
+  (should (eq (lookup-key corfu-map (kbd "M-n")) #'corfu-next))
+  (should (eq (lookup-key corfu-map (kbd "M-p")) #'corfu-previous)))
+
+(ert-deftest completion-test-one-key-opens-and-accepts ()
+  "`C-M-i' resolves to `completion-at-point', which `corfu-map' remaps.
+Binding the command rather than leaving the stock `complete-symbol' is
+what makes the same key accept inside the popup -- a remap only fires
+for the command the key actually resolves to.  This is why no separate
+accept key is needed."
+  (should (eq (keymap-global-lookup jotain-completion-key)
+              #'completion-at-point))
+  (should (eq (lookup-key corfu-map [remap completion-at-point])
+              #'corfu-complete)))
+
+(ert-deftest completion-test-tempel-fields-are-off-tab ()
+  "Snippet fields move on tempel's own keys and on `C-M-n'/`C-M-p', never TAB.
+No field key may collide with corfu's `M-n'/`M-p': `tempel-map' rides on
+an overlay `keymap' property, which outranks corfu's minor-mode map, so
+a shared key would be stolen from the popup mid-snippet."
+  (should-not (lookup-key tempel-map (kbd "TAB")))
+  (should-not (lookup-key tempel-map [tab]))
+  (should-not (lookup-key tempel-map (kbd "<backtab>")))
+  (should (eq (lookup-key tempel-map (kbd "C-M-n")) #'tempel-next))
+  (should (eq (lookup-key tempel-map (kbd "C-M-p")) #'tempel-previous))
+  (should (eq (lookup-key tempel-map (kbd "M-}")) #'tempel-next))
+  (should (eq (lookup-key tempel-map (kbd "M-{")) #'tempel-previous))
+  (should-not (lookup-key tempel-map (kbd "M-n")))
+  (should-not (lookup-key tempel-map (kbd "M-p"))))
+
+(ert-deftest completion-test-capf-wiring ()
+  "Snippets lead the buffer-local list; the cape fallbacks are global."
+  (should (memq #'jotain-tempel-setup-capf prog-mode-hook))
+  (should (memq #'jotain-tempel-setup-capf text-mode-hook))
+  (with-temp-buffer
+    (jotain-tempel-setup-capf)
+    (should (eq (car completion-at-point-functions) #'tempel-complete))
+    ;; The `t' sentinel is what lets the global list run afterwards.
+    (should (eq (car (last completion-at-point-functions)) t)))
+  (let ((global (default-value 'completion-at-point-functions)))
+    (should (memq #'cape-dabbrev global))
+    (should (memq #'cape-file global))
+    (should (memq #'cape-keyword global))))
+
+(provide 'completion-test)
+;;; completion-test.el ends here


### PR DESCRIPTION
## What this is

Research, design, and now implementation of the in-buffer completion behaviour for the corfu/cape/tempel/eglot stack.

- `docs/reviews/2026-07-completion-research.md` — cited research report
- `docs/design/completion.md` — the design/spec, amended with what measurement established
- `lisp/init-completion.el`, `lisp/init-snippets.el` — the implementation
- `test/completion-test.el` — 16 ERT tests

## Behaviour

The popup appears on its own **only in code**. **TAB is purely indentation.** **Enter is purely a newline.** `C-M-i` is the single completion gesture — it opens the popup and accepts inside it. Nine `jotain-completion-*` options disable each mechanism independently.

## A live bug this found

`cape-capf-super` propagates `:exclusive &#39;no` only when *every* input is non-exclusive, and eglot declares no `:exclusive` at all. So the merged snippet+server capf inherited eglot&#39;s exclusivity, and **`cape-dabbrev`, `cape-file` and `cape-keyword` never ran in any LSP buffer** — configured and dead. The merged capf is now wrapped in `cape-capf-nonexclusive`, plus `cape-capf-buster` for the candidate cache `cape-capf-super` otherwise holds for the capf&#39;s whole lifetime.

## Things that turned out to be wrong

1. **`tab-always-indent` defaults to `t`.** Moving completion off TAB is the stock default, not a deviation. The counter-claim that corfu recommends `complete` was refuted 0-3.
2. **`tab-first-completion` is Emacs 28.1**, not 30; five fixed symbols, not a predicate; inert unless `tab-always-indent` is `complete`. Irrelevant here.
3. **The shadowing comment in `init-snippets.el` was backwards.** Tempel returns `:exclusive &#39;no` from both capfs and falls through; eglot is the one that shadows.
4. **`corfu-map` binds TAB and RET itself**, so both requirements needed the keymap freed, not just the variable set.
5. **Upstream `tempel-map` never bound TAB.** The TAB/S-TAB pair was this config&#39;s own addition, so removing it is a deletion and tempel&#39;s `M-}`/`M-{` and `M-RET` come back for free. `C-M-n`/`C-M-p` are added as an alias.

## The two "blocking" questions, settled

Both were recorded as needing a live Emacs. They did — but a **batch** one. `elisp-test` already runs `emacs --batch` against the full package set, so capf dispatch and keymap state are directly assertable. Measured, not inferred:

- an exclusive capf shadows everything after it, unconditionally;
- `cape-capf-nonexclusive` restores the fallthrough without stealing the matching case;
- `cape-capf-super` is non-exclusive only when every input is;
- the `:exclusive &#39;no` fallthrough **ignores `completion-styles`** — decided by a bare `try-completion`, so `foo` is discarded against `barfoo` under orderless exactly as under `basic`, even though orderless itself matches. The `minibuffer.el` FIXME is real.

That last one bounds a residual weakness the merge happens to mitigate: inside the merge the collection also holds the server&#39;s candidates, so the prefix test generally succeeds. Mitigation, not a fix, and the approximation is upstream&#39;s.

## Departure from the spec, recorded

§2.4 originally proposed `tempel-expand` (exact-match, no popup entry), which would have been structurally immune to that weakness. The implementation keeps `tempel-complete` so snippet names stay visible — a knowing trade of immunity for discoverability. The ninth opt-out knob is likewise substituted (`-snippet-tab` → `-eglot-nonexclusive`) with the reason stated in §3.2, since the mechanism it gated no longer exists.

## Verification

`elisp-lint` and `packages-doc-in-sync` pass locally. The 16 ERT tests pass, and byte-compilation of both changed modules is warning-clean.

**Caveat:** `elisp-compile` and `elisp-test` could not be run in their real form locally — they need `jotainEmacsPackages`, whose `jylhis-emacs-themes` dependency fetches `github.com/Jylhis/design`, which this session&#39;s egress policy blocks (403) and which is not in the binary cache. I ran the equivalents against a substitute package set built from the same nixpkgs pin, and compared byte-compile output against the unmodified tree to confirm no new warnings. CI is the real check for those two.

Not yet done: the interactive smoke test. How `corfu-complete` *feels* as an accept gesture after `M-n`, and whether the auto-popup delay is comfortable, both need eyes on a screen — the delay in particular has no evidence base at all and is flagged as unmeasured rather than tuned.

## Unrelated fix carried here

`208fa72` reattaches the `doom-modeline` `;;; @doc` marker, which `513da74` detached by inserting a defun between it and the `use-package` form. That was failing `packages-doc-in-sync` on `main` independently of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YGHoYRcfqJWuQHX4KZ11Z

---
_Generated by [Claude Code](https://claude.ai/code/session_012YGHoYRcfqJWuQHX4KZ11Z)_