### PR TITLE
Enhance dired defaults per Cherti file-management article

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -539,7 +539,10 @@ The custom block below tames cross-platform ls quirks (BSD on
 macOS lacks `--group-directories-first` and `--dired`). `M-s R`
 previews a regex replacement across the contents of all marked
 files as a unified diff (Emacs 30's
-`dired-do-replace-regexp-as-diff').
+`dired-do-replace-regexp-as-diff'). `!'/`&' hand the file under
+point to the OS default application (`open'/`xdg-open'/`start')
+via `dired-guess-shell-alist-user'; files can also be dragged out
+to desktop apps with the mouse.
 
 ### `dired-x` *(built-in / Nix)*
 

--- a/lisp/init-navigation.el
+++ b/lisp/init-navigation.el
@@ -13,7 +13,10 @@
 ;;; macOS lacks `--group-directories-first` and `--dired`). `M-s R`
 ;;; previews a regex replacement across the contents of all marked
 ;;; files as a unified diff (Emacs 30's
-;;; `dired-do-replace-regexp-as-diff').
+;;; `dired-do-replace-regexp-as-diff'). `!'/`&' hand the file under
+;;; point to the OS default application (`open'/`xdg-open'/`start')
+;;; via `dired-guess-shell-alist-user'; files can also be dragged out
+;;; to desktop apps with the mouse.
 (use-package dired
   :ensure nil
   :custom
@@ -25,19 +28,29 @@
                                 "ls"))
   (dired-use-ls-dired (or (not (eq system-type 'darwin))
                           (and (executable-find "gls") t)))
+  ;; `v' sorts numbers naturally (foo2 before foo10) instead of lexically.
   (dired-listing-switches (if (and (eq system-type 'darwin)
                                    (not (executable-find "gls")))
-                              "-alh"
-                            "-alh --group-directories-first"))
+                              "-alhv"
+                            "-alhv --group-directories-first"))
   (dired-dwim-target t)
   (dired-kill-when-opening-new-dired-buffer t)
   (dired-recursive-copies 'always)
   (dired-recursive-deletes 'top)
+  (dired-deletion-confirmer #'y-or-n-p)
   (dired-auto-revert-buffer #'dired-buffer-stale-p)
+  ;; Auto-refresh a destination buffer after copy/rename, but never a
+  ;; remote one — a TRAMP round-trip per file op would stall the UI.
+  (dired-do-revert-buffer (lambda (dir) (not (file-remote-p dir))))
   (dired-clean-confirm-killing-deleted-buffers nil)
   (dired-create-destination-dirs 'ask)
   (dired-free-space nil)
   (dired-vc-rename-file t)
+  ;; Stop point at the first/last file line instead of drifting onto
+  ;; the header or trailing blank lines.
+  (dired-movement-style 'bounded-files)
+  ;; Drag files out of dired into external desktop applications.
+  (dired-mouse-drag-files t)
   :hook (dired-mode . dired-hide-details-mode)
   :bind (:map dired-mode-map
               ("M-s R" . dired-do-replace-regexp-as-diff))
@@ -45,7 +58,24 @@
   ;; Emacs 31+: also hide the absolute directory path in the header line
   ;; under `dired-hide-details-mode'. Guarded for Emacs 30.
   (when (boundp 'dired-hide-details-hide-absolute-location)
-    (setopt dired-hide-details-hide-absolute-location t)))
+    (setopt dired-hide-details-hide-absolute-location t))
+  ;; `!'/`&' guess the OS default handler for common document, image,
+  ;; and media types, so RET opens them in the desktop application.
+  (when-let* ((opener (cond
+                       ((eq system-type 'darwin) "open")
+                       ((memq system-type '(gnu gnu/linux gnu/kfreebsd
+                                                berkeley-unix))
+                        "xdg-open")
+                       ((memq system-type '(cygwin windows-nt ms-dos))
+                        "start"))))
+    (setopt dired-guess-shell-alist-user
+            `(("\\.\\(?:docx\\|pdf\\|odt\\|odg\\|ods\\|djvu\\|eps\\)\\'" ,opener)
+              ("\\.\\(?:jpe?g\\|webp\\|png\\|gif\\|xpm\\)\\'" ,opener)
+              ("\\.xcf\\'" ,opener)
+              ("\\.tex\\'" ,opener)
+              ("\\.\\(?:mp4\\|mkv\\|m4a\\|avi\\|flv\\|rm\\|rmvb\\|ogv\\)\\(?:\\.part\\)?\\'"
+               ,opener)
+              ("\\.\\(?:mp3\\|flac\\)\\'" ,opener)))))
 
 ;;; @doc Built-in dired extras — `dired-omit-mode` hides dotfiles and
 ;;; cache directories so dired listings show only the things you
@@ -60,9 +90,12 @@
    (concat "\\`[.]?#\\|\\`[.][.]?\\'"
            "\\|^[a-zA-Z0-9]\\.syncthing-enc\\'"
            "\\|^\\.git\\'"
+           "\\|^\\.DS_Store\\'"
            "\\|^\\.stfolder\\'"
            "\\|^\\.stversions\\'"
-           "\\|^__pycache__\\'")))
+           "\\|^__pycache__\\'"
+           "\\|^flycheck_.*"
+           "\\|^flymake_.*")))
 
 ;;; @doc Async file ops for dired — wraps `dired-do-copy`, `dired-do-rename`,
 ;;; `dired-do-symlink`, `dired-do-hardlink` so they fork into a subprocess


### PR DESCRIPTION
Adopts the applicable recommendations from James Cherti's ["Fixing Emacs Dired Defaults: Settings for Better File Management"](https://www.jamescherti.com/emacs-dired-configuration/) that weren't already present in `lisp/init-navigation.el`.

## What changed

New/updated settings in the `dired` `use-package` block:

- **`dired-deletion-confirmer #'y-or-n-p`** — single-key delete confirmation instead of typing `yes`. Safe here because `delete-by-moving-to-trash` is enabled, so deletions are recoverable via `M-x trashed`.
- **`dired-movement-style 'bounded-files`** — point stops on the first/last file line instead of drifting onto the header or trailing blank lines.
- **`dired-mouse-drag-files t`** — drag files out of dired into external desktop applications.
- **`dired-do-revert-buffer`** — auto-refresh a destination buffer after copy/rename, but skip remote directories (`(lambda (dir) (not (file-remote-p dir)))`) to avoid a TRAMP round-trip per file op.
- **`dired-guess-shell-alist-user`** — map common document/image/media extensions to the OS default opener (`open` / `xdg-open` / `start`) so `!`/`&` prefill the right handler.
- **Natural version sort** — added `v` to `dired-listing-switches` (both the GNU and BSD-fallback branches) so `foo2` sorts before `foo10`.
- **`dired-x` omit list** — added `.DS_Store` and `flycheck_*`/`flymake_*` temp files.

## Deliberately not changed

Settings the article recommends that Jotain already had were left untouched: dirs-first listing, `dired-hide-details-mode`, `dired-omit-mode`/`dired-omit-verbose`, recursive copies/deletes, `dired-kill-when-opening-new-dired-buffer`, `dired-vc-rename-file`, `dired-free-space nil`, `dired-create-destination-dirs 'ask`, `dired-clean-confirm-killing-deleted-buffers nil`. The existing `dired-auto-revert-buffer #'dired-buffer-stale-p` was kept rather than switching to the article's `dired-directory-changed-p` — the difference is marginal and the current value is a deliberate non-default.

## Docs

Regenerated the `dired` entry in `docs/configuration/package-reference.mdx` by hand to match the updated `;;; @doc` block (keeps the `packages-doc-in-sync` check green).

## Validation note

The Elisp checks (`elisp-compile`, `packages-doc-in-sync`) could not be run in this environment: the binary caches are unreachable from the session and `emacs-overlay` is a cache miss, so those checks would build Emacs from source. The changes are limited to well-known built-in dired `defcustom`s (all present in the repo's Emacs 30/31 floor) and a hand-synced doc entry; CI will exercise the full checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuoMnM16p6kPUfsWsydF5p)_