### PR TITLE
feat(org): configure Org Babel as a notebook environment

### DIFF
--- a/docs/architecture/modules.mdx
+++ b/docs/architecture/modules.mdx
@@ -135,6 +135,8 @@ Prose editing: `jinx` for spell-checking, `markdown-mode`, `denote` for notes, `
 
 `org-mode`, `org-modern`, capture templates, agenda, and friends. Binds `C-c a` → `org-agenda`, `C-c c` → `org-capture`, `C-c l` → `org-store-link`.
 
+Also holds the Org Babel layer that makes an `.org` file usable as a notebook: `jotain-org-babel-languages` (a curated set of languages, all backed by `ob-*` libraries Org itself ships), a trust-aware `org-confirm-babel-evaluate` predicate that skips the prompt for files under `org-directory` or inside the current project, inline-image refresh after every run, source-block editing that preserves indentation, and a `C-c b` notebook prefix (`b` run buffer, `e` run subtree, `r` restart session and run buffer, `s` switch to session, `k` clear results, `t` tangle). See [Notebooks with Org Babel](/usage/notebooks).
+
 ## Language modules
 
 Each `init-lang-*.el` file pins `:mode` regexes and provides font-lock for a group of related languages. Formatter configuration is centralised through `apheleia` in `init-prog.el`; LSP server hooks live in `init-prog.el` too.

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -1044,6 +1044,35 @@ Treated as a "third-party" package despite being built-in
 because it's the size and surface area of one. Capture templates
 and a small bind table live below.
 
+### `ob-core` *(built-in / Nix)*
+
+Org Babel, configured as a notebook. Enables a curated set of
+Org-provided languages (see `jotain-org-babel-languages'), swaps
+the blanket evaluation prompt for a trust check — your notes and
+project files run on `C-c C-c', a `.org' from anywhere else still
+asks — and redisplays inline images after every run so `:file'
+plots refresh in place. Adds a `C-c b' notebook prefix in Org
+buffers: `b' run buffer, `e' run subtree, `r' restart session and
+run buffer, `s' switch to session, `k' clear results, `t'
+tangle. Blocks are not re-evaluated during export (`:eval
+never-export'); what you see in the buffer is what gets exported.
+
+### `org-src` *(built-in / Nix)*
+
+Built-in source-block editing (`C-c '`). Edits open in the
+current window rather than stealing the frame layout, and
+indentation is left exactly as written — Org's default of
+re-indenting on exit corrupts Python blocks, where leading
+whitespace is syntax.
+
+### `org-tempo` *(built-in / Nix)*
+
+Built-in `<KEY TAB' block expansion, plus entries for the
+languages this config actually runs — `<py', `<sh', `<el',
+`<sql', `<jp' (Python with a session, for notebook-style
+work). Org's own list covers the structural blocks (`<s',
+`<q', `<e'); these add the source blocks worth two keystrokes.
+
 ### `org-clock` *(built-in / Nix)*
 
 Built-in time tracking with persistence across restarts. Lets
@@ -1091,7 +1120,10 @@ init-prog; format-on-save runs rustfmt through apheleia.
 Built-in Python mode pinned to its tree-sitter variant so we
 get the modern parser without any third-party package. The LSP
 server (pyright/basedpyright/ruff-lsp) comes from the project's
-own environment, not from this config.
+own environment, not from this config. When IPython is on PATH it
+becomes the REPL — better completion, tracebacks and `%magic' for
+`run-python' and for Org Babel `:session' blocks alike — while
+one-shot (sessionless) Babel blocks stay on plain `python3'.
 
 ## `init-lang-go.el` — Go
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,6 +43,7 @@
             "pages": [
               "usage/launching",
               "usage/devenv",
+              "usage/notebooks",
               "usage/ai-screenshot"
             ]
           },

--- a/docs/jotain.texi
+++ b/docs/jotain.texi
@@ -63,6 +63,7 @@ Usage
 
 * Launching Emacs::             One-shot, daemon + client, quick edit.
 * Devenv Integration::          Tasks, processes, env, LSP, MCP.
+* Notebooks::                   Org Babel as a literate notebook.
 * AI Screenshots::              Frame capture for AI assistants.
 
 Guides
@@ -126,6 +127,10 @@ Appendix
 @node Devenv Integration
 @chapter Devenv Integration
 @include usage-devenv.texi
+
+@node Notebooks
+@chapter Notebooks
+@include usage-notebooks.texi
 
 @node AI Screenshots
 @chapter AI Screenshots

--- a/docs/keybindings.mdx
+++ b/docs/keybindings.mdx
@@ -95,6 +95,11 @@ A few major modes rebind `C-c` leaves locally:
 - `dired-mode`: `C-c C-e` → `wdired-change-to-wdired-mode` (toggle writable dired)
 - `sops-mode`: `C-c C-c` save, `C-c C-k` cancel, `C-c C-d` edit
 - `embark` exports: `C-c C-o` → `embark-export`
+- `org-mode`: `C-c b` is an Org Babel notebook prefix — `b` run buffer,
+  `e` run subtree, `r` restart session and run buffer, `s` switch to
+  session, `k` clear results, `t` tangle. Single blocks stay on
+  `C-c C-c`, and Org's own `C-c C-v` babel map is untouched. See
+  [Notebooks with Org Babel](/usage/notebooks).
 
 ## Embark action menu
 

--- a/docs/usage/notebooks.mdx
+++ b/docs/usage/notebooks.mdx
@@ -1,0 +1,254 @@
+---
+title: Notebooks with Org Babel
+description: Use Org mode as a literate notebook — run code blocks, keep a session, get plots inline, tangle to source
+---
+
+# Notebooks with Org Babel
+
+Org Babel turns an ordinary `.org` file into a notebook: prose,
+executable source blocks, and their captured output in one plain-text
+document that diffs, greps, and merges like any other file. Jotain
+configures it in `lisp/init-org.el` for that workflow specifically —
+languages preloaded, evaluation prompt made unobtrusive, plots
+redisplayed after every run.
+
+Nothing here is a separate mode. You are in `org-mode` the whole time.
+
+## The loop
+
+Write a block, put point in it, press `C-c C-c`:
+
+```org
+#+begin_src python
+print(sum(range(10)))
+#+end_src
+
+#+RESULTS:
+: 45
+```
+
+The `#+RESULTS:` block is written back into the buffer, so results are
+part of the document and survive a restart. `C-c C-c` on a block that
+already has results replaces them.
+
+Type `<py` then `TAB` to insert an empty Python block —
+[`org-tempo`](#structure-templates) has entries for the languages this
+config actually runs. `C-c '` opens the block in a real major-mode
+buffer with LSP, formatting, and everything else you get in a
+standalone file; `C-c '` again returns.
+
+### The `C-c b` prefix
+
+Cell-at-a-time is `C-c C-c`. Everything wider than one block is under
+`C-c b` in Org buffers:
+
+| Key | Command | What it does |
+| --- | --- | --- |
+| `C-c b b` | `org-babel-execute-buffer` | Run every block in the file, top to bottom |
+| `C-c b e` | `org-babel-execute-subtree` | Run every block under the current heading |
+| `C-c b r` | `jotain-org-babel-restart-session-and-execute-buffer` | Kill the session of the block at point, then run the whole buffer — "restart kernel and run all" |
+| `C-c b s` | `org-babel-switch-to-session` | Jump into the live REPL behind the block at point |
+| `C-c b k` | `org-babel-remove-result-one-or-many` | Clear results; with a prefix arg, clear the whole buffer |
+| `C-c b t` | `org-babel-tangle` | Write the blocks out to real source files |
+
+Org's own `C-c C-v` babel map is untouched and still has everything
+else (`C-c C-v v` to expand a block, `C-c C-v i` to view header args,
+and so on).
+
+## Sessions
+
+By default each block runs in a fresh process, so nothing carries over
+between them. Add `:session` to keep a live interpreter around, which is
+what makes an Org file behave like a notebook rather than a pile of
+scripts:
+
+```org
+#+begin_src python :session notebook :results output
+import pandas as pd
+df = pd.read_csv("measurements.csv")
+#+end_src
+
+#+begin_src python :session notebook :results output
+print(df.describe())
+#+end_src
+```
+
+The second block sees `df`. `C-c b s` drops you into that interpreter
+to poke at state interactively; `C-c b r` throws it away and replays the
+file from the top, which is the reliable way to check that a notebook
+still runs end-to-end after you have been editing out of order.
+
+`<jp TAB` inserts a Python block with `:session notebook :results
+output` already filled in.
+
+## Results
+
+`:results` decides what gets captured. The two that matter:
+
+- **`output`** — everything the block printed. This is Jotain's default
+  for Python, because the notebook habit is to `print` things and Org's
+  own default (`value`) shows nothing at all unless the block ends in a
+  `return`.
+- **`value`** — the value of the last expression. Set it per block when
+  you want a table or a number rather than a transcript.
+
+A block that produces a table gets a real Org table back, which the rest
+of the document can reference by name:
+
+```org
+#+name: totals
+#+begin_src python :results value
+return [["region", "n"], None, ["north", 41], ["south", 58]]
+#+end_src
+```
+
+### Plots
+
+Write the figure to `:file` and Org inserts a link to it; the image is
+redisplayed automatically after every run, so re-running a cell updates
+the picture in place rather than leaving the previous one on screen.
+
+```org
+#+begin_src python :session notebook :results file :file plot.png
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+plt.plot([1, 4, 9, 16])
+plt.savefig("plot.png")
+"plot.png"
+#+end_src
+```
+
+Images are capped at 600px wide (`org-image-actual-width`) so a large
+figure does not push the text column off-screen. `C-c C-x C-v` toggles
+inline images if you want the raw links back.
+
+## Evaluation prompts and trust
+
+Running a source block runs arbitrary code, so Org asks for confirmation
+by default — which is correct for a file someone sent you and unbearable
+for the notebook you are editing right now.
+
+Jotain replaces the blanket prompt with a trust check
+(`jotain-org-babel-confirm-evaluate`). A file is trusted when it lives
+either:
+
+- under `org-directory` — the notes tree, `~/notes` by default, shared
+  with `org-capture`, `org-roam`, and `denote`; or
+- inside the current project, as `project-current` sees it.
+
+Trusted files evaluate straight away. Everything else — a downloaded
+`.org`, a mail attachment, a gist opened from a browser — still prompts
+on every block. To go back to Org's stock behaviour:
+
+```elisp
+(setopt org-confirm-babel-evaluate t)
+```
+
+## Export
+
+Export (`C-c C-e`) uses the results already in the buffer:
+`org-babel-default-header-args` sets `:eval never-export`, so producing
+an HTML or PDF copy never re-runs your code. What you see in the buffer
+is what gets published. Pass `:eval yes` on a block to opt it back into
+running at export time.
+
+The matching default is `:exports both`, so a block and its output both
+appear in the exported document. `:exports results` hides the code;
+`:exports none` hides both.
+
+## Tangling
+
+`C-c b t` writes blocks out to real files, which is how a notebook
+graduates into a program:
+
+```org
+#+begin_src python :tangle analysis/load.py
+def load(path):
+    ...
+#+end_src
+```
+
+Indentation is preserved exactly as written (`org-src-preserve-indentation`),
+which is not Org's default and is not optional for Python — Org's
+re-indent-on-exit behaviour corrupts blocks where leading whitespace is
+syntax.
+
+## Languages
+
+`jotain-org-babel-languages` in `lisp/init-org.el` lists what is
+enabled:
+
+```
+emacs-lisp  org
+shell       eshell
+python      C     R    haskell  js  css
+sql         sqlite
+awk         sed   calc
+dot         gnuplot     latex
+```
+
+Every entry is backed by an `ob-LANG` library that ships with Org
+itself, so no source block depends on a package being installed. `C`
+covers C, C++ and D; `shell` covers bash, sh and the other shell
+dialects Org knows. A test (`test/test-org-babel.el`) `require`s each
+one, so a language that gets renamed or moved out to org-contrib during
+an Org bump fails CI rather than a `C-c C-c` months later.
+
+Enabling a language teaches Org how to run the block — it does not
+provide the interpreter. Python, R, `gnuplot`, `dot` and the rest come
+from the project's own environment, the same way LSP servers do.
+
+Add one by editing the list:
+
+```elisp
+(defconst jotain-org-babel-languages
+  '(emacs-lisp org shell eshell python C R haskell js css
+    sql sqlite awk sed calc dot gnuplot latex
+    ruby))                               ; ← ob-ruby ships with Org
+```
+
+### Python and IPython
+
+`init-lang-python.el` points the Python REPL at `ipython` when it is on
+`PATH`, which gets you IPython's completion, tracebacks and `%magic` in
+`run-python` and in `:session` blocks. When it is absent, `python3` is
+used and nothing else changes.
+
+Blocks *without* a session always use plain `python3`
+(`org-babel-python-command`), deliberately: a one-shot block handed an
+interactive `ipython -i` would wait for input instead of returning a
+result.
+
+## Structure templates
+
+`org-tempo` expands `<KEY` + `TAB`. Jotain adds:
+
+| Key | Expands to |
+| --- | --- |
+| `<py` | `#+begin_src python` |
+| `<jp` | `#+begin_src python :session notebook :results output` |
+| `<sh` | `#+begin_src bash` |
+| `<el` | `#+begin_src emacs-lisp` |
+| `<sql` | `#+begin_src sql` |
+| `<dot` | `#+begin_src dot :file diagram.png` |
+
+Org's own entries (`<s` source, `<q` quote, `<e` example, and the rest)
+still work.
+
+## What this is not
+
+This is Org Babel, not a Jupyter client. Blocks run through Org's own
+`ob-*` backends and comint, so there are no Jupyter kernels, no
+`.ipynb` files, and no rich MIME output beyond images and tables.
+
+If you need actual kernels — a remote kernel, a language with no
+`ob-` backend, or `.ipynb` interchange — the
+[`emacs-jupyter`](https://github.com/emacs-jupyter/jupyter) package
+provides `jupyter-python` blocks alongside everything above. It is not
+included here because it needs the `zmq` dynamic module and a `jupyter`
+binary at runtime, neither of which this configuration ships.
+
+Long-running blocks also execute synchronously and will block Emacs. Use
+`:session` and a REPL you can watch (`C-c b s`) rather than waiting on a
+30-minute `C-c C-c`.

--- a/lisp/init-lang-python.el
+++ b/lisp/init-lang-python.el
@@ -6,20 +6,43 @@
 ;; The eglot hook is registered in `init-prog'; the LSP server itself
 ;; (pyright / basedpyright / ruff-lsp) comes from the project's own
 ;; environment, not from this config.
+;;
+;; Everything about *which* Python runs — the REPL interpreter and the
+;; one Org Babel shells out to — is decided here rather than in
+;; `init-org', so there is a single place to look when a `#+begin_src
+;; python' block picks up the wrong binary.
 
 ;;; Code:
 
 ;;; @doc Built-in Python mode pinned to its tree-sitter variant so we
 ;;; get the modern parser without any third-party package. The LSP
 ;;; server (pyright/basedpyright/ruff-lsp) comes from the project's
-;;; own environment, not from this config.
+;;; own environment, not from this config. When IPython is on PATH it
+;;; becomes the REPL — better completion, tracebacks and `%magic' for
+;;; `run-python' and for Org Babel `:session' blocks alike — while
+;;; one-shot (sessionless) Babel blocks stay on plain `python3'.
 (use-package python
   :ensure nil
   :mode ("\\.py\\'" . python-ts-mode)
   :interpreter ("python3" . python-ts-mode)
   :custom
   (python-indent-offset 4)
-  (python-shell-interpreter "python3"))
+  (python-shell-interpreter "python3")
+  :config
+  ;; Org 9.7's default for `org-babel-python-command' is `auto', which
+  ;; derives the non-session command from `python-shell-interpreter'
+  ;; *and its args*. Pinning it explicitly keeps the REPL swap below
+  ;; from handing a one-shot block an interactive `ipython -i', which
+  ;; would sit waiting for input instead of returning a result.
+  (setopt org-babel-python-command "python3")
+  ;; The IPython REPL is strictly nicer than the stock one, but it is
+  ;; not guaranteed to be installed — this config never assumes an
+  ;; interpreter it does not ship. `--simple-prompt' is what makes
+  ;; IPython usable from comint at all: it turns off the prompt_toolkit
+  ;; UI that python.el cannot drive.
+  (when (executable-find "ipython")
+    (setopt python-shell-interpreter "ipython"
+            python-shell-interpreter-args "-i --simple-prompt")))
 
 (provide 'init-lang-python)
 ;;; init-lang-python.el ends here

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -5,11 +5,21 @@
 ;; Org gets its own file because it's an entire writing/agenda/literate-
 ;; programming environment, not a single feature. Treat the built-in
 ;; `org' the same as a third-party package — it's big enough to earn it.
+;;
+;; The Babel half of that environment — source blocks, sessions, inline
+;; results, tangling — is configured further down as a notebook: a
+;; curated language set, a trust-aware evaluation prompt, and a `C-c b'
+;; prefix for the run/restart/clear loop.  See docs/usage/notebooks.mdx.
 
 ;;; Code:
 
+(require 'seq)
+
 ;; Defined in init-writing.el, which init.el loads before this file.
 (defvar jotain-notes-directory)
+
+(declare-function project-current "project" (&optional maybe-prompt directory))
+(declare-function project-root "project" (project))
 
 ;;; @doc Built-in Org — outline, agenda, capture, literate-programming.
 ;;; Treated as a "third-party" package despite being built-in
@@ -33,9 +43,6 @@
   (org-startup-folded          'content)
   (org-hide-emphasis-markers   t)
   (org-pretty-entities         t)
-  (org-src-fontify-natively    t)
-  (org-src-tab-acts-natively   t)
-  (org-confirm-babel-evaluate  t)
   (org-log-done                'time)
   (org-return-follows-link     t)
   (org-fold-catch-invisible-edits 'show-and-error)
@@ -49,6 +56,196 @@
           ("n" "Note" entry
            (file+headline org-default-notes-file "Notes")
            "* %?\n  %U"))))
+
+;;; Org Babel — the notebook half of Org
+;;
+;; Everything below turns Org's literate-programming engine into a
+;; usable replacement for a Jupyter notebook: evaluate a block with
+;; `C-c C-c', keep state in a `:session', get plots back inline, and
+;; tangle the whole thing out to real source files when it graduates
+;; from an experiment to a program.
+
+;; `ob-core' and friends are loaded lazily behind `:after org', so the
+;; byte-compiler needs to be told these exist. Declared rather than
+;; required: pulling Org in at compile time would defeat the deferral.
+(declare-function org-babel-execute-buffer "ob-core" (&optional arg))
+(declare-function org-babel-execute-subtree "ob-core" (&optional arg))
+(declare-function org-babel-initiate-session "ob-core" (&optional arg info))
+(declare-function org-babel-remove-result-one-or-many "ob-core" (&optional arg))
+(declare-function org-babel-switch-to-session "ob-core" (&optional arg info))
+(declare-function org-babel-tangle "ob-tangle" (&optional arg target-file lang-re))
+
+;; Set in `:config' below with `setq' rather than `setopt' because
+;; ob-python declares it with `defvar', not `defcustom'.
+(defvar org-babel-default-header-args:python)
+
+(defconst jotain-org-babel-languages
+  '(emacs-lisp org
+    shell eshell
+    python C R haskell js css
+    sql sqlite
+    awk sed calc
+    dot gnuplot latex)
+  "Languages Org Babel may evaluate in a source block.
+Every entry must be backed by an `ob-LANG' library that ships with
+Org itself — no entry here may need a package from ELPA, so a
+source block never fails on a machine where the config is only
+half-installed.  `C' covers C, C++ and D; `shell' covers bash, sh
+and every other shell dialect Org knows about.
+
+The interpreter is a separate question: enabling `python' teaches
+Org how to run a Python block, it does not put Python on PATH.
+Interpreters come from the project's own environment, exactly like
+the LSP servers in `init-prog'.")
+
+(defun jotain-org-babel-trusted-p ()
+  "Return non-nil when the current buffer is an Org file we consider ours.
+A file counts as ours when it lives under `org-directory' (the notes
+tree) or inside the current project.  Anything else — a downloaded
+`.org' file, a mail attachment, a gist opened straight from a
+browser — does not, because evaluating a source block runs arbitrary
+code with the user's privileges."
+  (when-let* ((file (buffer-file-name (buffer-base-buffer))))
+    (let ((file (expand-file-name file)))
+      (or (and (stringp org-directory)
+               (file-in-directory-p file org-directory))
+          (when-let* ((project (project-current nil (file-name-directory file))))
+            (file-in-directory-p file (project-root project)))))))
+
+(defun jotain-org-babel-confirm-evaluate (_lang _body)
+  "Decide whether to prompt before evaluating a source block.
+Suitable as the value of `org-confirm-babel-evaluate', which calls
+its function with the block's language and body and prompts when the
+result is non-nil.  Both arguments are ignored: the question is not
+what the block contains but where it came from, so the answer comes
+from `jotain-org-babel-trusted-p'.
+
+The effect is that your own notes and project files evaluate with no
+friction — the notebook loop stays `C-c C-c' — while a source block
+in a file from anywhere else still has to be confirmed."
+  (not (jotain-org-babel-trusted-p)))
+
+(defun jotain-org-babel-redisplay-images ()
+  "Refresh inline images after a source block runs.
+Added to `org-babel-after-execute-hook' so a block that writes a plot
+to `:file' shows the new image instead of the previous run's.
+
+Org 9.8 (Emacs 31) folded the inline-image commands into the generic
+link-preview machinery and marked the old names obsolete, so the
+command is looked up at runtime instead of being named directly —
+that is what keeps this file byte-compiling warning-clean against
+both Org 9.7 and 9.8.  Errors are demoted because refreshing an
+image is cosmetic: it must never abort a block that just ran fine."
+  (when (derived-mode-p 'org-mode)
+    (when-let* ((refresh (seq-find #'fboundp
+                                   '(org-link-preview-region
+                                     org-redisplay-inline-images))))
+      (with-demoted-errors "Inline image refresh failed: %S"
+        (funcall refresh)))))
+
+(defun jotain-org-babel-restart-session-and-execute-buffer ()
+  "Kill the session of the block at point, then re-run the whole buffer.
+The Org equivalent of a notebook's \"restart kernel and run all\": the
+one command you want when the session has accumulated state you can no
+longer account for.  Blocks that do not use a `:session' have no
+session to kill, so this degrades to `org-babel-execute-buffer'."
+  (interactive)
+  (when-let* ((session (save-window-excursion
+                         (ignore-errors (org-babel-initiate-session))))
+              (buffer (and (stringp session) (get-buffer session))))
+    (let ((kill-buffer-query-functions nil))
+      (kill-buffer buffer)))
+  (org-babel-execute-buffer))
+
+;;; @doc Org Babel, configured as a notebook. Enables a curated set of
+;;; Org-provided languages (see `jotain-org-babel-languages'), swaps
+;;; the blanket evaluation prompt for a trust check — your notes and
+;;; project files run on `C-c C-c', a `.org' from anywhere else still
+;;; asks — and redisplays inline images after every run so `:file'
+;;; plots refresh in place. Adds a `C-c b' notebook prefix in Org
+;;; buffers: `b' run buffer, `e' run subtree, `r' restart session and
+;;; run buffer, `s' switch to session, `k' clear results, `t'
+;;; tangle. Blocks are not re-evaluated during export (`:eval
+;;; never-export'); what you see in the buffer is what gets exported.
+(use-package ob-core
+  :ensure nil
+  :after org
+  :bind
+  (:map org-mode-map
+        ("C-c b b" . org-babel-execute-buffer)
+        ("C-c b e" . org-babel-execute-subtree)
+        ("C-c b r" . jotain-org-babel-restart-session-and-execute-buffer)
+        ("C-c b s" . org-babel-switch-to-session)
+        ("C-c b k" . org-babel-remove-result-one-or-many)
+        ("C-c b t" . org-babel-tangle))
+  :hook (org-babel-after-execute . jotain-org-babel-redisplay-images)
+  :custom
+  (org-confirm-babel-evaluate #'jotain-org-babel-confirm-evaluate)
+  ;; Org's own defaults plus two opinions: `:exports both' so a block
+  ;; and its output both survive export, and `:eval never-export' so
+  ;; exporting a document never re-runs code behind your back — the
+  ;; results already in the buffer are the ones that get published.
+  (org-babel-default-header-args
+   '((:session . "none")
+     (:results . "replace")
+     (:exports . "both")
+     (:eval    . "never-export")
+     (:cache   . "no")
+     (:noweb   . "no")
+     (:hlines  . "no")
+     (:tangle  . "no")))
+  ;; A block that writes a plot to `:file' is only useful if the plot
+  ;; shows up. Cap the width so a 2000px figure doesn't push the text
+  ;; column off-screen.
+  (org-startup-with-inline-images t)
+  (org-image-actual-width '(600))
+  :config
+  (setopt org-babel-load-languages
+          (mapcar (lambda (lang) (cons lang t)) jotain-org-babel-languages))
+  ;; `org-babel-default-header-args:python' is a plain defvar, not a
+  ;; defcustom, so `setq' is the correct setter here.
+  ;;
+  ;; Org's default for Python is `:results value', which returns the
+  ;; value of a `return' statement and therefore shows nothing at all
+  ;; for the print-and-see-what-happens style a notebook invites.
+  ;; `output' captures stdout instead, which is what people mean.
+  ;; Per-block `:results value' still works when you want the value.
+  (setq org-babel-default-header-args:python '((:results . "output replace"))))
+
+;;; @doc Built-in source-block editing (`C-c '`). Edits open in the
+;;; current window rather than stealing the frame layout, and
+;;; indentation is left exactly as written — Org's default of
+;;; re-indenting on exit corrupts Python blocks, where leading
+;;; whitespace is syntax.
+(use-package org-src
+  :ensure nil
+  :after org
+  :custom
+  (org-src-fontify-natively t)
+  (org-src-tab-acts-natively t)
+  (org-src-preserve-indentation t)
+  (org-edit-src-content-indentation 0)
+  (org-src-window-setup 'current-window)
+  (org-src-ask-before-returning-to-edit-buffer nil))
+
+;;; @doc Built-in `<KEY TAB' block expansion, plus entries for the
+;;; languages this config actually runs — `<py', `<sh', `<el',
+;;; `<sql', `<jp' (Python with a session, for notebook-style
+;;; work). Org's own list covers the structural blocks (`<s',
+;;; `<q', `<e'); these add the source blocks worth two keystrokes.
+(use-package org-tempo
+  :ensure nil
+  :after org
+  :config
+  (setopt org-structure-template-alist
+          (seq-uniq (append '(("py"  . "src python")
+                              ("jp"  . "src python :session notebook :results output")
+                              ("sh"  . "src bash")
+                              ("el"  . "src emacs-lisp")
+                              ("sql" . "src sql")
+                              ("dot" . "src dot :file diagram.png"))
+                            org-structure-template-alist)
+                    (lambda (a b) (equal (car a) (car b))))))
 
 ;;; @doc Built-in time tracking with persistence across restarts. Lets
 ;;; you resume an interrupted clock without losing the entry.

--- a/nix/info-manual.nix
+++ b/nix/info-manual.nix
@@ -93,6 +93,10 @@ let
       out = "usage-devenv.texi";
     }
     {
+      src = "usage/notebooks.mdx";
+      out = "usage-notebooks.texi";
+    }
+    {
       src = "usage/ai-screenshot.mdx";
       out = "usage-ai-screenshot.texi";
     }

--- a/test/test-org-babel.el
+++ b/test/test-org-babel.el
@@ -1,0 +1,143 @@
+;;; test-org-babel.el --- Org Babel wiring regression tests -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Two things in `init-org.el' can rot silently.
+;;
+;; The first is `jotain-org-babel-languages'.  Enabling a language is a
+;; promise that `ob-LANG' exists in the Org that actually ships — a
+;; typo, or a language that moved out to org-contrib, produces nothing
+;; at byte-compile time and a broken `C-c C-c' months later.  These
+;; tests `require' every one of them.
+;;
+;; The second is `jotain-org-babel-confirm-evaluate'.  It relaxes
+;; `org-confirm-babel-evaluate' from "always ask" to "ask unless the
+;; file is ours", which is a security boundary: a regression that makes
+;; it return nil unconditionally would silently evaluate source blocks
+;; from any `.org' file the user opens.  That deserves a test.
+;;
+;; Like `test-ui.el', these read `init-org.el' rather than loading it —
+;; the module's `:custom' forms reference `jotain-notes-directory' from
+;; `init-writing', so requiring it standalone would fail.  Only the two
+;; `defun' forms under test are evaluated.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'org)
+(require 'project)
+(require 'seq)
+
+(defconst test-org-babel--init-org-file
+  (expand-file-name "lisp/init-org.el"
+                    (locate-dominating-file
+                     (or load-file-name buffer-file-name default-directory)
+                     "init.el"))
+  "Absolute path to the Org module under test.")
+
+(defun test-org-babel--top-level-form (head name)
+  "Return the `(HEAD NAME ...)' form from the Org module, or nil.
+HEAD is a symbol such as `defun' or `defconst'.  The module is read as
+data, so no `use-package' form is expanded and no package is loaded."
+  (with-temp-buffer
+    (insert-file-contents test-org-babel--init-org-file)
+    (goto-char (point-min))
+    (catch 'found
+      (condition-case nil
+          (while t
+            (let ((form (read (current-buffer))))
+              (when (and (consp form)
+                         (eq (car form) head)
+                         (eq (nth 1 form) name))
+                (throw 'found form))))
+        (end-of-file nil)))))
+
+(defun test-org-babel--languages ()
+  "Return the language list `init-org.el' enables."
+  (let ((form (test-org-babel--top-level-form 'defconst 'jotain-org-babel-languages)))
+    (should form)
+    (eval (nth 2 form) t)))
+
+(defun test-org-babel--define (name)
+  "Evaluate the `defun' named NAME out of the Org module."
+  (let ((form (test-org-babel--top-level-form 'defun name)))
+    (should form)
+    (eval form t)))
+
+(ert-deftest test-org-babel-languages-are-distinct-symbols ()
+  "The enabled-language list is a clean list of symbols."
+  (let ((languages (test-org-babel--languages)))
+    (should languages)
+    (should (seq-every-p #'symbolp languages))
+    (should (equal languages (seq-uniq languages)))))
+
+(ert-deftest test-org-babel-languages-have-backends ()
+  "Every enabled language is backed by an `ob-LANG' library Org ships.
+This is the test that catches a language which was renamed, or moved
+out of Org core into org-contrib, during an Org version bump."
+  (dolist (lang (test-org-babel--languages))
+    (let ((feature (intern (format "ob-%s" lang))))
+      (should (require feature nil t)))))
+
+(ert-deftest test-org-babel-trusts-files-under-org-directory ()
+  "A file in the notes tree needs no evaluation prompt."
+  (test-org-babel--define 'jotain-org-babel-trusted-p)
+  (let* ((notes (file-name-as-directory (make-temp-file "jotain-notes" t)))
+         (org-directory notes)
+         ;; No project anywhere, so only the notes-tree branch can match.
+         (project-find-functions nil))
+    (unwind-protect
+        (with-temp-buffer
+          (setq buffer-file-name (expand-file-name "notebook.org" notes))
+          (should (jotain-org-babel-trusted-p)))
+      (delete-directory notes t))))
+
+(ert-deftest test-org-babel-trusts-files-inside-a-project ()
+  "A file in the current project needs no evaluation prompt."
+  (test-org-babel--define 'jotain-org-babel-trusted-p)
+  (let* ((root (file-name-as-directory (make-temp-file "jotain-project" t)))
+         (org-directory (expand-file-name "elsewhere" temporary-file-directory))
+         (project-find-functions
+          (list (lambda (dir) (and (file-in-directory-p dir root)
+                                   (cons 'transient root))))))
+    (unwind-protect
+        (with-temp-buffer
+          (setq buffer-file-name (expand-file-name "README.org" root))
+          (should (jotain-org-babel-trusted-p)))
+      (delete-directory root t))))
+
+(ert-deftest test-org-babel-does-not-trust-foreign-files ()
+  "An Org file from outside the notes tree and outside any project asks.
+This is the security-relevant direction: a downloaded `.org' must not
+be able to run code on `C-c C-c' without confirmation."
+  (test-org-babel--define 'jotain-org-babel-trusted-p)
+  (let* ((elsewhere (file-name-as-directory (make-temp-file "jotain-foreign" t)))
+         (org-directory (expand-file-name "notes" temporary-file-directory))
+         (project-find-functions nil))
+    (unwind-protect
+        (with-temp-buffer
+          (setq buffer-file-name (expand-file-name "downloaded.org" elsewhere))
+          (should-not (jotain-org-babel-trusted-p)))
+      (delete-directory elsewhere t))))
+
+(ert-deftest test-org-babel-does-not-trust-buffers-without-a-file ()
+  "A buffer with no backing file is not trusted."
+  (test-org-babel--define 'jotain-org-babel-trusted-p)
+  (let ((org-directory (expand-file-name "notes" temporary-file-directory))
+        (project-find-functions nil))
+    (with-temp-buffer
+      (should-not (jotain-org-babel-trusted-p)))))
+
+(ert-deftest test-org-babel-confirm-inverts-trust ()
+  "`org-confirm-babel-evaluate' prompts exactly when the file is untrusted.
+The predicate takes the block's language and body and ignores both —
+guard the arity too, since Org calls it with two arguments."
+  (test-org-babel--define 'jotain-org-babel-confirm-evaluate)
+  (cl-letf (((symbol-function 'jotain-org-babel-trusted-p) (lambda () t)))
+    (should-not (jotain-org-babel-confirm-evaluate "python" "print(1)")))
+  (cl-letf (((symbol-function 'jotain-org-babel-trusted-p) (lambda () nil)))
+    (should (jotain-org-babel-confirm-evaluate "python" "print(1)"))))
+
+(provide 'test-org-babel)
+;;; test-org-babel.el ends here


### PR DESCRIPTION
Implements Org Babel support along the lines of [Replace Jupyter Notebook With Emacs Org Mode](https://michaelneuper.com/posts/replace-jupyter-notebook-with-emacs-org-mode/) — languages loaded, evaluation prompt made workable, IPython as the REPL, plots inline.

Org's literate-programming engine ships with Emacs but arrives unconfigured: one language enabled, a confirmation prompt on every evaluation, re-indentation that corrupts Python blocks, and no inline image refresh. Before this change `lisp/init-org.el` set exactly three Babel-adjacent options.

## What changed

**`lisp/init-org.el`**

- `jotain-org-babel-languages` — 18 languages, every one backed by an `ob-LANG` library Org itself ships, so no source block depends on an ELPA package being installed. Enabling a language teaches Org to run the block; the interpreter still comes from the project's own environment, same as LSP servers.
- `jotain-org-babel-confirm-evaluate` — replaces the blanket prompt with a trust check. Files under `org-directory` or inside the current project evaluate on `C-c C-c`; a downloaded `.org` still asks on every block. Relaxing `org-confirm-babel-evaluate` is a security boundary, so it gets its own tests rather than just being set to `nil`.
- Inline images refresh after every run, so a `:file` plot updates in place.
- `org-src`: indentation preserved (not Org's default, and not optional for Python), edits open in the current window.
- `:eval never-export` — exporting a document never re-runs code behind your back. `:results output` for Python, because Org's `value` default shows nothing for print-and-look.
- New `C-c b` prefix in Org buffers: `b` run buffer, `e` run subtree, `r` restart session and run buffer, `s` switch to session, `k` clear results, `t` tangle. Single blocks stay on `C-c C-c` and Org's own `C-c C-v` map is untouched.
- `org-tempo` entries for the languages this config runs (`<py`, `<jp`, `<sh`, `<el`, `<sql`, `<dot`).

**`lisp/init-lang-python.el`** — points the REPL at `ipython` when it is on `PATH` (with `--simple-prompt`), and pins `org-babel-python-command` to plain `python3`. That second half matters: Org 9.7's `auto` default derives the sessionless command from `python-shell-interpreter` *and its args*, so without the pin a one-shot block gets an interactive `ipython -i` and sits waiting for input.

**Docs** — new `docs/usage/notebooks.mdx`, wired into `docs.json`, `docs/jotain.texi` and the `nix/info-manual.nix` chapter list; module reference and keybinding docs updated; `docs/configuration/package-reference.mdx` regenerated from the `@doc` markers.

## Compatibility note

Org 9.8 (Emacs 31) folded the inline-image commands into the generic link-preview machinery and made the 9.7 names obsolete. Under `byte-compile-error-on-warn` an obsolete-function reference is a build break, so the refresh command is resolved through `fboundp` at runtime instead of being named directly — the same file compiles clean against both Org versions.

## Verification

Ran against a cache-built Emacs 30.2 / Org 9.7.11 (the flake's own Emacs could not be built here — the sandbox proxy blocks the `emacs-overlay` tarball fetch, so `nix flake check` did not run):

- `lisp/init-org.el` and `lisp/init-lang-python.el` byte-compile with **no new warnings** (the one `org-roam-directory` free-variable warning is pre-existing and only appears because org-roam is absent from a bare Emacs).
- New `test/test-org-babel.el` — 7 tests, all passing: every one of the 18 `ob-` backends `require`s successfully, and the trust predicate is checked in all four directions (notes tree, project, foreign file, no file at all).
- Existing `test-ui`/`test-smoke` still pass.
- A real notebook executed end-to-end: emacs-lisp, two `:session` Python blocks with state carried between them, and a shell block, all evaluated with no prompt because the file was trusted.
- `nix/info-manual.nix` builds and the Notebooks chapter lands as a proper Info node; `nixfmt --check` clean; the regenerated package reference diffs against the checked-in copy with **only** the new blocks, confirming the generator toolchain matches CI's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9CrwEDgZGryj6qzqhMm1A)_