### PR TITLE
Harden network security: GnuTLS verification and NSM

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -111,6 +111,21 @@ colours and proportional fonts so rendered HTML inherits the
 theme and the user's monospace face — better contrast,
 predictable layout.
 
+### `gnutls` *(built-in / Nix)*
+
+Built-in GnuTLS. Harden TLS connections: verify server
+certificates and raise an error instead of silently continuing
+when verification fails (`gnutls-verify-error`), and require a
+strong Diffie-Hellman prime so weak key exchanges are rejected
+(`gnutls-min-prime-bits`).
+
+### `nsm` *(built-in / Nix)*
+
+Built-in Network Security Manager. `network-security-level`
+'high applies the strictest connection checks (certificate
+changes, weak ciphers, downgrades); the settings file is themed
+under var/ to keep the repo root clean.
+
 ## `init-keys.el` — Global keys
 
 ### `emacs` *(built-in / Nix)*

--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -391,5 +391,26 @@ freezes — start, reproduce, stop."
   (shr-use-colors nil)
   (shr-use-fonts nil))
 
+;;; @doc Built-in GnuTLS. Harden TLS connections: verify server
+;;; certificates and raise an error instead of silently continuing
+;;; when verification fails (`gnutls-verify-error`), and require a
+;;; strong Diffie-Hellman prime so weak key exchanges are rejected
+;;; (`gnutls-min-prime-bits`).
+(use-package gnutls
+  :ensure nil
+  :custom
+  (gnutls-verify-error t)
+  (gnutls-min-prime-bits 3072))
+
+;;; @doc Built-in Network Security Manager. `network-security-level`
+;;; 'high applies the strictest connection checks (certificate
+;;; changes, weak ciphers, downgrades); the settings file is themed
+;;; under var/ to keep the repo root clean.
+(use-package nsm
+  :ensure nil
+  :custom
+  (network-security-level 'high)
+  (nsm-settings-file (jotain-var-file "network-security.data")))
+
 (provide 'init-core)
 ;;; init-core.el ends here


### PR DESCRIPTION
## What

Add TLS / network-security hardening defaults to `init-core.el`, following the recommendations in James Cherti's [*Emacs security settings*](https://www.jamescherti.com/emacs-security-settings/) article:

| Setting | Value | Effect |
|---|---|---|
| `gnutls-verify-error` | `t` | Verify server certificates and signal an error instead of silently continuing when verification fails. |
| `gnutls-min-prime-bits` | `3072` | Reject weak Diffie-Hellman key exchanges. |
| `network-security-level` | `'high` | Apply the Network Security Manager's strictest connection checks (certificate changes, weak ciphers, downgrades). |

Both built-ins get `:ensure nil` and set their options via `:custom`, matching the module's conventions. `nsm-settings-file` is themed under `var/` (gitignored) like the rest of Jotain's persistent state, keeping the repo root clean.

The generated package reference (`docs/configuration/package-reference.mdx`) is updated by hand to match the two new `;;; @doc` markers so the `packages-doc-in-sync` check stays green.

## Notes / please double-check

- I could **not fetch the source article** — `jamescherti.com` (and the Wayback Machine) are blocked by this session's egress policy, so the settings above are reconstructed from knowledge of that article and standard Emacs hardening practice. Please confirm the exact values match the article, in particular:
  - **`gnutls-min-prime-bits 3072`** — this is deliberately strict and will *reject* TLS servers that negotiate a smaller DH prime. If a package archive or other endpoint fails to connect, lowering this (e.g. to `2048`, or `nil` to let GnuTLS decide) is the knob to turn.
  - `network-security-level 'high` is aggressive and can prompt on certificate changes — swap to `'medium` if it's noisier than you want.
- I couldn't run the flake checks locally: the `emacs-overlay` flake input isn't in the binary caches and GitHub tarball fetch is blocked in this sandbox, so config-building checks can't evaluate here. CI will validate (note: App pushes need a manual `workflow_dispatch` per CLAUDE.md).

## Testing

- [ ] `elisp-compile` (byte-compile, warnings-as-errors)
- [ ] `packages-doc-in-sync`
- [ ] `elisp-lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGsuKWTrzFr6BtKN5C2S8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGsuKWTrzFr6BtKN5C2S8M)_