### PR TITLE
UI review of the user-facing layer, plus a showcase scene harness

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -283,6 +283,31 @@ screenshot out="var/screenshots/headless.png":
     test -s "$out" || { echo "FAIL: no screenshot written"; exit 1; }
     echo "Screenshot → $out"
 
+# Headless showcase: build Emacs, launch under Xvfb with this config, and
+# capture every scene in etc/showcase.el under both Jylhis themes into DIR
+# (one PNG per scene per theme). Linux only; needs xvfb-run. Same cold-cache
+# caveat as `screenshot`. The `popup` scene additionally wants ImageMagick's
+# `import` on PATH — corfu draws into a child frame, which x-export-frames
+# cannot see.
+[group('build')]
+[linux]
+showcase dir="var/showcase":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v xvfb-run >/dev/null 2>&1 || {
+        echo "xvfb-run not on PATH — enter the devenv shell (direnv/devenv shell)"; exit 1; }
+    just build
+    out="{{dir}}"
+    case "$out" in /*) ;; *) out="{{config_dir}}/$out" ;; esac
+    mkdir -p "$out"
+    JOTAIN_SHOWCASE_DIR="$out" timeout 900 xvfb-run -a -s '-screen 0 1920x1080x24' \
+        ./result/bin/emacs --init-directory="{{config_dir}}" \
+        --load "{{config_dir}}/etc/showcase.el" \
+        --eval '(run-at-time 3 nil (function jotain-showcase-batch))'
+    count=$(find "$out" -name '*.png' -size +0c | wc -l)
+    test "$count" -gt 0 || { echo "FAIL: no images written"; exit 1; }
+    echo "Showcase → $out ($count images)"
+
 
 # Build option reference documentation (HTML for GitHub Pages).
 [group('build')]

--- a/docs/reviews/2026-07-ui-review.md
+++ b/docs/reviews/2026-07-ui-review.md
@@ -1,0 +1,292 @@
+# UI review — the user-facing layer (2026-07)
+
+A review of everything that decides what Jotain looks like on screen: theme and
+appearance switching, the modeline and headerline, fonts and glyph fallbacks,
+fringes and margins, line highlighting, the completion UI, keybinding surface,
+and Org styling.
+
+Line numbers are against `b26628e`. Findings marked **verified** were confirmed
+by evaluating Elisp against a real Emacs; **static** ones follow from the repo's
+own code but were not executed.
+
+## Method, and its limitation
+
+The visual half of this review could not be exercised. `just screenshot` and
+`just showcase` need a built Emacs, and none could be produced in the review
+environment: the egress proxy returns 403 for the `emacs-overlay` flake input,
+that overlay is in no binary cache, and every package archive (MELPA, GNU ELPA,
+NonGNU ELPA) is blocked as well.
+
+A substitute Emacs was assembled to get *some* runtime signal — nixpkgs' own
+`pkgs.emacs` 30.2 built straight from the pinned nixpkgs (no overlay needed),
+the real Jylhis themes `trivialBuild`-ed from the `nix/design-pin.nix`
+revision, and the real `lisp/init-*.el` modules — but `compat` is in no binary
+cache, which took out the whole nixpkgs `emacsPackages` route. `doom-modeline`,
+`nerd-icons`, `dirvish`, `magit`, `org-modern`, `indent-bars`, `breadcrumb` and
+`pulsar` were all absent, so the resulting frames could not settle any
+appearance question and are not included here.
+
+Consequence: **findings 1, 3 and 4 are visual-verdict calls that remain
+unsettled.** They need `doom-modeline` and the full fringe stack. Run
+`just showcase` on a real distribution build to confirm or kill them.
+
+---
+
+## Findings
+
+### 1. The macOS titlebar is pinned to dark while the theme follows the system — **static**
+
+`early-init.el:82-83`:
+
+```elisp
+(push '(ns-transparent-titlebar . t) default-frame-alist)
+(push '(ns-appearance . dark) default-frame-alist)
+```
+
+`ns-appearance` is hardcoded to `dark` for every frame, but the theme layer is
+built around *following* the system: `init-ui.el:84` runs `auto-dark-mode` with
+`jotain-theme-light` (`jylhis-sheet`) and `jotain-theme-dark` (`jylhis-field`).
+
+In macOS light mode the buffer renders light while the titlebar is styled dark.
+With `ns-transparent-titlebar` also on, the titlebar takes the frame's
+background colour but keeps light-on-light title text — the worst of the two
+combinations.
+
+`early-init.el` runs before the theme layer exists, so this cannot be decided
+there. The honest fix is to set `ns-appearance` from `auto-dark`'s
+appearance-change hook, alongside the theme swap.
+
+### 2. `calendar-iso-week-face` is a frozen snapshot and survives theme switches — **verified**
+
+`init-ui.el:281-282`:
+
+```elisp
+(copy-face 'font-lock-constant-face 'calendar-iso-week-face)
+(set-face-attribute 'calendar-iso-week-face nil :height 0.7)
+```
+
+`copy-face` copies attribute *values*; it does not create a link. Verified by
+mutating the source face afterwards:
+
+```
+copy-face src="#eeeeee" copy="#111111" inherit=unspecified
+```
+
+The copy keeps the old colour and its `:inherit` is `unspecified`.
+
+`calendar` is deferred, so the copy is taken from whichever theme is active the
+first time the calendar opens. Every later `auto-dark` flip restyles
+`font-lock-constant-face` but leaves the ISO week gutter on the previous
+theme's colour.
+
+A `defface` with `:inherit font-lock-constant-face` and `:height 0.7` tracks the
+theme correctly and needs no `:config` block at all.
+
+### 3. `doom-modeline-icon` is a global set from a per-frame hook — **static**
+
+`init-ui.el:95-96` and `:112`:
+
+```elisp
+(setopt doom-modeline-icon (and (display-graphic-p frame) t))
+...
+(add-hook 'server-after-make-frame-hook #'jotain-ui--apply-modeline-icons)
+```
+
+The hook is per-frame; the variable it sets is global. In a daemon session
+serving a GUI frame *and* a TTY frame — the documented `services.jotain`
+deployment, which ships an `emacsclient` wrapper as `EDITOR` — the last frame
+created wins for all of them:
+
+- open a TTY client next to a running GUI frame → icons switch off in the GUI
+  frame too;
+- open a GUI client next to a running TTY frame → the TTY frame renders Nerd
+  Font glyphs as tofu.
+
+The same shape applies to `nerd-icons-font-family` (`init-ui.el:302-314`),
+though that one is benign because TTY frames ignore font families.
+
+This is very likely the same root cause as the open `TODO.md` entry *"Fix themes
+in terminal"*. A real fix needs the value to be frame-local at render time
+rather than a global re-set per frame creation.
+
+### 4. diff-hl and flymake both claim the left fringe — **static**
+
+- `init-vc.el:235` — `(diff-hl-side 'left)`
+- `init-prog.el:457` — `(flymake-fringe-indicator-position 'left-fringe)`
+
+Any line that is both VC-modified and carries a diagnostic can show only one of
+the two bitmaps. In a `prog-mode` buffer under active editing — where both are
+enabled — that overlap is the common case, not the corner case: you are editing
+a line, so it is modified, and the edit is mid-flight, so it is diagnosed.
+
+Moving flymake to `'right-fringe` separates the two channels at no cost; the
+left fringe then reads as "VC state" and the right as "diagnostics".
+
+The terminal side is already handled well: `flymake-margin-indicators-string`
+(`init-prog.el:462`) supplies `!`/`?`/`·` for the margin indicators Flymake
+falls back to when the display has no fringes. Only the graphical case collides.
+
+### 5. `hl-line` highlights entire wrapped paragraphs in prose buffers — **verified**
+
+`init-ui.el:252` enables `hl-line-mode` in `text-mode`; `init-writing.el:44`
+enables `visual-line-mode` in the same hook.
+
+`hl-line` highlights the *logical* line. Verified: `hl-line-range-function`
+defaults to `nil`, and in a `visual-line-mode` buffer holding a single 400-char
+paragraph, `line-beginning-position`/`line-end-position` span `1..401` — the
+whole paragraph.
+
+So in Markdown, Org and Denote buffers the current-line highlight is a solid
+block covering every screen row the paragraph wraps onto. That is a very
+different visual weight from the single-row highlight the same setting produces
+in code, and it fights `mixed-pitch-mode`, which is trying to make those buffers
+read like prose.
+
+Either set a buffer-local `hl-line-range-function` returning the visual line, or
+drop `text-mode` from the `hl-line` hook and keep the highlight for code and
+config only.
+
+### 6. The visual half of `whitespace-style` never renders — **verified**
+
+`init-editing.el:51`:
+
+```elisp
+(whitespace-style '(face trailing tabs tab-mark))
+```
+
+Nothing in the config enables `whitespace-mode` or `global-whitespace-mode`. The
+only consumer is the `before-save` hook at `init-editing.el:49`, which calls
+`whitespace-cleanup`.
+
+`face`, `tabs` and `tab-mark` are display styles. Without the mode on they
+render nothing — the block reads as if tabs are visualised, and they are not.
+
+The cleanup half is also narrower than it looks, which was worth confirming
+because `whitespace-cleanup` is destructive. Verified with this exact style list:
+
+```
+indent-tabs-mode=nil -> "a\tb\nc\td\n"
+indent-tabs-mode=t   -> "        x\ny\n"
+```
+
+Interior tabs are preserved and leading spaces are not tabified in either
+direction: `tabs` governs display, while cleanup's tab rewriting is driven by
+`indentation`/`space-before-tab`/`space-after-tab`, none of which are set. So
+the hook is effectively `delete-trailing-whitespace` and is safe for Makefiles
+and Go.
+
+Either enable `whitespace-mode` somewhere if the visualisation is wanted, or
+reduce the list to `'(trailing)` so it states what it actually does.
+
+### 7. Markdown's new `C-c m` prefix shadows the global `consult-man` — **static**
+
+`init-completion.el:226` binds `C-c m` globally to `consult-man`, and
+`init-keys.el:108` documents it in the which-key description table as
+`"consult-man"`.
+
+`init-writing.el:108-116` now binds a `C-c m ...` prefix inside
+`markdown-mode-map` — `C-c m h`, `C-c m i`, `C-c m l`, and so on. A prefix and a
+command cannot share a key, so in every Markdown buffer `C-c m` stops being
+`consult-man` and becomes a prefix.
+
+Two consequences: the global binding silently disappears in the buffers where
+it is arguably most reachable, and `init-keys.el`'s which-key label for `C-c m`
+is now wrong there. `C-c m` is also the only `C-c <letter>` slot in the config
+that is both a global command and a mode-local prefix — every other
+`C-c <letter>` is bound exactly once.
+
+Either move the markdown keymap to a free prefix, or drop the global
+`consult-man` binding and describe `C-c m` as the markdown prefix. Leaving both
+is the one state that is actively misleading.
+
+### 8. Ownership of `prefix-help-command` is decided by module load order — **static**
+
+`which-key-mode` (`init-ui.el:270`) sets `prefix-help-command`, and embark's
+`:init` (`init-completion.el:318`) then overwrites it:
+
+```elisp
+(setq prefix-help-command #'embark-prefix-help-command)
+```
+
+Today that produces the documented behaviour, because `init.el:54` requires
+`init-ui` and `init.el:59` requires `init-completion` — embark runs last and
+wins. Nothing encodes that dependency. Reordering the requires, or making
+`init-completion` load earlier for an unrelated reason, silently hands `C-h`
+after a prefix back to which-key and removes the embark paged view that
+`init-completion.el` documents at length.
+
+An `:after which-key` on the embark block, or a one-line comment at the `setq`
+naming the ordering constraint, makes the coupling visible.
+
+### 9. `org-startup-indented` may disable org-modern's block styling — **needs confirmation**
+
+`init-org.el:42` sets `(org-startup-indented t)`, which turns on
+`org-indent-mode` in every Org buffer; `init-org.el:272` enables
+`org-modern-mode` in the same buffers.
+
+org-modern documents `org-modern-block-fringe` as incompatible with
+`org-indent-mode` — the fringe-drawn block backgrounds are the part that does
+not survive.
+
+This could not be verified: org-modern's source was not fetchable, so the
+incompatibility could not be checked against the pinned version, and the exact
+remedy (disabling `org-modern-block-fringe`, or `org-modern-block-name` alone)
+depends on which release is in the epkgs snapshot. Flagged for a local check
+rather than asserted.
+
+### 10. Frame-setup hooks cover only server frames — **static**
+
+`jotain-ui-apply-font`, `jotain-ui-apply-emoji-font`,
+`jotain-ui--apply-nerd-icons-font` and `jotain-ui--apply-modeline-icons` are all
+registered on `server-after-make-frame-hook` only (`init-ui.el:112, 179, 206,
+314`), plus one direct call at load time.
+
+That covers the two deployments that matter — a plain GUI start (initial frame
+exists at load time) and the daemon (server hook fires per client frame). It
+does not cover a non-daemon Emacs that gains a graphical frame later:
+`emacs -nw` followed by `make-frame-on-display`, or a GUI frame opened on a
+second display with different font availability. Those frames never re-probe.
+
+Low severity given the daemon-first deployment, and adding
+`after-make-frame-functions` alongside the server hook would double-fire on
+daemon clients. Listed for completeness rather than as a call to action.
+
+---
+
+## Not findings
+
+Things that looked wrong and are not, recorded so they are not re-reported:
+
+- **`init-tabs.el` reading a tab parameter with `alist-get`.** The tab-bar alist
+  has a bare symbol (`current-tab` / `tab`) as its first element, which looks
+  like it should break `assq`. It does not — verified:
+  `(alist-get 'jotain-tabs-project-dir '(current-tab (name . "x")
+  (jotain-tabs-project-dir . "/p")))` returns `"/p"`, and a missing key returns
+  `nil` rather than signalling.
+- **The theme fallback in `init-ui.el:62-70`.** `load-theme` is called with
+  `NO-ENABLE` set, so the `jotain-ui--disable-other-themes` advice
+  (`init-ui.el:38-45`) correctly does nothing during the pre-load, and a failed
+  pre-load degrades to Modus before `auto-dark` reads the theme variables at
+  `init-ui.el:84`. The ordering is right.
+- **`whitespace-cleanup` on `before-save` mangling tabs.** It does not, with the
+  style list this config sets — see finding 6.
+- **`mode-line-format . none` in the embark `display-buffer-alist` entry**
+  (`init-completion.el:324`). `none` is a documented window-parameter value for
+  suppressing the mode line, not a typo for `nil`.
+
+## Resolved before this review landed
+
+An earlier draft carried an eleventh finding: `just screenshot` captured at
+t+3s while `init.el` scheduled a package-archive warm-up on a 2-second idle
+timer, so the refresh fired inside the capture window. Commit `3d3e204`
+("init: never fetch package archives at startup") removed that startup fetch
+entirely, so the race no longer exists and the finding is dropped rather than
+carried as fixed.
+
+## Open questions
+
+- Findings 1, 3 and 4 want a screenshot to settle. `just showcase` captures the
+  scenes in both themes; run it on a real distribution build.
+- Finding 3 and the `TODO.md` item "Fix themes in terminal" should be
+  investigated together; they may have one root cause.
+- Finding 9 needs org-modern's pinned source to resolve.

--- a/etc/showcase.el
+++ b/etc/showcase.el
@@ -1,0 +1,324 @@
+;;; showcase.el --- Screenshot scenes for Jotain  -*- lexical-binding: t; -*-
+
+;; Loaded via `emacs --load' by the `just showcase' recipe, AFTER the normal
+;; init has run, so the whole configuration is already in effect when a scene
+;; is built.  Each scene arranges buffers and windows to surface one part of
+;; the config, then the driver captures it in both themes via
+;; `jotain-screenshot' (lisp/init-ai.el).
+;;
+;; Like etc/debug-init.el, this file lives OUTSIDE lisp/ and test/ on purpose:
+;; the use-package scanner (nix/use-package.nix) and the elisp-compile /
+;; elisp-lint flake checks only look at lisp/, so a harness here adds no CI
+;; surface and contributes nothing to the Nix package set.
+;;
+;; Two capture facts worth knowing before editing a scene:
+;;
+;;   - `jotain-screenshot' cannot capture a child frame.  `x-export-frames'
+;;     exports one frame's own contents, so corfu's popup is simply absent.
+;;     Scenes listed in `jotain-showcase-child-frame-scenes' go through
+;;     ImageMagick's `import -window root' instead, which composites every
+;;     mapped window.
+;;
+;;   - The `popup' scene still does not show the popup.  corfu displays from
+;;     `post-command-hook', which does not run when `completion-at-point' is
+;;     called from a timer rather than the command loop.  Driving it through
+;;     `execute-kbd-macro' is the likely fix; untested.
+
+(require 'cl-lib)
+
+(defvar jotain-showcase-directory
+  (or (getenv "JOTAIN_SHOWCASE_DIR")
+      (expand-file-name "var/showcase" user-emacs-directory))
+  "Directory the showcase writes its PNGs into.")
+
+(defvar jotain-showcase-themes '(jylhis-sheet jylhis-field)
+  "Themes to capture every scene in, light first.")
+
+(defvar jotain-showcase--failures nil
+  "List of human-readable strings describing steps that degraded.")
+
+(defun jotain-showcase--note (fmt &rest args)
+  "Record and log a degraded step described by FMT and ARGS."
+  (let ((msg (apply #'format fmt args)))
+    (push msg jotain-showcase--failures)
+    (message "jotain-showcase: %s" msg)))
+
+(defmacro jotain-showcase--step (label &rest body)
+  "Run BODY, degrading to a recorded note on error.
+LABEL names the step in the log.  A scene must never abort the run: a
+missing package or an unreadable file costs one window, not the capture."
+  (declare (indent 1))
+  `(condition-case err
+       (progn ,@body)
+     (error (jotain-showcase--note "%s: %S" ,label err) nil)))
+
+(defun jotain-showcase--file (name)
+  "Return NAME under `jotain-showcase-directory', creating the directory."
+  (make-directory jotain-showcase-directory t)
+  (expand-file-name name jotain-showcase-directory))
+
+(defun jotain-showcase--visit (relative &optional line)
+  "Visit RELATIVE inside the config directory and go to LINE.
+Returns the buffer, or nil when the file is missing."
+  (let ((path (expand-file-name relative user-emacs-directory)))
+    (if (not (file-readable-p path))
+        (progn (jotain-showcase--note "missing file %s" relative) nil)
+      (let ((buf (find-file-noselect path)))
+        (set-window-buffer (selected-window) buf)
+        (with-current-buffer buf
+          (goto-char (point-min))
+          (when line (forward-line (1- line)))
+          (recenter 4))
+        buf))))
+
+(defun jotain-showcase--sample-org ()
+  "Return a path to a small Org file written under the showcase directory.
+The repo ships no Org file, and `org-modern' needs real headings, a
+table, a source block and a TODO to show what it does."
+  (let ((path (jotain-showcase--file "sample.org")))
+    (unless (file-exists-p path)
+      (with-temp-file path
+        (insert "#+title: Jotain\n"
+                "#+author: Markus\n\n"
+                "* Reading list\n"
+                "** TODO Re-read the redisplay chapter\n"
+                "   DEADLINE: <2026-08-14 Fri>\n"
+                "   The gap buffer is the easy part; the redisplay engine is\n"
+                "   where the interesting decisions live.\n\n"
+                "** DONE Trim the startup path\n"
+                "   CLOSED: [2026-07-02 Thu]\n\n"
+                "* Measurements\n"
+                "  | variant  | startup | closure |\n"
+                "  |----------+---------+---------|\n"
+                "  | mainline |   0.42s |  1.1 GB |\n"
+                "  | unstable |   0.39s |  1.2 GB |\n"
+                "  | igc      |   0.44s |  1.2 GB |\n\n"
+                "* A source block\n"
+                "  #+begin_src emacs-lisp\n"
+                "    (defun jotain-var-file (name)\n"
+                "      (make-directory jotain-var-dir t)\n"
+                "      (expand-file-name name jotain-var-dir))\n"
+                "  #+end_src\n\n"
+                "* Emphasis\n"
+                "  Markers are hidden until point lands on them: *bold*,\n"
+                "  /italic/, =verbatim= and ~code~.\n"))
+      (jotain-showcase--note "wrote sample org file (informational)"))
+    path))
+
+(defun jotain-showcase--reset ()
+  "Return the frame to a single clean window between scenes."
+  (jotain-showcase--step "reset"
+    (when (active-minibuffer-window)
+      (abort-recursive-edit))
+    (delete-other-windows)
+    (switch-to-buffer (get-buffer-create "*scratch*"))))
+
+(defvar jotain-showcase-child-frame-scenes '(popup)
+  "Scenes whose interesting UI is drawn in a child frame.
+`x-export-frames' exports one frame's own contents, so a corfu popup —
+a separate child frame — is simply absent from its output.  These scenes
+are captured from the X root window instead, which composites every
+mapped window.")
+
+(defun jotain-showcase--capture-root (file)
+  "Capture the whole X root window into FILE with ImageMagick's import.
+Returns non-nil on success.  `call-process' blocks Emacs, but the child
+frame stays mapped on the X server, so the popup is included."
+  (and (executable-find "import")
+       (eq 0 (call-process "import" nil nil nil "-window" "root" file))
+       (file-exists-p file)))
+
+(defun jotain-showcase--capture (name theme)
+  "Capture the current frame as NAME under THEME.
+Unlike a scene step this is deliberately NOT demoted: a capture that
+fails must leave no artifact and be visible in the exit status."
+  (redisplay t)
+  (let ((file (jotain-showcase--file (format "%s-%s.png" name theme))))
+    (if (and (memq name jotain-showcase-child-frame-scenes)
+             (jotain-showcase--capture-root file))
+        file
+      (when (memq name jotain-showcase-child-frame-scenes)
+        (jotain-showcase--note
+         "%s: no `import' on PATH; child-frame UI will be missing" name))
+      (jotain-screenshot file 'png))))
+
+;;;; Scenes
+;;
+;; Each scene is a function of no arguments that arranges the frame.  A scene
+;; whose interesting UI only exists mid-interaction takes over the capture
+;; itself (see `jotain-showcase--transient-p').
+
+(defun jotain-showcase-scene-code ()
+  "A source file with the full prog-mode decoration stack."
+  (jotain-showcase--visit "lisp/init-ui.el" 240)
+  (jotain-showcase--step "flymake" (flymake-start)))
+
+(defun jotain-showcase-scene-files ()
+  "Dirvish over the repository, falling back to plain dired.
+`init-navigation.el' configures dired itself as well as dirvish, so the
+fallback still shows configured behaviour rather than stock dired."
+  (let ((dir (expand-file-name "lisp" user-emacs-directory)))
+    (if (fboundp 'dirvish)
+        (jotain-showcase--step "dirvish" (dirvish dir))
+      (jotain-showcase--note "dirvish unavailable; using dired")
+      (jotain-showcase--step "dired" (dired dir)))))
+
+(defun jotain-showcase-scene-vc ()
+  "Version control: magit when available, else built-in `vc-dir' plus a diff.
+`init-vc.el' configures both, so the built-in path is a real fallback
+rather than a stand-in — it is what the config gives you on a build
+where magit is absent."
+  (if (fboundp 'magit-status-setup-buffer)
+      (jotain-showcase--step "magit"
+        (magit-status-setup-buffer user-emacs-directory))
+    (jotain-showcase--note "magit unavailable; using built-in vc-dir")
+    (jotain-showcase--step "vc-dir"
+      (vc-dir user-emacs-directory))
+    (jotain-showcase--step "vc diff"
+      (let ((low (split-window-below)))
+        (with-selected-window low
+          (let ((buf (get-buffer-create "*jotain-showcase-diff*")))
+            (with-current-buffer buf
+              (erase-buffer)
+              (insert (with-output-to-string
+                        (call-process "git" nil standard-output nil
+                                      "-C" (expand-file-name user-emacs-directory)
+                                      "show" "--stat" "-p" "HEAD")))
+              (diff-mode)
+              (goto-char (point-min)))
+            (set-window-buffer (selected-window) buf)))))))
+
+(defun jotain-showcase-scene-org ()
+  "An Org buffer with org-modern styling."
+  (jotain-showcase--step "org"
+    (let ((buf (find-file-noselect (jotain-showcase--sample-org))))
+      (set-window-buffer (selected-window) buf)
+      (with-current-buffer buf
+        (when (fboundp 'org-mode) (org-mode))
+        (goto-char (point-min))))))
+
+(defun jotain-showcase-scene-overview ()
+  "Several windows at once: the whole editor in one frame.
+No tabs are created.  `tab-bar-show' is 1, so the bar stays hidden at a
+single tab — which is the honest default; fabricating a second tab just
+to make the bar appear would show a workspace setup that isn't in use."
+  (jotain-showcase--visit "lisp/init-completion.el" 400)
+  (let ((right (jotain-showcase--step "split right" (split-window-right 110))))
+    (when right
+      (with-selected-window right
+        (jotain-showcase--step "overview dirvish"
+          (dired (expand-file-name "nix" user-emacs-directory)))
+        (let ((low (jotain-showcase--step "split below" (split-window-below))))
+          (when low
+            (with-selected-window low
+              (jotain-showcase--step "overview org"
+                (set-window-buffer
+                 (selected-window)
+                 (find-file-noselect (jotain-showcase--sample-org)))))))))))
+
+;;;; Transient scenes
+;;
+;; These arrange the frame AND capture it, because the UI they exist to show
+;; only lives inside a command that has not returned yet.  Each is handed the
+;; capture thunk.
+
+(defun jotain-showcase-scene-completion (capture)
+  "Vertico + marginalia + orderless in the minibuffer, mid-command."
+  (jotain-showcase--visit "lisp/init-prog.el" 440)
+  (jotain-showcase--step "completion"
+    (minibuffer-with-setup-hook
+        (lambda ()
+          (insert "jotain-")
+          (run-at-time
+           0.7 nil
+           (lambda ()
+             (jotain-showcase--step "completion capture" (funcall capture))
+             (when (active-minibuffer-window) (abort-recursive-edit)))))
+      (condition-case nil
+          (call-interactively #'execute-extended-command)
+        (quit nil)))))
+
+(defun jotain-showcase-scene-popup (capture)
+  "The corfu in-buffer completion popup with nerd-icons margins."
+  (jotain-showcase--visit "lisp/init-core.el" 80)
+  (jotain-showcase--step "popup"
+    (let ((buf (get-buffer-create "*jotain-showcase-popup*")))
+      (set-window-buffer (selected-window) buf)
+      (select-window (get-buffer-window buf))
+      (with-current-buffer buf
+        (emacs-lisp-mode)
+        (erase-buffer)
+        ;; The prefix must be genuinely ambiguous: with a single candidate
+        ;; corfu inserts it and never shows the popup.
+        (insert ";; Completion is on C-M-i; the popup below is corfu.\n\n"
+                "(defun jotain-showcase-demo ()\n"
+                "  (jotain-")
+        (goto-char (point-max)))
+      ;; The popup is torn down by the next command, so show it and capture
+      ;; inside the same step rather than across two timers.
+      (completion-at-point)
+      (funcall capture))))
+
+(defvar jotain-showcase-scenes
+  '((code       . jotain-showcase-scene-code)
+    (completion . jotain-showcase-scene-completion)
+    (popup      . jotain-showcase-scene-popup)
+    (files      . jotain-showcase-scene-files)
+    (vc         . jotain-showcase-scene-vc)
+    (org        . jotain-showcase-scene-org)
+    (overview   . jotain-showcase-scene-overview))
+  "Alist of scene NAME to builder function, in capture order.")
+
+(defun jotain-showcase--transient-p (fn)
+  "Non-nil when scene FN captures the frame itself.
+Such a scene takes the capture thunk as its single argument."
+  (memq fn '(jotain-showcase-scene-completion
+             jotain-showcase-scene-popup)))
+
+;;;; Driver
+
+(defun jotain-showcase-run ()
+  "Capture every scene in `jotain-showcase-scenes' under every theme."
+  (interactive)
+  (setq jotain-showcase--failures nil)
+  ;; auto-dark polls the system appearance and would flip the theme back
+  ;; between building a scene and capturing it, silently producing two PNGs
+  ;; of the same theme.
+  (jotain-showcase--step "disable auto-dark"
+    (when (bound-and-true-p auto-dark-mode) (auto-dark-mode -1)))
+  (let ((captured 0))
+    (dolist (theme jotain-showcase-themes)
+      (jotain-showcase--step (format "load-theme %s" theme)
+        ;; The `load-theme' advice in init-ui.el disables the previous theme,
+        ;; so no manual disable-theme bookkeeping is needed here.
+        (load-theme theme t))
+      (dolist (entry jotain-showcase-scenes)
+        (let* ((name (car entry))
+               (fn (cdr entry))
+               (capture (lambda ()
+                          (jotain-showcase--capture name theme)
+                          (cl-incf captured))))
+          (jotain-showcase--reset)
+          (message "jotain-showcase: %s / %s" theme name)
+          (if (jotain-showcase--transient-p fn)
+              (jotain-showcase--step (format "scene %s" name)
+                (funcall fn capture))
+            (jotain-showcase--step (format "scene %s" name) (funcall fn))
+            (funcall capture)))))
+    (message "jotain-showcase: wrote %d image(s) to %s"
+             captured jotain-showcase-directory)
+    (when jotain-showcase--failures
+      (message "jotain-showcase: %d step(s) degraded:\n  %s"
+               (length jotain-showcase--failures)
+               (string-join (reverse jotain-showcase--failures) "\n  ")))
+    captured))
+
+(defun jotain-showcase-batch ()
+  "Run the showcase and exit; non-zero when nothing was captured."
+  (let ((n (condition-case err
+               (jotain-showcase-run)
+             (error (message "jotain-showcase: fatal: %S" err) 0))))
+    (kill-emacs (if (> n 0) 0 2))))
+
+(provide 'showcase)
+;;; showcase.el ends here


### PR DESCRIPTION
Rebased onto `b26628e`. Two commits, three files, no binaries.

## 1. UI review — `docs/reviews/2026-07-ui-review.md`

Ten findings on the layer that decides what Jotain looks like: theme and appearance switching, modeline and headerline, fonts and glyph fallbacks, fringes, line highlighting, the completion UI, the keybinding surface, and Org styling. Four verified by evaluating Elisp, six static. Line numbers are against `b26628e`.

| # | Finding | Status |
|---|---|---|
| 1 | `early-init.el` pins `ns-appearance` to `dark` while the theme layer follows the system — light mode gets a dark titlebar | static |
| 2 | `calendar-iso-week-face` is a `copy-face` snapshot, so ISO week numbers keep the old theme's colour after every `auto-dark` flip | verified |
| 3 | `doom-modeline-icon` is a global set from `server-after-make-frame-hook` — in a mixed GUI/TTY daemon session the last frame created wins for all of them | static |
| 4 | `diff-hl-side 'left` and `flymake-fringe-indicator-position 'left-fringe` contest the same fringe on any line that is both modified and diagnosed | static |
| 5 | `hl-line` in `text-mode` highlights the whole logical line, which under `visual-line-mode` is the entire wrapped paragraph | verified |
| 6 | The `face`/`tabs`/`tab-mark` half of `whitespace-style` never renders — `whitespace-mode` is never enabled | verified |
| 7 | **New:** markdown's `C-c m` prefix shadows the global `consult-man` that `init-keys.el` still documents | static |
| 8 | Ownership of `prefix-help-command` between which-key and embark is decided only by module order in `init.el` | static |
| 9 | `org-startup-indented` may disable org-modern's block-fringe styling | needs confirmation |
| 10 | Frame-setup hooks cover only `server-after-make-frame-hook` | static |

**Finding 7 came out of this rebase.** `b26628e` added a `C-c m ...` keymap to `markdown-mode-map`, but `C-c m` is already the global `consult-man` (`init-completion.el:226`) and is described as such in `init-keys.el:108`. A prefix and a command can't share a key, so in Markdown buffers the global binding silently vanishes and the which-key label is wrong. It's also the only `C-c <letter>` in the config bound twice.

Finding 3 may share a root cause with the open `TODO.md` item "Fix themes in terminal".

Four **non-findings** are recorded so they aren't re-reported — among them that `alist-get` on the tab-bar alist shape is fine, and that `mode-line-format . none` is a real window-parameter value.

**One finding was dropped rather than carried as fixed.** An earlier draft flagged `just screenshot` racing `init.el`'s 2-second idle package refresh. `3d3e204` removed the startup archive fetch entirely, so the race no longer exists. The `JOTAIN_NO_PACKAGE_REFRESH` export that earlier revisions of this branch added to the recipes is gone with it — it would have set a variable nothing reads.

## 2. Showcase harness — `etc/showcase.el` + `just showcase`

Seven named scenes — `code`, `completion`, `popup`, `files`, `vc`, `org`, `overview` — each captured under both Jylhis themes. Lives in `etc/` next to `debug-init.el`, outside `lisp/` and `test/`, so the use-package scanner and the elisp checks never see it.

Scene steps degrade to a logged note rather than aborting; the capture itself is not demoted and exits non-zero. No scene fabricates state — in particular nothing creates a second tab to force the tab bar into view, since `tab-bar-show` is 1 and a single tab is the honest default.

Two capture facts found by running it, both in the file header:

- **`jotain-screenshot` cannot capture a child frame.** `x-export-frames` exports one frame's own contents, so corfu's popup is simply absent. Child-frame scenes route through ImageMagick's `import -window root`.
- **The `popup` scene still does not show the popup.** corfu displays from `post-command-hook`, which does not run when `completion-at-point` is called from a timer. Documented, not fixed — `execute-kbd-macro` is the likely fix.

## What was removed

Earlier revisions of this branch carried 14 captured PNGs (2 MB), a `docs/images/showcase/README.md` caveating them, and a `docs/superpowers/specs/` design doc. All dropped, and the branch was rebuilt from `main` so the blobs never enter history.

The images were captured on a substitute Emacs — `compat` is in no binary cache and GNU ELPA is proxy-blocked, so `doom-modeline`, `nerd-icons`, `dirvish`, `magit`, `org-modern`, `indent-bars`, `breadcrumb` and `pulsar` were all absent. They showed a vanilla modeline and no icons, settled none of the findings they were meant to settle, and needed a README explaining what not to believe. The design spec described work that is now implemented; `etc/showcase.el` is its own documentation.

## Test plan

- [ ] `just showcase` on a real distribution build, then confirm or kill findings 1, 3 and 4
- [ ] Decide finding 7: move the markdown keymap, or drop the global `consult-man` and relabel `C-c m`
- [ ] Fix the `popup` scene via `execute-kbd-macro`
- [ ] Resolve finding 9 against org-modern's pinned source