### PR TITLE
Add project-nix-store project.el backend for the Nix store

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -872,6 +872,16 @@ on a VCS root. Project list lives under var/. `C-x p P' scans
 `jotain-repositories-roots' to add+open projects not yet in
 the known list.
 
+### `project-nix-store` *(built-in / Nix)*
+
+`project.el' backend for the Nix (and Guix) store: each
+`/nix/store' path that is a directory becomes a project root, so
+`project-find-file' jumps between files under the same store path
+while reading a dependency's source. `project-nix-store-try' is
+registered ahead of the built-in `project-try-vc' (upstream's
+performance advice), and store paths are kept out of the saved
+project list.
+
 ### `projection`
 
 `.dir-locals.el`-driven per-project commands (configure, build,

--- a/lisp/init-project.el
+++ b/lisp/init-project.el
@@ -71,6 +71,27 @@ projects sharing a basename across different roots stay distinct."
    '(".project" "package.json" "Cargo.toml" "pyproject.toml" "flake.nix"
      "devenv.nix")))
 
+;;; @doc `project.el' backend for the Nix (and Guix) store: each
+;;; `/nix/store' path that is a directory becomes a project root, so
+;;; `project-find-file' jumps between files under the same store path
+;;; while reading a dependency's source. `project-nix-store-try' is
+;;; registered ahead of the built-in `project-try-vc' (upstream's
+;;; performance advice), and store paths are kept out of the saved
+;;; project list.
+(use-package project-nix-store
+  :ensure nil ; Provided by Nix
+  :after project
+  :init
+  ;; `add-hook' without APPEND prepends, so this runs before the default
+  ;; `project-try-vc' member of `project-find-functions' — the ordering
+  ;; upstream recommends for good performance.
+  (add-hook 'project-find-functions #'project-nix-store-try)
+  :config
+  ;; Keep store paths out of the remembered project list. The option is
+  ;; newer than this config's Emacs 30.1 floor, so guard the reference.
+  (when (boundp 'project-list-exclude)
+    (add-to-list 'project-list-exclude #'project-nix-store-p)))
+
 ;;;; projection — per-project commands keyed off .dir-locals.el
 
 ;;; @doc `.dir-locals.el`-driven per-project commands (configure, build,

--- a/nix/extra-packages.nix
+++ b/nix/extra-packages.nix
@@ -75,6 +75,26 @@ efinal: eprev: {
     };
   };
 
+  # `project.el' backend for the Nix (and Guix) store, wired in
+  # lisp/init-project.el: each /nix/store path that is a directory becomes a
+  # project root, so `project-find-file' works while visiting store files.
+  # Published on NonGNU ELPA as `project-nix-store', but the pinned
+  # emacs-overlay snapshot (2026-08-24) predates the upstream
+  # `project-store' -> `project-nix-store' rename (0.10.0), so the base epkgs
+  # scope does not carry this name yet; build it from the tagged release.
+  # Package-Requires is ((emacs "29.1")) — only built-ins — so no
+  # packageRequires.
+  project-nix-store = efinal.trivialBuild {
+    pname = "project-nix-store";
+    version = "0.10.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "jian-lin";
+      repo = "project-nix-store";
+      rev = "ae6c743f98f2f46222cec670d96b1d125db1c7c5"; # tag 0.10.0
+      sha256 = "184hy7jy1zq97xr4ddgxi2mppj25gv53j0k692mx74lwlbxic5cd";
+    };
+  };
+
   # Tree-sitter QML major mode (lisp/init-lang-qml.el), for editing
   # Quickshell / Qt Quick `.qml' files.  Not on MELPA.  Uses the `qmljs'
   # grammar, which the distribution already ships via

--- a/nix/nix-provided-packages.nix
+++ b/nix/nix-provided-packages.nix
@@ -24,6 +24,7 @@
   "jylhis-emacs-themes"
   "majutsu"
   "nix-ts-mode"
+  "project-nix-store"
   "qml-ts-mode"
   "tagref"
 ]


### PR DESCRIPTION
## What

Wires in [`project-nix-store`](https://elpa.nongnu.org/nongnu/project-nix-store.html) (NonGNU ELPA, by Lin Jian) — a `project.el` backend for the Nix store. Each `/nix/store` path that is a directory becomes a project root, so `project-find-file` and the rest of the project interface work while reading a dependency's source under the store.

## Why

Nothing else in the Nix+Emacs space covers this niche: `nix-mode`'s `nix-store.el` *inspects* store-path metadata but has no `project.el` integration, and `pretty-sha-path` (already shipped, in `init-navigation.el`) only prettifies the paths visually. This adds native project navigation *inside* store paths, composing cleanly with both. Followed a fact-checked survey of the package and the surrounding tooling before wiring it.

## Changes

- **`lisp/init-project.el`** — `use-package project-nix-store` block, placed beside `project` itself (per the no-builtins/third-party-split rule). Registers `project-nix-store-try` *ahead of* the built-in `project-try-vc` (upstream's performance advice — `add-hook` without `APPEND` prepends), and adds `project-nix-store-p` to `project-list-exclude` so store paths stay out of the saved project list. The `project-list-exclude` reference is guarded on `boundp` because that option is newer than the config's Emacs 30.1 floor. `:ensure nil` — Nix provides it.
- **`nix/extra-packages.nix`** — builds it via `trivialBuild` from the tagged `0.10.0` release (`jian-lin/project-nix-store`, commit `ae6c743`). The pinned emacs-overlay snapshot (2026-08-24) predates the upstream `project-store` → `project-nix-store` rename, so the base epkgs scope doesn't carry this name yet. `Package-Requires` is `((emacs "29.1"))` — only built-ins — so no `packageRequires`.
- **`nix/nix-provided-packages.nix`** — force-injects it into the distribution and the API-doc set (the `:ensure nil` path).
- **`docs/configuration/package-reference.mdx`** — regenerated entry so `packages-doc-in-sync` stays green.

## Validation (offline; the archive fetch is blocked in this sandbox but works in CI)

- `nix-instantiate` — the `trivialBuild` derivation evaluates: `emacs-project-nix-store-0.10.0.drv`.
- Fetch hash computed from the git tree of the `0.10.0` commit (equals `fetchFromGitHub`'s NAR hash).
- `use-package.nix` scanner parses the new block as `ensureNil=true`, and its extracted `@doc` body is byte-identical to the checked-in `.mdx` entry → `packages-doc-in-sync` passes.
- Nix files parse; `nixfmt-rfc-style` makes no changes; Elisp parens balance. Both `project-nix-store-try` and `project-nix-store-p` carry `;;;###autoload` cookies, so the `elisp-compile` byte-compile (which loads package autoloads via the wrapper's `site-start.el`) stays warning-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4FCqWRD4kFHJdPtA9TSmQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4FCqWRD4kFHJdPtA9TSmQ)_