### PR TITLE
Tune scrolling behaviour per jamescherti recommendations

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -156,10 +156,18 @@ without editing this file.
 
 ### `pixel-scroll` *(built-in / Nix)*
 
-Built-in pixel-precision smooth scrolling. Required for usable
-trackpad / smooth-mouse scrolling. `fast-but-imprecise-scrolling'
+Built-in pixel-precision smooth scrolling, plus the scrolling
+behaviour tuning from James Cherti's "Enhancing Emacs Scrolling"
+(jamescherti.com). `pixel-scroll-precision-mode' is required for
+usable trackpad / smooth-mouse scrolling; `fast-but-imprecise-scrolling'
 lets large jumps skip exact intermediate fontification — a worthwhile
-redisplay win on this integrated-GPU Intel machine.
+redisplay win on this integrated-GPU Intel machine. `scroll-conservatively'
+20 scrolls just enough to keep point visible instead of eagerly
+recentering (0, the default, is too eager); `auto-window-vscroll' nil
+avoids random half-screen jumps on long lines; `scroll-error-top-bottom'
+moves point to the buffer edge before signalling; and the `hscroll-*'
+pair steps horizontal scrolling one column at a time.
+(`scroll-preserve-screen-position' is set in init-core.el.)
 
 ### `hl-line` *(built-in / Nix)*
 

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -260,13 +260,27 @@ availability on the right display."
   :ensure nil
   :hook ((prog-mode conf-mode) . jotain-ui--maybe-line-numbers))
 
-;;; @doc Built-in pixel-precision smooth scrolling. Required for usable
-;;; trackpad / smooth-mouse scrolling. `fast-but-imprecise-scrolling'
+;;; @doc Built-in pixel-precision smooth scrolling, plus the scrolling
+;;; behaviour tuning from James Cherti's "Enhancing Emacs Scrolling"
+;;; (jamescherti.com). `pixel-scroll-precision-mode' is required for
+;;; usable trackpad / smooth-mouse scrolling; `fast-but-imprecise-scrolling'
 ;;; lets large jumps skip exact intermediate fontification — a worthwhile
-;;; redisplay win on this integrated-GPU Intel machine.
+;;; redisplay win on this integrated-GPU Intel machine. `scroll-conservatively'
+;;; 20 scrolls just enough to keep point visible instead of eagerly
+;;; recentering (0, the default, is too eager); `auto-window-vscroll' nil
+;;; avoids random half-screen jumps on long lines; `scroll-error-top-bottom'
+;;; moves point to the buffer edge before signalling; and the `hscroll-*'
+;;; pair steps horizontal scrolling one column at a time.
+;;; (`scroll-preserve-screen-position' is set in init-core.el.)
 (use-package pixel-scroll
   :ensure nil
-  :custom (fast-but-imprecise-scrolling t)
+  :custom
+  (fast-but-imprecise-scrolling t)
+  (scroll-conservatively 20)
+  (scroll-error-top-bottom t)
+  (auto-window-vscroll nil)
+  (hscroll-margin 2)
+  (hscroll-step 1)
   :config (pixel-scroll-precision-mode 1))
 
 ;;; @doc Built-in current-line highlight — on for code and prose, off


### PR DESCRIPTION
## What

Adopts the scrolling configuration from James Cherti's [*Enhancing Emacs Scrolling: Better Performance and Usability*](https://www.jamescherti.com/emacs-scrolling-better-performance-usability/), extending the existing `pixel-scroll` block in `lisp/init-ui.el`.

New settings:

- `scroll-conservatively 20` — scroll just enough to keep point visible instead of eagerly recentering (the default `0` recenters far too often).
- `auto-window-vscroll nil` — prevents automatic `window-vscroll` adjustments on long lines, resolving random half-screen jumps while scrolling.
- `scroll-error-top-bottom t` — move point to the top/bottom of the buffer before signalling a scrolling error.
- `hscroll-margin 2` / `hscroll-step 1` — step horizontal scrolling one column at a time.

## Notes

- `fast-but-imprecise-scrolling` and `pixel-scroll-precision-mode` were already enabled in this block and are unchanged.
- `scroll-preserve-screen-position` (which the article sets to `t`) already lives in `init-core.el` at the repo's stronger value `1`; left as-is and cross-referenced in the doc comment.
- Followed the repo's `setopt`/`:custom` convention (no `setq`), and kept these in the established "scrolling block" rather than the article's flat `setq` list.
- Regenerated the `@doc` text in `docs/configuration/package-reference.mdx` to keep the `packages-doc-in-sync` check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1Tqd7ge7RPfYYJWTrp6KK

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1Tqd7ge7RPfYYJWTrp6KK)_