### PR TITLE
feat(completion): calmer, more natural in-buffer completion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,9 +6,12 @@
 
 ## Deferred review findings (docs/reviews/2026-07-emacs-nix-deep-review.md)
 
-- **Finding 12, option (b)** — adopt `completion-preview` alongside corfu in
+- ~~**Finding 12, option (b)** — adopt `completion-preview` alongside corfu in
   `init-completion.el` (with the Emacs 31 `completion-preview-sort-function`
-  pairing). Feature decision; the docs-only fix (option a) shipped instead.
+  pairing).~~ **Done 2026-08-26** — `completion-preview-mode` in
+  `init-completion.el`, gated by `jotain-completion-inline-preview`, with the
+  sort pairing, the R2 `C-i` unbind, and a comment/string inhibit. See
+  `docs/design/completion.md` §6 and `docs/reviews/2026-08-completion-ux-research.md`.
 - **Finding 21** — make `devenv-env--turn-on` subprocess-free: consult only
   `devenv-modeline--cached-trust` and replay via the async
   `devenv-modeline--probe-trust` callback (the long-TTL trust cache shipped;

--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -484,6 +484,17 @@ Persists corfu's pick history into savehist so frequent
 completions float to the top across sessions. Bundled with
 corfu.
 
+### `corfu-popupinfo` *(built-in / Nix)*
+
+Documentation panel beside the popup — a child frame that shows
+the selected candidate's docstring or source location, the way an IDE
+shows a detail pane. Off unless `jotain-completion-doc-popup' is
+non-nil. The delay is a cons (INITIAL . SUBSEQUENT): it waits a beat
+before first appearing so it does not flash on every pause, then
+refreshes quickly as you move between candidates. Bundled with corfu;
+binds only `M-t'/`M-h'/`M-g'/`C-M-v', so it never touches the freed
+RET/TAB or the `M-n'/`M-p' navigation keys.
+
 ### `cape`
 
 Completion-at-point Extensions — extra capf functions (dabbrev,
@@ -494,6 +505,22 @@ buffer-local, major-mode capfs run. `cape-elisp-symbol' is instead
 added buffer-locally in Elisp buffers, where it completes symbols
 even inside comments and docstrings (out there `elisp-completion-at-point'
 only fires in code), without polluting completion elsewhere.
+
+### `completion-preview` *(built-in / Nix)*
+
+Inline completion preview — the built-in `completion-preview-mode'
+(Emacs 30, extended in 31). It greys out the most likely completion
+after point as you type, the way a modern editor does, drawing its
+candidate from the same `completion-at-point-functions' the corfu
+popup uses. Enabled only in `jotain-completion-auto-modes' buffers (so
+prose stays quiet), and only when `jotain-completion-inline-preview'
+is non-nil. Two things keep it inside this config's rules: it binds
+`C-i' — which is the TAB event — to accept the preview, so that entry
+is removed and TAB still only indents; and it never binds RET, so
+Enter stays a newline. Accept the whole preview with `M-RET', or just
+the common prefix with `M-i'. The preview is suppressed inside
+comments and strings, and its sort is paired with corfu's so the ghost
+text matches the popup's top row.
 
 ## `init-navigation.el` — dired, project, windows
 

--- a/docs/design/completion.md
+++ b/docs/design/completion.md
@@ -416,3 +416,72 @@ at all (§2.1).
   covers the in-buffer side only.
 - **Performance tuning** — no evidence base exists (research §6.6). Any future
   tuning should start by measuring, not by copying numbers.
+
+---
+
+## 6. Addendum — "less annoying, more natural" round (2026-08-26)
+
+A second, narrow round on the in-buffer side, prompted by the request to make
+the popup "less annoying and more natural." It does not revisit the trigger
+model, the freed RET/TAB, or the capf chain — those stand. Evidence base:
+[`../reviews/2026-08-completion-ux-research.md`](../reviews/2026-08-completion-ux-research.md).
+Everything here is opt-out-gated per R6 and validated in `test/completion-test.el`.
+
+**6.1 The popup no longer commits candidates you did not choose.**
+`corfu-preview-current` ships as `insert`, which auto-inserts the selected
+candidate on *continued typing* — quietly undercutting the "never accept unless
+asked" intent that R4 and the freed keys were built for. Set to `nil`: the menu
+shows, nothing enters the buffer until an explicit `corfu-complete` (`C-M-i`).
+This is also what makes room for 6.4 — with corfu contributing no inline text,
+the ghost text is the sole inline surface.
+
+**6.2 The auto-popup timing moved onto corfu's documented defaults.**
+`jotain-completion-auto-delay` `0.1 → 0.2` and `jotain-completion-auto-prefix`
+`2 → 3`. §2.1 flagged the old `0.1`/`2` as unmeasured folklore; corfu's own
+defaults are `0.2`/`3`, and its docstrings caution against sitting *below* them
+(load/flicker). With no measurement either way, the documented resting point is
+the better-justified one, and `3` now matches
+`completion-preview-minimum-symbol-length` so both surfaces start at the same
+keystroke. Still not "tuned" — just no longer below the values upstream warns
+about.
+
+**6.3 A documentation panel (`corfu-popupinfo`).** New knob
+`jotain-completion-doc-popup` (default `t`) enables `corfu-popupinfo-mode`, the
+bundled IDE-style detail panel, delay `(1.0 . 0.5)`. It binds only
+`M-t`/`M-h`/`M-g`/`C-M-v` — no collision with the freed RET/TAB or `M-n`/`M-p`.
+`corfu-echo` is the documented lighter fallback.
+
+**6.4 Inline ghost text (`completion-preview-mode`) — Finding 12(b), adopted.**
+New knob `jotain-completion-inline-preview` (default `t`) enables the built-in
+inline preview in `jotain-completion-auto-modes` — the *same* mode list as the
+auto-popup, so prose stays quiet (R1) and the minibuffer is never touched. It
+draws the top capf candidate as ghost text after point, the modern-editor feel.
+
+Two rule-preserving specifics, both measured in the test file:
+
+- **R2 landmine, fixed.** `completion-preview-active-mode-map` binds `C-i` →
+  `completion-preview-insert`, and `C-i` *is* the TAB event — so the shipped
+  binding is "TAB accepts the preview." `(keymap-unset … "C-i" t)` removes it;
+  TAB still only indents while a preview shows. The whole-candidate accept moves
+  to `M-RET` (R4-safe — R4 governs bare RET), and `M-i` (common-prefix) is left
+  as upstream ships it.
+- **R4 is safe out of the box** — the map binds no RET; the only obligation is
+  not to add one.
+
+The previewed candidate's sort is paired with `corfu-sort-function` (Emacs 31
+user option, guarded), and the preview is inhibited inside comments/strings
+(Emacs 31 hook, guarded), so nothing appears where symbol completion is
+meaningless.
+
+**6.5 What still needs eyes on a GUI.** As §4 already noted for `corfu-complete`,
+two things batch tests cannot settle: whether ghost + popup together reads as
+integrated or busy, and whether the prefix-only ghost (preview keeps its own
+`'(basic)` style) ever disagrees jarringly with an orderless popup row. Both are
+structurally mitigated (`corfu-preview-current nil`, matched sorts) and behind a
+one-line opt-out (`jotain-completion-inline-preview`).
+
+**6.6 Considered, not taken this round:** `corfu-preselect 'prompt` (marginal
+once auto-insert is gone), a buffer-local `orderless-literal-only`/`basic` style
+for the corfu popup (a real predictability lever, but it changes matching
+semantics and is orthogonal to "annoying popup" — deferred as its own decision),
+and cosmetic width-pinning. See research §6.

--- a/docs/reviews/2026-08-completion-ux-research.md
+++ b/docs/reviews/2026-08-completion-ux-research.md
@@ -1,0 +1,253 @@
+# In-buffer completion UX — "less annoying, more natural" research
+
+**Date:** 2026-08-26
+**Scope:** A second round on the in-buffer side of `lisp/init-completion.el`,
+narrowly aimed at the request "make the autocomplete popup and usage less
+annoying and more natural." Builds on
+[`2026-07-completion-research.md`](./2026-07-completion-research.md) and the
+design in [`../design/completion.md`](../design/completion.md); the capf/keymap
+facts settled there are not re-litigated here.
+**Status:** Research + implementation. The changes it motivates shipped in the
+same round in `lisp/init-completion.el` and `test/completion-test.el`.
+
+## How to read this
+
+Each concrete claim is tagged:
+
+- **[V]** — verified against a primary source (package source read on its
+  release branch, GNU manual, or NEWS).
+- **[CFG]** — corroborated by a widely-cited real configuration, not by a
+  normative source.
+- **[FOLK]** — community consensus / folklore; sensible but not documented.
+- **[I]** — a sound inference from a verified source.
+
+Two hard constraints from the existing design bound every option below and are
+treated as non-negotiable: **TAB indents only** (R2) and **RET is a newline,
+never an accept** (R4).
+
+---
+
+## 1. The three levers that were actually available
+
+The 2026-07 round left the trigger model (auto in code, manual in prose),
+the freed RET/TAB, and the capf chain settled. What it did **not** tune, and
+what this round found, are three orthogonal levers:
+
+1. **The popup commits candidates you did not choose** — `corfu-preview-current`.
+2. **The popup fires half a beat too eagerly** — `corfu-auto-delay` / `-prefix`.
+3. **Two "more natural" surfaces were simply absent** — a documentation panel
+   (`corfu-popupinfo`) and inline ghost text (`completion-preview-mode`).
+
+Nothing here needs a new package: `corfu-popupinfo` is a bundled corfu
+extension and `completion-preview` is built into Emacs 30+, so all three are
+`:ensure nil` and add nothing to the package closure.
+
+---
+
+## 2. `corfu-preview-current` — the accidental-accept lever [V]
+
+**Finding, and a corrected premise.** corfu's `corfu-preview-current` defaults
+to the symbol **`insert`**, not `t`. Its docstring: *"If the variable has the
+value `insert', the candidate is automatically inserted on further input."* So
+with the shipped default, while a popup is open, **continued typing commits the
+selected candidate** into the buffer. [V — corfu.el defcustom]
+
+This directly undercuts the spirit of R4 and the freed RET/TAB. The 2026-07
+design took great care that RET, TAB, and continued typing never *accept* a
+candidate — but `corfu-preview-current insert` was quietly doing exactly that on
+continued input. Setting it to **`nil`** shows the menu with no inline text and
+inserts nothing until an explicit `corfu-complete` (`C-M-i`). [V — docstring;
+CFG — this is what Prot's config sets]
+
+This is the single biggest "less annoying / more natural" win, and it is also
+what makes room for lever 3: with `nil`, corfu contributes **no** inline text,
+so `completion-preview-mode`'s ghost is the one and only inline surface — no
+duelling previews.
+
+**Shipped:** `(corfu-preview-current nil)` in the corfu `:custom` block.
+
+## 3. Auto-popup timing — the eagerness lever [V]
+
+**Corrected premises.** corfu's shipped defaults are `corfu-auto-delay` = **0.2**
+and `corfu-auto-prefix` = **3**. [V — corfu.el / GNU ELPA doc] This config was
+running **0.1 / 2** — *below both defaults*, in the direction corfu's own
+docstrings caution against: a very short delay or small prefix "will create high
+load for Emacs, in particular if executing the completion backend is costly,"
+and the README example annotates `corfu-auto-delay 0` / `corfu-auto-prefix 0`
+with "TOO SMALL — NOT RECOMMENDED!". [V — corfu README + docstrings]
+
+The 2026-07 design was explicit that 0.1 / 2 were **not measured** — "every
+number in circulation for this stack is folklore until measured." Given no
+measurement exists either way, moving to corfu's *documented defaults* (0.2 / 3)
+is the better-justified resting point than sitting below them: it is the one
+change most directly aimed at "it pops up while I'm still typing," and it aligns
+the popup with `completion-preview-minimum-symbol-length` (3), so the ghost text
+and the popup begin suggesting at the same keystroke. [V for the defaults; I for
+"better-justified than 0.1/2"]
+
+Real configs cluster at delay 0.1–0.25 and prefix 2–3; anything at or above
+0.2 / 3 is squarely inside the documented-safe range, below it is the debated
+zone. Prot side-steps the question entirely (no auto-popup). [CFG]
+
+**Shipped:** defaults raised to `jotain-completion-auto-delay 0.2`,
+`jotain-completion-auto-prefix 3`, with the docstrings rewritten to cite the
+corfu recommendation instead of "not tuned."
+
+## 4. `corfu-popupinfo` — the documentation panel [V]
+
+**What it is.** A bundled corfu extension (successor to `corfu-doc`) that shows
+a child-frame panel beside the candidate list with the selected candidate's
+docstring or source location — the IDE "detail pane." Enabled with
+`(corfu-popupinfo-mode 1)`; inactive by default like all corfu extensions.
+[V — extensions/corfu-popupinfo.el + corfu README]
+
+**Delay is a cons `(INITIAL . SUBSEQUENT)`,** defaulting to `(2.0 . 0.5)`: a
+long wait before it first appears (so docs do not flash on every pause) and a
+short refresh as you arrow between candidates. The split exists precisely to
+make first appearance unobtrusive while keeping candidate-to-candidate refresh
+instant. A responsive-but-quiet value is `(1.0 . 0.5)` (Prot uses `(1.25 . 0.5)`).
+[V — defcustom; CFG — Prot]
+
+**Keymap safety.** `corfu-popupinfo-map` binds only `M-t` (toggle),
+`M-h`/`M-g` (documentation/location), and the `C-M-v` scroll family. It touches
+**neither** the freed RET/TAB **nor** `M-n`/`M-p`, so it is safe under this
+config's constraints — verified against the full `corfu-map` list. [V]
+
+`corfu-echo` (one-line echo-area doc, `corfu-echo-delay '(2.0 . 1.0)`) is the
+lighter alternative; running both is redundant. This config chose the panel for
+the fuller IDE feel; the echo mode is the documented fallback if the child frame
+ever feels heavy. [V — extensions/corfu-echo.el; FOLK — "pick one"]
+
+**Shipped:** `corfu-popupinfo` block, delay `(1.0 . 0.5)`, gated by
+`jotain-completion-doc-popup` (default t).
+
+## 5. `completion-preview-mode` — inline ghost text (Finding 12b) [V]
+
+This is the deferred feature decision from
+[`2026-07-emacs-nix-deep-review.md` Finding 12](./2026-07-emacs-nix-deep-review.md),
+option (b): adopt the built-in inline preview alongside corfu.
+
+**What it is.** A buffer-local minor mode (Emacs **30.1**; user options extended
+in **31**) that draws the top completion candidate as greyed "ghost text" after
+point, updated as you type, sourced from the **same** `completion-at-point-functions`
+corfu uses — so it previews the eglot/cape/tempel candidates already configured,
+with no separate source list. `global-completion-preview-mode` is the global
+twin. [V — NEWS.30 "New Modes and Packages"; completion-preview.el commentary]
+
+### 5.1 The R2 landmine [V — decisive]
+
+`completion-preview-active-mode-map` (active only while a preview shows) binds,
+verbatim on the `emacs-31` branch:
+
+```elisp
+"C-i" #'completion-preview-insert
+"M-i" #'completion-preview-complete
+```
+
+`C-i`, `TAB`, and `?\t` are the **same event** in Emacs — `"C-i"` and `"TAB"`
+are identical keymap keys. So the shipped binding **is** "TAB accepts the
+preview": on a terminal the Tab key sends `C-i` directly; in a GUI the `<tab>`
+event is translated to `C-i` by `local-function-key-map` when `<tab>` is unbound
+in the active maps, and the minor-mode map then shadows `indent-for-tab-command`.
+The mode's commentary confirms the intended UX is "accept with TAB." Left as-is
+this is a **direct R2 violation** in exactly the buffers it runs in. [V — keymap
+source + Emacs key-translation semantics]
+
+The remedy is a one-liner: `(keymap-unset completion-preview-active-mode-map
+"C-i" t)` (REMOVE = t), after which Tab falls through to indentation while a
+preview shows. The whole-candidate accept then needs a non-TAB home; this config
+binds `completion-preview-insert` to **`M-RET`** (R4 governs bare RET only; `M-RET`
+is a distinct event) and leaves `M-i` (common-prefix complete) as shipped. [V —
+`keymap-unset` semantics; I — M-RET is R4-safe]
+
+**Do not** copy the common community recipe that binds TAB to
+`completion-preview-complete` (e.g. the "À la Mode" corfu+preview config): it
+re-introduces the exact R2 violation. [FOLK, explicitly incompatible with R2]
+
+**R4 is safe out of the box** — the map binds no `RET`/`<return>`, not even
+commented out. The only obligation is: do not add one. [V]
+
+### 5.2 The options that matter [V — all defaults from the emacs-31 source]
+
+| Option | Default | Use here |
+| --- | --- | --- |
+| `completion-preview-idle-delay` | `nil` (immediate) | Set to `jotain-completion-auto-delay` (0.2) so the ghost and the popup share one debounce, and a costly LSP capf is not hit twice per keystroke at different times. |
+| `completion-preview-minimum-symbol-length` | `3` | Left as-is; matches the 3-char popup prefix. (`nil` would fire after punctuation/whitespace too — *more* aggressive, not less.) |
+| `completion-preview-sort-function` | `#'minibuffer--sort-by-length-alpha` (user option in 31) | Paired with `corfu-sort-function` so the ghost matches the popup's top row — NEWS.31 promotes it as a user option *specifically* "together with … Corfu … for a more integrated experience." Guarded on the option's `custom-type` so Emacs 30 is untouched. |
+| `completion-preview-inhibit-functions` | `nil` (new in 31) | Add a comment/string predicate (`(nth 8 (syntax-ppss))`) so the ghost does not appear where symbol completion is meaningless. Guarded on `boundp` (absent on 30). |
+| `completion-preview-completion-styles` | `'(basic)` — a **`defvar`**, not a defcustom | **Left as shipped.** The preview computes candidates with `basic` (prefix) matching, *not* the config's orderless. Consequence: the ghost is prefix-only, which is the conservative, predictable choice for an always-on inline hint; orderless stays where it belongs, in the popup and the minibuffer. [V — it is a defvar defaulting to `(basic)`; I — leaving it prefix-only is the calmer choice] |
+
+### 5.3 Coexistence with corfu, and where to run it [V + FOLK]
+
+corfu has **no** inline ghost text of its own; it previews only inside its popup
+(`corfu-preview-current`). The corfu README does not mention completion-preview —
+they are independent, rendering in different places (popup vs. inline overlay),
+and do not fight over one UI element. They *do* both read the same capf, so with
+both surfaces live you see the popup list **and** one ghost line. [V]
+
+The folklore worry about a "busy double surface" comes almost entirely from
+running completion-preview together with `corfu-preview-current insert` — i.e.
+*two* inline previews. Setting `corfu-preview-current nil` (§2) collapses that to
+exactly one inline surface (the ghost) plus the popup list — which is the
+familiar modern-editor arrangement, not noise. [I from §2 + the coexistence
+facts]
+
+**Placement decision.** Rather than `global-completion-preview-mode` (which would
+put ghost text in prose and the minibuffer — the minibuffer is explicitly *not*
+recommended, and prose is meant to stay quiet per R1), the mode is enabled only
+in `jotain-completion-auto-modes` — the *same* mode list that gets the
+auto-popup. Code gets both surfaces; prose inherits neither and stays manual-only
+via `C-M-i`; the minibuffer is never touched. [FOLK for "run preview where
+auto-popup is on"; V for the minibuffer caveat — minad/vertico discussion #512]
+
+**Shipped:** `completion-preview` block enabled across
+`jotain-completion-auto-modes`, gated by `jotain-completion-inline-preview`
+(default t), with the C-i unbind, the M-RET accept, the idle-delay pairing, the
+sort pairing, and the comment/string inhibit.
+
+### 5.4 Residual — needs eyes on a GUI [I]
+
+Two things batch tests cannot settle, recorded honestly, same as the 2026-07
+design did for `corfu-complete`'s feel:
+
+1. Whether ghost + popup together feels integrated or busy in day-to-day coding.
+   Mitigated structurally (`corfu-preview-current nil`, matched sorts) and by the
+   one-toggle opt-out `jotain-completion-inline-preview`.
+2. Whether prefix-only ghost (from `completion-preview-completion-styles '(basic)`)
+   ever disagrees jarringly with an orderless popup top row. If so, the lever is
+   aligning that defvar with `completion-styles`, at the cost of a fuzzy ghost.
+
+---
+
+## 6. Options considered and *not* taken
+
+- **`corfu-preselect 'prompt`** — would keep typed input selected so an
+  accidental accept inserts your own text. With `corfu-preview-current nil`
+  already removing auto-insert, the marginal safety is small and it complicates
+  accepting the first candidate; left at the default `valid`. [V — defcustom;
+  decision: out of scope]
+- **Buffer-local `orderless-literal-only`/`basic` style for corfu** (the README's
+  "separate styles for minibuffer vs. Corfu" recipe) — a real "more predictable
+  in-buffer matching" lever, but it changes matching semantics the owner has been
+  living with and is orthogonal to "annoying popup." Deferred as a separate
+  decision, not bundled into this round. [V — README recipe]
+- **`corfu-on-exact-match`** — already `nil` (no surprising auto-insert); no
+  change. [V]
+- **Width-pinning (`corfu-min-width`/`-max-width`) and hiding the scrollbar** —
+  cosmetic calm-feel tweaks; not "annoying-usage" fixes. Left alone. [CFG]
+
+---
+
+## 7. Sources
+
+- corfu.el, `extensions/corfu-popupinfo.el`, `extensions/corfu-echo.el`, and
+  README — <https://github.com/minad/corfu>; GNU ELPA doc
+  <https://elpa.gnu.org/packages/doc/corfu.html>.
+- `completion-preview.el` on the `emacs-31` branch —
+  <https://raw.githubusercontent.com/emacs-mirror/emacs/emacs-31/lisp/completion-preview.el>.
+- Emacs NEWS.30 ("New Modes and Packages in Emacs 30.1") and NEWS.31
+  ("Minibuffer and Completions") — emacs-mirror/emacs, branches `emacs-30` / `emacs-31`.
+- minad/vertico discussion #512 (completion-preview in the minibuffer is not
+  recommended).
+- Prot's Emacs configuration (2024-11-28) for `corfu-preview-current nil` and the
+  popupinfo delay — <https://protesilaos.com/codelog/2024-11-28-basic-emacs-configuration/>.

--- a/lisp/init-completion.el
+++ b/lisp/init-completion.el
@@ -41,16 +41,28 @@ Buffers already open when corfu first starts keep their old value."
   :type '(repeat symbol)
   :group 'jotain-completion)
 
-(defcustom jotain-completion-auto-delay 0.1
+(defcustom jotain-completion-auto-delay 0.2
   "Idle seconds before the automatic popup appears.
-Applies only in `jotain-completion-auto-modes' buffers.  This value is
-not tuned -- no measurement backs it."
+Applies only in `jotain-completion-auto-modes' buffers, and also drives
+`completion-preview-idle-delay' when `jotain-completion-inline-preview'
+is on, so the inline ghost text and the popup wait the same beat.
+
+`0.2' is corfu's own shipped default.  corfu's docstrings explicitly
+caution against very short delays -- they \"create high load for Emacs,
+in particular if executing the completion backend is costly\" -- so the
+previous `0.1' sat below the default in the direction upstream warns
+about, which is the setting most likely to feel like the popup fires
+while you are still typing."
   :type 'number
   :group 'jotain-completion)
 
-(defcustom jotain-completion-auto-prefix 2
+(defcustom jotain-completion-auto-prefix 3
   "Characters typed before the automatic popup appears.
-Applies only in `jotain-completion-auto-modes' buffers."
+Applies only in `jotain-completion-auto-modes' buffers.  `3' is corfu's
+shipped default; it also matches `completion-preview-minimum-symbol-length'
+so the inline preview and the popup start suggesting at the same point.
+Lower values pop up on one- or two-character fragments, which is the
+main source of \"it keeps interrupting me\" noise."
   :type 'integer
   :group 'jotain-completion)
 
@@ -113,6 +125,41 @@ run when the server offers nothing for the text at point.
 
 Both halves of that are measured in `test/completion-test.el'.  nil
 leaves the capf exactly as eglot installs it."
+  :type 'boolean
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-doc-popup t
+  "When non-nil, show a documentation panel beside the corfu popup.
+Enables `corfu-popupinfo-mode' -- a child-frame panel next to the
+candidate list that renders the selected candidate's docstring or source
+location, the way an IDE shows a detail pane.  The delay is a cons
+\(INITIAL . SUBSEQUENT): a longer wait before it first appears so it does
+not flash on every brief pause, and a short refresh as you move between
+candidates so it keeps up.  It binds only `M-t' / `M-h' / `M-g' /
+`C-M-v', so it never collides with the freed RET and TAB or with
+`M-n' / `M-p'.
+
+Read at load time; nil skips `corfu-popupinfo-mode' entirely."
+  :type 'boolean
+  :group 'jotain-completion)
+
+(defcustom jotain-completion-inline-preview t
+  "When non-nil, show inline \"ghost text\" of the top candidate as you type.
+Enables the built-in `completion-preview-mode' in
+`jotain-completion-auto-modes' buffers -- the same modes that get the
+auto-popup -- so prose stays quiet (it inherits nothing) while code gains
+a greyed-out preview of the most likely completion after point, the way a
+modern editor does.  The popup still lists the alternatives; this is the
+single inline hint beside it.
+
+TAB is kept safe: `completion-preview-active-mode-map' binds `C-i' (which
+IS the TAB event) to accept the preview, so this config unbinds it -- TAB
+still only indents while a preview shows.  RET is untouched by the mode
+and stays a newline.  Accept the whole preview with `M-RET'; `M-i'
+completes just the common prefix.
+
+Read at load time; nil adds no preview mode.  `completion-preview-mode'
+also toggles it per-buffer on demand."
   :type 'boolean
   :group 'jotain-completion)
 
@@ -445,6 +492,14 @@ Setting `corfu-auto' from `corfu-mode-hook' would be too late, since
   (corfu-auto nil)
   (corfu-auto-prefix jotain-completion-auto-prefix)
   (corfu-auto-delay jotain-completion-auto-delay)
+  ;; corfu's default is `insert', which previews the selected candidate
+  ;; inline AND commits it on further input -- so typing past an open popup
+  ;; can silently accept a candidate you never chose.  `nil' shows the
+  ;; menu with no inline text and inserts nothing until an explicit
+  ;; `corfu-complete' (`C-M-i'), which is the "never accept unless I ask"
+  ;; behaviour the freed RET/TAB already aim for -- and it leaves the one
+  ;; inline surface to `completion-preview-mode's ghost text.
+  (corfu-preview-current nil)
   :config
   ;; REMOVE = t genuinely deletes the entry rather than binding it to nil,
   ;; so the key falls through to the buffer and global maps.
@@ -461,6 +516,23 @@ Setting `corfu-auto' from `corfu-mode-hook' would be too late, since
   :ensure nil
   :after corfu
   :config (corfu-history-mode 1))
+
+;;; @doc Documentation panel beside the popup — a child frame that shows
+;;; the selected candidate's docstring or source location, the way an IDE
+;;; shows a detail pane. Off unless `jotain-completion-doc-popup' is
+;;; non-nil. The delay is a cons (INITIAL . SUBSEQUENT): it waits a beat
+;;; before first appearing so it does not flash on every pause, then
+;;; refreshes quickly as you move between candidates. Bundled with corfu;
+;;; binds only `M-t'/`M-h'/`M-g'/`C-M-v', so it never touches the freed
+;;; RET/TAB or the `M-n'/`M-p' navigation keys.
+(use-package corfu-popupinfo
+  :ensure nil
+  :when jotain-completion-doc-popup
+  :after corfu
+  :functions (corfu-popupinfo-mode)
+  :custom
+  (corfu-popupinfo-delay '(1.0 . 0.5))
+  :config (corfu-popupinfo-mode 1))
 
 ;;; @doc Completion-at-point Extensions — extra capf functions (dabbrev,
 ;;; file path, keyword) that feed corfu when the major mode's own
@@ -492,6 +564,66 @@ comments and docstrings."
     (add-hook 'completion-at-point-functions #'cape-elisp-symbol 90 t))
   (add-hook 'emacs-lisp-mode-hook #'jotain-cape-setup-elisp)
   (add-hook 'lisp-interaction-mode-hook #'jotain-cape-setup-elisp))
+
+;;; @doc Inline completion preview — the built-in `completion-preview-mode'
+;;; (Emacs 30, extended in 31). It greys out the most likely completion
+;;; after point as you type, the way a modern editor does, drawing its
+;;; candidate from the same `completion-at-point-functions' the corfu
+;;; popup uses. Enabled only in `jotain-completion-auto-modes' buffers (so
+;;; prose stays quiet), and only when `jotain-completion-inline-preview'
+;;; is non-nil. Two things keep it inside this config's rules: it binds
+;;; `C-i' — which is the TAB event — to accept the preview, so that entry
+;;; is removed and TAB still only indents; and it never binds RET, so
+;;; Enter stays a newline. Accept the whole preview with `M-RET', or just
+;;; the common prefix with `M-i'. The preview is suppressed inside
+;;; comments and strings, and its sort is paired with corfu's so the ghost
+;;; text matches the popup's top row.
+(use-package completion-preview
+  :ensure nil
+  :when jotain-completion-inline-preview
+  :defer t
+  :functions (completion-preview-insert)
+  :preface
+  ;; Defined in completion-preview.el / corfu.el, neither loaded at
+  ;; byte-compile time; declare them so the `:config' edits below compile
+  ;; clean under `byte-compile-error-on-warn'.
+  (defvar completion-preview-active-mode-map)
+  (defvar completion-preview-idle-delay)
+  (defvar completion-preview-inhibit-functions)
+  (defvar corfu-sort-function)
+  (defun jotain-completion--preview-inhibit-in-comment ()
+    "Return non-nil inside a comment or string.
+Added to `completion-preview-inhibit-functions' (Emacs 31) so the ghost
+text does not appear where symbol completion is meaningless."
+    (nth 8 (syntax-ppss)))
+  :init
+  (dolist (hook jotain-completion-auto-modes)
+    (add-hook hook #'completion-preview-mode))
+  :config
+  ;; Match the popup's debounce so the inline preview and corfu wait the
+  ;; same beat, and one keystroke does not fire two capf passes at
+  ;; different times (relevant for a costly LSP capf).  Set in `:config'
+  ;; (after load) rather than `:custom' so touching this deferred built-in
+  ;; never forces it to load at startup.
+  (setopt completion-preview-idle-delay jotain-completion-auto-delay)
+  ;; R2: `C-i' is the TAB event, and the active-mode map binds it to
+  ;; `completion-preview-insert'.  REMOVE = t drops it so TAB falls
+  ;; through to `indent-for-tab-command' while a preview shows.
+  (keymap-unset completion-preview-active-mode-map "C-i" t)
+  ;; A non-TAB, non-RET accept gesture for the whole candidate; `M-i'
+  ;; (common-prefix complete) is left as upstream ships it.
+  (keymap-set completion-preview-active-mode-map "M-RET"
+              #'completion-preview-insert)
+  ;; Pair the previewed candidate with corfu's top row.  In Emacs 31
+  ;; `completion-preview-sort-function' is a user option added for exactly
+  ;; this; guard on its custom type so Emacs 30 is left untouched.
+  (when (and (get 'completion-preview-sort-function 'custom-type)
+             (boundp 'corfu-sort-function))
+    (setopt completion-preview-sort-function corfu-sort-function))
+  ;; Suppress in comments/strings (Emacs 31 hook; absent on 30).
+  (when (boundp 'completion-preview-inhibit-functions)
+    (add-hook 'completion-preview-inhibit-functions
+              #'jotain-completion--preview-inhibit-in-comment)))
 
 (provide 'init-completion)
 ;;; init-completion.el ends here

--- a/test/completion-test.el
+++ b/test/completion-test.el
@@ -193,19 +193,31 @@ This is why `init-snippets.el' wraps its eglot merge."
 (require 'tempel)
 (require 'init-completion)
 (require 'init-snippets)
+;; Loaded after `init-completion' so the `with-eval-after-load' body its
+;; `completion-preview' block registers (the R2 keymap edits) fires on this
+;; require, letting the assertions below observe the real map state.
+(require 'completion-preview)
 
 (ert-deftest completion-test-defcustom-defaults ()
   "The opt-out knobs carry their documented defaults."
   (should (equal jotain-completion-auto-modes '(prog-mode-hook)))
-  (should (equal jotain-completion-auto-delay 0.1))
-  (should (equal jotain-completion-auto-prefix 2))
+  (should (equal jotain-completion-auto-delay 0.2))
+  (should (equal jotain-completion-auto-prefix 3))
   (should (equal jotain-completion-key "C-M-i"))
   (should (eq jotain-completion-free-return t))
   (should (eq jotain-completion-free-tab t))
   (should (eq jotain-completion-fallbacks t))
   (should (eq jotain-completion-snippets t))
   (should (eq jotain-completion-eglot-nonexclusive t))
+  (should (eq jotain-completion-doc-popup t))
+  (should (eq jotain-completion-inline-preview t))
   (should (key-valid-p jotain-completion-key)))
+
+(ert-deftest completion-test-corfu-preview-current-off ()
+  "The popup inserts nothing until asked: `corfu-preview-current' is nil.
+corfu's own default is `insert', which commits the selected candidate on
+further input -- exactly the accidental-accept this config avoids."
+  (should (eq corfu-preview-current nil)))
 
 (ert-deftest completion-test-tab-indents-only ()
   "TAB is on the stock default, so `indent-for-tab-command' cannot complete."
@@ -230,6 +242,28 @@ This is why `init-snippets.el' wraps its eglot merge."
   (should-not (lookup-key corfu-map [tab]))
   (should (eq (lookup-key corfu-map (kbd "M-n")) #'corfu-next))
   (should (eq (lookup-key corfu-map (kbd "M-p")) #'corfu-previous)))
+
+(ert-deftest completion-test-inline-preview-tab-is-freed ()
+  "The inline preview never lets TAB (or RET) accept a candidate.
+`completion-preview-active-mode-map' ships `C-i' -> `completion-preview-insert',
+and `C-i' IS the TAB event, so leaving it bound would let TAB accept the
+preview -- violating the TAB-indents-only rule.  This config removes it and
+puts the whole-candidate accept on `M-RET' instead; RET is never bound by
+the mode, so Enter stays a newline."
+  (should-not (lookup-key completion-preview-active-mode-map (kbd "C-i")))
+  (should-not (lookup-key completion-preview-active-mode-map (kbd "TAB")))
+  (should-not (lookup-key completion-preview-active-mode-map [tab]))
+  (should-not (lookup-key completion-preview-active-mode-map (kbd "RET")))
+  (should-not (lookup-key completion-preview-active-mode-map [return]))
+  (should (eq (lookup-key completion-preview-active-mode-map (kbd "M-RET"))
+              #'completion-preview-insert)))
+
+(ert-deftest completion-test-inline-preview-is-per-mode-like-auto ()
+  "Inline preview rides the same mode list as the auto-popup, so prose stays quiet.
+`completion-preview-mode' is enabled in `jotain-completion-auto-modes'
+buffers (prog-mode) and nowhere prose lives (text-mode)."
+  (should (memq #'completion-preview-mode prog-mode-hook))
+  (should-not (memq #'completion-preview-mode text-mode-hook)))
 
 (ert-deftest completion-test-one-key-opens-and-accepts ()
   "`C-M-i' resolves to `completion-at-point', which `corfu-map' remaps.


### PR DESCRIPTION
## What & why

The autocomplete popup was tuned more eagerly than corfu's own defaults and was missing the two surfaces that make modern completion feel "natural." This round makes the popup less intrusive and adds an IDE-style doc panel plus inline ghost text — every change opt-out-gated, all within the config's existing rules (TAB indents only, RET is a newline, prose stays quiet).

Deep-researched against upstream sources first (corfu source/README, `completion-preview.el` on `emacs-31`, NEWS.30/31); the evidence base is written up in `docs/reviews/2026-08-completion-ux-research.md`, and the design in `docs/design/completion.md` §6.

## Changes (`lisp/init-completion.el`)

- **`corfu-preview-current` → `nil`.** corfu's `insert` default previews the selected candidate *and commits it on continued typing* — so typing past an open popup could silently accept a candidate. `nil` inserts nothing until an explicit `C-M-i`, matching the freed RET/TAB intent.
- **Auto-popup onto corfu's documented defaults:** `auto-delay` 0.1 → 0.2, `auto-prefix` 2 → 3. The old values sat *below* the defaults, in the range corfu's docstrings caution against; 3 also matches `completion-preview-minimum-symbol-length`.
- **`corfu-popupinfo`** (new knob `jotain-completion-doc-popup`, default t): the bundled IDE-style documentation panel beside the candidate list, delay `(1.0 . 0.5)`. Binds only `M-t`/`M-h`/`M-g`/`C-M-v` — no collision with freed RET/TAB or `M-n`/`M-p`.
- **`completion-preview-mode`** (new knob `jotain-completion-inline-preview`, default t) — the built-in inline ghost text, adopting deferred review **Finding 12(b)**. Enabled only in `jotain-completion-auto-modes` (prose stays quiet; minibuffer untouched).
  - **R2 landmine fixed:** the active-mode map binds `C-i` → accept, and `C-i` *is* the TAB event — so the shipped binding is "TAB accepts the preview." That entry is unbound; whole-candidate accept moves to `M-RET`, `M-i` keeps common-prefix complete, RET is never bound.
  - Previewed sort paired with `corfu-sort-function`, preview inhibited in comments/strings — both Emacs-31 features, guarded so Emacs 30 is untouched.

## Tests (`test/completion-test.el`)

Added coverage for the new defaults, `corfu-preview-current nil`, the freed preview keymap (C-i/TAB/RET absent, M-RET → `completion-preview-insert`), and that the preview rides the same per-mode list as the auto-popup.

## Validation

- All edited files pass `check-parens`; the module loads and the **R2 keymap contract is verified against the real built-in `completion-preview.el`** (Emacs 30.2), with the 31-only guards confirmed to degrade cleanly.
- No byte-compile warnings on any new form; `docs/configuration/package-reference.mdx` regenerated and in sync.
- The full `elisp-compile`/`elisp-test`/`elisp-lint` closure could not be realized in this session (the environment's egress policy 403s the MELPA package source fetches), so **CI is the authoritative gate** for the warnings-as-errors byte-compile and the full ERT run.

## Notes for the reviewer

- Two things need eyes on a GUI (documented in design §6.5): whether ghost text + popup together reads as integrated or busy, and whether the prefix-only ghost ever disagrees jarringly with an orderless popup row. Both are structurally mitigated (`corfu-preview-current nil`, matched sorts) and behind a one-line opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8g7oEsHxh3mtxytWDERp7)_