### PR TITLE
chore(design): re-pin to merged main commit ec1bf783

### DIFF
--- a/nix/design-pin.nix
+++ b/nix/design-pin.nix
@@ -25,7 +25,7 @@
 {
   owner = "Jylhis";
   repo = "design";
-  rev = "464012a3d84e113492962f7cfc7cc02d768a8e1b";
+  rev = "ec1bf783b229810e04d53830a810a6da95a3ec44";
   sha256 = "1ann8fzvfxfy2xl748czx4m087qhikzzch3r68dz23cra1bc36cl";
   version = "2.0.0-unstable-2026-09-01";
 }


### PR DESCRIPTION
Follow-up to #226 (merged).

That PR pinned the design system to `464012a`, which was the head of the `Jylhis/design` sync PR ([design#42](https://github.com/Jylhis/design/pull/42)). design#42 was **squash-merged** and its PR branch **deleted**, so `464012a` is now a dangling commit that GitHub will eventually stop serving — a reproducibility hazard for `jylhis-emacs-themes` and `ds-assets`.

This re-pins `nix/design-pin.nix` to `ec1bf783b229810e04d53830a810a6da95a3ec44`, the canonical squash-merge commit on `Jylhis/design` main.

## Why it's a no-op build-wise

The squash of a single-commit PR has the **identical tree** to `464012a`, verified:
- `nix flake prefetch` → `sha256-lJnBVlCZDfEbMnlA9v+MEB8EKumfIXJoF951t79D1qo=` (same)
- `nix-prefetch-url --unpack` → `1ann8fzvfxfy2xl748czx4m087qhikzzch3r68dz23cra1bc36cl` (same)

So the `sha256` is unchanged and `website/public/ds` needs no re-vendor — `ds-in-sync` stays green. Only the `rev` moves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JngdY98LTVSrr9A6jJg59o)_