### PR TITLE
config: adopt GNU Emacs newcomers-presets-theme user options

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -171,17 +171,19 @@ without editing this file.
 
 ### `pixel-scroll` *(built-in / Nix)*
 
-Built-in pixel-precision smooth scrolling, plus the scrolling
-behaviour tuning from James Cherti's "Enhancing Emacs Scrolling"
-(jamescherti.com). `pixel-scroll-precision-mode' is required for
-usable trackpad / smooth-mouse scrolling; `fast-but-imprecise-scrolling'
-lets large jumps skip exact intermediate fontification — a worthwhile
-redisplay win on this integrated-GPU Intel machine. `scroll-conservatively'
-20 scrolls just enough to keep point visible instead of eagerly
-recentering (0, the default, is too eager); `auto-window-vscroll' nil
-avoids random half-screen jumps on long lines; `scroll-error-top-bottom'
-moves point to the buffer edge before signalling; and the `hscroll-*'
-pair steps horizontal scrolling one column at a time.
+Built-in smooth scrolling, plus the scrolling behaviour tuning
+from James Cherti's "Enhancing Emacs Scrolling" (jamescherti.com).
+`pixel-scroll-mode' (the newcomers-presets theme's choice) smooths
+mouse-wheel scrolling; the theme deliberately prefers it over
+`pixel-scroll-precision-mode', which it leaves off citing bug#69972.
+`fast-but-imprecise-scrolling' lets large jumps skip exact
+intermediate fontification — a worthwhile redisplay win on this
+integrated-GPU Intel machine. `scroll-conservatively' 20 scrolls just
+enough to keep point visible instead of eagerly recentering (0, the
+default, is too eager); `auto-window-vscroll' nil avoids random
+half-screen jumps on long lines; `scroll-error-top-bottom' moves point
+to the buffer edge before signalling; and the `hscroll-*' pair steps
+horizontal scrolling one column at a time.
 (`scroll-preserve-screen-position' is set in init-core.el.)
 
 ### `hl-line` *(built-in / Nix)*
@@ -482,14 +484,15 @@ matches first.
 
 ### `emacs` *(built-in / Nix)*
 
-`tab-always-indent' = t is the stock Emacs default, restored here
-deliberately: TAB indents the line and does nothing else.
-`indent-for-tab-command's only call to `completion-at-point' is
-guarded by (eq tab-always-indent 'complete), so with t that branch is
-unreachable and TAB provably cannot summon a capf. Completion lives on
-`C-M-i' instead (`jotain-completion-key'). `tab-first-completion' is
-inert unless `tab-always-indent' is `complete', so it is irrelevant
-here and is never set.
+`tab-always-indent' = `complete', adopted from the
+newcomers-presets theme: TAB first reindents the line, and when the
+line is already correctly indented it runs `completion-at-point' and
+opens the corfu popup. `C-M-i' (`jotain-completion-key') still
+triggers completion explicitly regardless of point.
+`tab-first-completion' is left at its default (nil), so a single TAB
+completes as soon as the line is indented. While the corfu popup is
+showing, TAB stays unbound in `corfu-map', so it indents rather than
+accepting a candidate — accept is `C-M-i'.
 
 ### `corfu`
 
@@ -541,15 +544,18 @@ Inline completion preview — the built-in `completion-preview-mode'
 (Emacs 30, extended in 31). It greys out the most likely completion
 after point as you type, the way a modern editor does, drawing its
 candidate from the same `completion-at-point-functions' the corfu
-popup uses. Enabled only in `jotain-completion-auto-modes' buffers (so
-prose stays quiet), and only when `jotain-completion-inline-preview'
-is non-nil. Two things keep it inside this config's rules: it binds
-`C-i' — which is the TAB event — to accept the preview, so that entry
-is removed and TAB still only indents; and it never binds RET, so
-Enter stays a newline. Accept the whole preview with `M-RET', or just
-the common prefix with `M-i'. The preview is suppressed inside
-comments and strings, and its sort is paired with corfu's so the ghost
-text matches the popup's top row.
+popup uses. Enabled globally via `global-completion-preview-mode'
+(adopted from the newcomers-presets theme), so the ghost text appears
+in every buffer — prose, shells, and the minibuffer included; on the
+Emacs 30.1 floor, which has no globalized variant, it falls back to
+the per-mode `jotain-completion-auto-modes' hooks. Gated on
+`jotain-completion-inline-preview'. Two things keep it inside this
+config's rules: it binds `C-i' — which is the TAB event — to accept
+the preview, so that entry is removed and TAB does not accept a
+candidate; and it never binds RET, so Enter stays a newline. Accept
+the whole preview with `M-RET', or just the common prefix with `M-i'.
+The preview is suppressed inside comments and strings, and its sort is
+paired with corfu's so the ghost text matches the popup's top row.
 
 ## `init-navigation.el` — dired, project, windows
 
@@ -824,6 +830,12 @@ you type.
 Built-in cross-reference engine. Pinned to ripgrep (in the
 devenv shell) for orders-of-magnitude faster project-wide
 lookups than default grep.
+
+### `imenu` *(built-in / Nix)*
+
+Built-in symbol index (the source behind `consult-imenu', M-g i).
+`imenu-auto-rescan' reparses the buffer on each invocation so the
+index never goes stale after you add or rename a definition.
 
 ### `tagref` *(built-in / Nix)*
 

--- a/lisp/init-completion.el
+++ b/lisp/init-completion.el
@@ -145,18 +145,18 @@ Read at load time; nil skips `corfu-popupinfo-mode' entirely."
 
 (defcustom jotain-completion-inline-preview t
   "When non-nil, show inline \"ghost text\" of the top candidate as you type.
-Enables the built-in `completion-preview-mode' in
-`jotain-completion-auto-modes' buffers -- the same modes that get the
-auto-popup -- so prose stays quiet (it inherits nothing) while code gains
-a greyed-out preview of the most likely completion after point, the way a
-modern editor does.  The popup still lists the alternatives; this is the
-single inline hint beside it.
+Enables the built-in `completion-preview-mode' globally via
+`global-completion-preview-mode' (Emacs 31; on the Emacs 30.1 floor,
+which lacks the globalized variant, it falls back to the
+`jotain-completion-auto-modes' hooks).  A greyed-out preview of the most
+likely completion after point appears as you type, the way a modern
+editor does.  The popup still lists the alternatives; this is the single
+inline hint beside it.
 
-TAB is kept safe: `completion-preview-active-mode-map' binds `C-i' (which
-IS the TAB event) to accept the preview, so this config unbinds it -- TAB
-still only indents while a preview shows.  RET is untouched by the mode
-and stays a newline.  Accept the whole preview with `M-RET'; `M-i'
-completes just the common prefix.
+`completion-preview-active-mode-map' binds `C-i' (which IS the TAB event)
+to accept the preview, so this config unbinds it -- TAB does not accept a
+candidate.  RET is untouched by the mode and stays a newline.  Accept the
+whole preview with `M-RET'; `M-i' completes just the common prefix.
 
 Read at load time; nil adds no preview mode.  `completion-preview-mode'
 also toggles it per-buffer on demand."
@@ -172,7 +172,20 @@ also toggles it per-buffer on demand."
   :custom
   (completions-detailed t)
   (completions-format 'one-column)
-  (completions-sort 'historical))
+  (completions-sort 'historical)
+  ;; Default *Completions*-buffer / minibuffer-completion knobs from the
+  ;; newcomers-presets theme.  Vertico replaces this surface in normal
+  ;; use, so these mostly govern the fallback default completion, but
+  ;; they are correct there: keep the typed input visible while
+  ;; completing, group candidates by category, and let a second TAB move
+  ;; point into the completions list.
+  (minibuffer-visible-completions t)
+  (completions-group t)
+  (completion-auto-select 'second-tab)
+  :config
+  ;; `completion-eager-update' is Emacs 31; guarded for the 30.1 floor.
+  (when (boundp 'completion-eager-update)
+    (setopt completion-eager-update t)))
 
 ;;; @doc Fuzzy, space-separated, order-independent completion. Pairs with
 ;;; partial-completion (path globbing) so `/u/s/a` matches
@@ -439,18 +452,19 @@ ignoring sentinel to just that process."
 
 ;;;; In-buffer completion
 
-;;; @doc `tab-always-indent' = t is the stock Emacs default, restored here
-;;; deliberately: TAB indents the line and does nothing else.
-;;; `indent-for-tab-command's only call to `completion-at-point' is
-;;; guarded by (eq tab-always-indent 'complete), so with t that branch is
-;;; unreachable and TAB provably cannot summon a capf. Completion lives on
-;;; `C-M-i' instead (`jotain-completion-key'). `tab-first-completion' is
-;;; inert unless `tab-always-indent' is `complete', so it is irrelevant
-;;; here and is never set.
+;;; @doc `tab-always-indent' = `complete', adopted from the
+;;; newcomers-presets theme: TAB first reindents the line, and when the
+;;; line is already correctly indented it runs `completion-at-point' and
+;;; opens the corfu popup. `C-M-i' (`jotain-completion-key') still
+;;; triggers completion explicitly regardless of point.
+;;; `tab-first-completion' is left at its default (nil), so a single TAB
+;;; completes as soon as the line is indented. While the corfu popup is
+;;; showing, TAB stays unbound in `corfu-map', so it indents rather than
+;;; accepting a candidate — accept is `C-M-i'.
 (use-package emacs
   :ensure nil
   :custom
-  (tab-always-indent t))
+  (tab-always-indent 'complete))
 
 ;; The one completion gesture.  `completion-at-point' rather than the stock
 ;; `complete-symbol' is load-bearing: `corfu-map' contains a
@@ -590,20 +604,25 @@ comments and docstrings."
 ;;; (Emacs 30, extended in 31). It greys out the most likely completion
 ;;; after point as you type, the way a modern editor does, drawing its
 ;;; candidate from the same `completion-at-point-functions' the corfu
-;;; popup uses. Enabled only in `jotain-completion-auto-modes' buffers (so
-;;; prose stays quiet), and only when `jotain-completion-inline-preview'
-;;; is non-nil. Two things keep it inside this config's rules: it binds
-;;; `C-i' — which is the TAB event — to accept the preview, so that entry
-;;; is removed and TAB still only indents; and it never binds RET, so
-;;; Enter stays a newline. Accept the whole preview with `M-RET', or just
-;;; the common prefix with `M-i'. The preview is suppressed inside
-;;; comments and strings, and its sort is paired with corfu's so the ghost
-;;; text matches the popup's top row.
+;;; popup uses. Enabled globally via `global-completion-preview-mode'
+;;; (adopted from the newcomers-presets theme), so the ghost text appears
+;;; in every buffer — prose, shells, and the minibuffer included; on the
+;;; Emacs 30.1 floor, which has no globalized variant, it falls back to
+;;; the per-mode `jotain-completion-auto-modes' hooks. Gated on
+;;; `jotain-completion-inline-preview'. Two things keep it inside this
+;;; config's rules: it binds `C-i' — which is the TAB event — to accept
+;;; the preview, so that entry is removed and TAB does not accept a
+;;; candidate; and it never binds RET, so Enter stays a newline. Accept
+;;; the whole preview with `M-RET', or just the common prefix with `M-i'.
+;;; The preview is suppressed inside comments and strings, and its sort is
+;;; paired with corfu's so the ghost text matches the popup's top row.
 (use-package completion-preview
   :ensure nil
   :when jotain-completion-inline-preview
   :defer t
-  :functions (completion-preview-insert)
+  :functions (completion-preview-insert
+              completion-preview-mode
+              global-completion-preview-mode)
   :preface
   ;; Defined in completion-preview.el / corfu.el, neither loaded at
   ;; byte-compile time; declare them so the `:config' edits below compile
@@ -618,8 +637,18 @@ Added to `completion-preview-inhibit-functions' (Emacs 31) so the ghost
 text does not appear where symbol completion is meaningless."
     (nth 8 (syntax-ppss)))
   :init
-  (dolist (hook jotain-completion-auto-modes)
-    (add-hook hook #'completion-preview-mode))
+  ;; The newcomers-presets theme enables inline preview globally.  Load
+  ;; the library up front (enabling the global mode is what turns the
+  ;; preview on, so this block is no longer deferred): Emacs 31 ships the
+  ;; globalized `global-completion-preview-mode'; on the 30.1 floor (no
+  ;; globalized variant) fall back to the per-mode hooks so the feature
+  ;; still rides `jotain-completion-auto-modes'.  Requiring first makes
+  ;; the `fboundp' probe see the symbol that only exists once loaded.
+  (require 'completion-preview)
+  (if (fboundp 'global-completion-preview-mode)
+      (global-completion-preview-mode 1)
+    (dolist (hook jotain-completion-auto-modes)
+      (add-hook hook #'completion-preview-mode)))
   :config
   ;; Match the popup's debounce so the inline preview and corfu wait the
   ;; same beat, and one keystroke does not fire two capf passes at

--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -88,6 +88,9 @@ immediately for writes."
   (use-short-answers t)
   (read-answer-short t)
   (list-matching-lines-jump-to-current-line nil)
+  ;; Visiting a read-only file drops you into `view-mode' (SPC/DEL to
+  ;; page, q to quit) instead of a normal read-only buffer.
+  (view-read-only t)
   (use-dialog-box nil)
   (create-lockfiles nil)
   (delete-by-moving-to-trash t)
@@ -98,6 +101,12 @@ immediately for writes."
   (ring-bell-function #'ignore)
   (scroll-preserve-screen-position 1)
   (mouse-yank-at-point t)
+  ;; Drag a region to move/copy it, including across a split (and, with
+  ;; the -cross-program knob, to and from other applications); drag the
+  ;; buffer name in the mode line to move that buffer to another window.
+  (mouse-drag-and-drop-region t)
+  (mouse-drag-and-drop-region-cross-program t)
+  (mouse-drag-mode-line-buffer t)
   (kill-do-not-save-duplicates t)
   (save-interprogram-paste-before-kill t)
   (set-mark-command-repeat-pop t)
@@ -193,6 +202,18 @@ immediately for writes."
       (fset 'ask-user-about-supersession-threat saved))))
 (advice-add 'custom-save-all :around
             #'jotain-core--custom-save-without-supersession)
+
+;;;; package.el conveniences (newcomers-presets theme)
+
+;; `package-autosuggest-mode' (Emacs 31) offers to install a package when
+;; you open a file type Emacs has no mode for; `package-menu-use-current-
+;; if-no-marks' nil makes the package-menu action keys act only on marked
+;; entries, never silently on the line at point. Both guarded for the
+;; Emacs 30.1 floor. `package' is already loaded (required in init.el).
+(when (boundp 'package-menu-use-current-if-no-marks)
+  (setopt package-menu-use-current-if-no-marks nil))
+(when (fboundp 'package-autosuggest-mode)
+  (package-autosuggest-mode 1))
 
 ;;; @doc Repeat-mode lets you press the trailing key alone after a prefix
 ;;; command (e.g. C-x o o o instead of C-x o C-x o). Built-in,

--- a/lisp/init-editing.el
+++ b/lisp/init-editing.el
@@ -29,11 +29,21 @@
 ;;; 30, so it needs no config here.)
 (use-package simple
   :ensure nil
+  :custom
+  ;; `M-!' / `M-&' show the directory the command will run in as part of
+  ;; the prompt, so a shell command never lands in a surprising `cwd'.
+  (shell-command-prompt-show-cwd t)
   :config
   (when (boundp 'kill-region-dwim)
     (setopt kill-region-dwim 'emacs-word))
   (when (boundp 'delete-pair-push-mark)
     (setopt delete-pair-push-mark t)))
+
+;; Indent with spaces by default. `.editorconfig' and dtrt-indent (both
+;; in init-prog.el) still override per file/project, and modes that
+;; require tabs (makefile-mode, go-ts-mode) set it themselves — this only
+;; changes the fallback when nothing else has an opinion.
+(setopt indent-tabs-mode nil)
 
 ;;; @doc Strip trailing whitespace and stray tabs on save without
 ;;; reformatting the rest of the buffer. Built-in. Skipped during

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -545,7 +545,27 @@ connection alongside any existing language server."
 (use-package xref
   :ensure nil
   :custom
-  (xref-search-program 'ripgrep))
+  (xref-search-program 'ripgrep)
+  :config
+  ;; Emacs 31+: mouse-1 follows an identifier to its definition and the
+  ;; mouse-over shows a "jump to definition" hint. Guarded for Emacs 30.
+  (when (fboundp 'global-xref-mouse-mode)
+    (global-xref-mouse-mode 1))
+  ;; `etags-regen-mode' (Emacs 30) regenerates a project TAGS table on
+  ;; demand, giving `xref' a definition source in buffers without an LSP
+  ;; server. Adopted from the newcomers-presets theme; guarded for safety.
+  (when (fboundp 'etags-regen-mode)
+    (etags-regen-mode 1)))
+
+;;;; imenu
+
+;;; @doc Built-in symbol index (the source behind `consult-imenu', M-g i).
+;;; `imenu-auto-rescan' reparses the buffer on each invocation so the
+;;; index never goes stale after you add or rename a definition.
+(use-package imenu
+  :ensure nil
+  :custom
+  (imenu-auto-rescan t))
 
 ;;;; tagref
 

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -244,6 +244,28 @@ availability on the right display."
 (setopt cursor-in-non-selected-windows nil)
 (setopt highlight-nonselected-windows nil)
 
+;; Resize the frame and its windows to exact pixels rather than rounding
+;; to whole character cells — the frame then sits flush against a tiling
+;; window manager's gaps (pgtk/Wayland is the Linux GUI default) and
+;; horizontal splits divide evenly. (`frame-inhibit-implied-resize' is
+;; set in early-init.el.)
+(setopt frame-resize-pixelwise t)
+(setopt window-resize-pixelwise t)
+
+;; From the newcomers-presets theme. `mode-line-compact' `long only
+;; compacts (collapses runs of spaces in) the mode line when it is longer
+;; than the window — mostly inert here since doom-modeline builds its own
+;; format, but harmless and correct for the stock mode line. Prefer the
+;; system's configured font for the default face; Jotain's explicit font
+;; probing (`jotain-ui-apply-font' above) still sets the default face on
+;; each GUI frame, so this only governs the pre-font-hook default.
+(setopt mode-line-compact 'long)
+;; `font-use-system-font' only exists on builds with system-font support
+;; (xsettings); the terminal-only distribution loads this same config, so
+;; guard it or `setopt' errors at startup there.
+(when (boundp 'font-use-system-font)
+  (setopt font-use-system-font t))
+
 (defcustom jotain-line-numbers-in-prog t
   "When non-nil, show line numbers in `prog-mode' and `conf-mode' buffers."
   :type 'boolean
@@ -262,17 +284,19 @@ availability on the right display."
   :ensure nil
   :hook ((prog-mode conf-mode) . jotain-ui--maybe-line-numbers))
 
-;;; @doc Built-in pixel-precision smooth scrolling, plus the scrolling
-;;; behaviour tuning from James Cherti's "Enhancing Emacs Scrolling"
-;;; (jamescherti.com). `pixel-scroll-precision-mode' is required for
-;;; usable trackpad / smooth-mouse scrolling; `fast-but-imprecise-scrolling'
-;;; lets large jumps skip exact intermediate fontification — a worthwhile
-;;; redisplay win on this integrated-GPU Intel machine. `scroll-conservatively'
-;;; 20 scrolls just enough to keep point visible instead of eagerly
-;;; recentering (0, the default, is too eager); `auto-window-vscroll' nil
-;;; avoids random half-screen jumps on long lines; `scroll-error-top-bottom'
-;;; moves point to the buffer edge before signalling; and the `hscroll-*'
-;;; pair steps horizontal scrolling one column at a time.
+;;; @doc Built-in smooth scrolling, plus the scrolling behaviour tuning
+;;; from James Cherti's "Enhancing Emacs Scrolling" (jamescherti.com).
+;;; `pixel-scroll-mode' (the newcomers-presets theme's choice) smooths
+;;; mouse-wheel scrolling; the theme deliberately prefers it over
+;;; `pixel-scroll-precision-mode', which it leaves off citing bug#69972.
+;;; `fast-but-imprecise-scrolling' lets large jumps skip exact
+;;; intermediate fontification — a worthwhile redisplay win on this
+;;; integrated-GPU Intel machine. `scroll-conservatively' 20 scrolls just
+;;; enough to keep point visible instead of eagerly recentering (0, the
+;;; default, is too eager); `auto-window-vscroll' nil avoids random
+;;; half-screen jumps on long lines; `scroll-error-top-bottom' moves point
+;;; to the buffer edge before signalling; and the `hscroll-*' pair steps
+;;; horizontal scrolling one column at a time.
 ;;; (`scroll-preserve-screen-position' is set in init-core.el.)
 (use-package pixel-scroll
   :ensure nil
@@ -283,7 +307,7 @@ availability on the right display."
   (auto-window-vscroll nil)
   (hscroll-margin 2)
   (hscroll-step 1)
-  :config (pixel-scroll-precision-mode 1))
+  :config (pixel-scroll-mode 1))
 
 ;;; @doc Built-in current-line highlight — on for code and prose, off
 ;;; in shells/dired where it would fight the cursor.

--- a/lisp/init-vc.el
+++ b/lisp/init-vc.el
@@ -37,7 +37,27 @@
   (when (boundp 'vc-allow-rewriting-published-history)
     (setopt vc-allow-rewriting-published-history t))
   (when (boundp 'vc-dir-auto-hide-up-to-date)
-    (setopt vc-dir-auto-hide-up-to-date 'revert)))
+    (setopt vc-dir-auto-hide-up-to-date 'revert))
+  ;; A few modern `vc' conveniences, guarded so the config still loads on
+  ;; the Emacs 30.1 floor: run `C-x v' commands from non-VC buffers by
+  ;; deducing the backend from `default-directory'; save modified buffers
+  ;; before a `vc-dir' revert; view old revisions without dropping temp
+  ;; files on disk; and adopt the incoming/outgoing keymap prefixes
+  ;; (`C-x v I' log-incoming, `C-x v O' log-outgoing, etc.).
+  (when (boundp 'vc-deduce-backend-nonvc-modes)
+    (setopt vc-deduce-backend-nonvc-modes t))
+  (when (boundp 'vc-dir-save-some-buffers-on-revert)
+    (setopt vc-dir-save-some-buffers-on-revert t))
+  (when (boundp 'vc-find-revision-no-save)
+    (setopt vc-find-revision-no-save t))
+  (when (boundp 'vc-use-incoming-outgoing-prefixes)
+    (setopt vc-use-incoming-outgoing-prefixes t))
+  ;; `vc-auto-revert-mode' (Emacs 31) reverts VC-controlled buffers when
+  ;; their file changes on disk. Largely subsumed by the global
+  ;; `auto-revert-mode' enabled in init-core.el, but adopted from the
+  ;; newcomers-presets theme for completeness; guarded for Emacs 30.
+  (when (fboundp 'vc-auto-revert-mode)
+    (vc-auto-revert-mode 1)))
 
 ;;; @doc Quick jump to a file git status reports as changed. Runs
 ;;; `git status --porcelain=v1 -z -uall' (-z keeps spaces and

--- a/test/completion-test.el
+++ b/test/completion-test.el
@@ -219,9 +219,12 @@ corfu's own default is `insert', which commits the selected candidate on
 further input -- exactly the accidental-accept this config avoids."
   (should (eq corfu-preview-current nil)))
 
-(ert-deftest completion-test-tab-indents-only ()
-  "TAB is on the stock default, so `indent-for-tab-command' cannot complete."
-  (should (eq tab-always-indent t)))
+(ert-deftest completion-test-tab-completes-when-indented ()
+  "TAB completes once the line is indented: `tab-always-indent' is `complete'.
+Adopted from the newcomers-presets theme.  While the corfu popup is open TAB
+stays unbound in `corfu-map' (see `completion-test-corfu-map-frees-return-and-tab'),
+so it indents rather than accepting a candidate."
+  (should (eq tab-always-indent 'complete)))
 
 (ert-deftest completion-test-auto-popup-is-opt-in-per-mode ()
   "Auto-popup is off globally and opted into per mode hook, buffer-locally."
@@ -258,12 +261,16 @@ the mode, so Enter stays a newline."
   (should (eq (lookup-key completion-preview-active-mode-map (kbd "M-RET"))
               #'completion-preview-insert)))
 
-(ert-deftest completion-test-inline-preview-is-per-mode-like-auto ()
-  "Inline preview rides the same mode list as the auto-popup, so prose stays quiet.
-`completion-preview-mode' is enabled in `jotain-completion-auto-modes'
-buffers (prog-mode) and nowhere prose lives (text-mode)."
-  (should (memq #'completion-preview-mode prog-mode-hook))
-  (should-not (memq #'completion-preview-mode text-mode-hook)))
+(ert-deftest completion-test-inline-preview-is-global ()
+  "Inline preview is enabled globally (adopted from the newcomers-presets theme).
+On Emacs 31 `global-completion-preview-mode' is turned on, so the ghost text
+rides `completion-preview-mode' in every buffer rather than a per-mode hook
+list.  On the Emacs 30.1 floor, which lacks the globalized variant, the config
+falls back to the `jotain-completion-auto-modes' hooks; that path is asserted
+only when the global mode is unavailable."
+  (if (fboundp 'global-completion-preview-mode)
+      (should (bound-and-true-p global-completion-preview-mode))
+    (should (memq #'completion-preview-mode prog-mode-hook))))
 
 (ert-deftest completion-test-one-key-opens-and-accepts ()
   "`C-M-i' resolves to `completion-at-point', which `corfu-map' remaps.


### PR DESCRIPTION
## What

Emacs 31 ships [`etc/themes/newcomers-presets-theme.el`](https://github.com/emacs-mirror/emacs/blob/master/etc/themes/newcomers-presets-theme.el) — a *user-options* theme (no faces/colors) that turns on sensible defaults a new user would likely want but not discover. This ports its settings into the modular config, at the theme's values, following repo conventions (`setopt`, `:ensure nil`, `(when (boundp …) …)` / `(when (fboundp …) …)` guards for the Emacs 30.1 floor). Per request, options are adopted **even where they are inert** under Jotain's stack, except the six where Jotain made a deliberate, documented choice — those were each confirmed individually.

## Options added

- **init-ui.el:** `frame-resize-pixelwise`, `window-resize-pixelwise`, `mode-line-compact 'long`, `font-use-system-font` (guarded — the C variable is absent on the `-nox` build); pixel-scroll switched from `pixel-scroll-precision-mode` to plain `pixel-scroll-mode` (theme's choice, per bug#69972).
- **init-core.el:** `mouse-drag-and-drop-region` (+`-cross-program`), `mouse-drag-mode-line-buffer`, `view-read-only`; `package-autosuggest-mode` + `package-menu-use-current-if-no-marks` (guarded, Emacs 31).
- **init-editing.el:** `shell-command-prompt-show-cwd`, `indent-tabs-mode nil`.
- **init-prog.el:** new `imenu` block (`imenu-auto-rescan`); `global-xref-mouse-mode` and `etags-regen-mode` enabled in the xref block (guarded).
- **init-vc.el:** `vc-deduce-backend-nonvc-modes`, `vc-dir-save-some-buffers-on-revert`, `vc-find-revision-no-save`, `vc-use-incoming-outgoing-prefixes`, `vc-auto-revert-mode` (all guarded).
- **init-completion.el:** `minibuffer-visible-completions`, `completions-group`, `completion-auto-select`, `completion-eager-update` (guarded).

## Behavioral changes chosen over Jotain's prior defaults

- `tab-always-indent` → `'complete` (TAB completes once the line is indented).
- `global-completion-preview-mode` enabled (inline preview in every buffer; the 30.1 floor keeps the per-mode fallback).

Both update the affected `@doc` blocks **and** the ERT tests that encoded the old invariants (`completion-test-tab-completes-when-indented`, `completion-test-inline-preview-is-global`).

## Kept Jotain's deliberate values (theme diverges)

`completion-styles` (orderless fuzzy matching), `tab-bar-show 1`, `dired-auto-revert-buffer` predicate. The theme's `newcomers-presets-mode` local modes are already covered (`flymake`, prog-mode line numbers) or intentionally superseded (`jinx` replaces `flyspell`/`flyspell-prog-mode`).

## Notes / validation

- Already-set options (`context-menu-mode`, `savehist-mode`, `save-place-mode`, `recentf-mode`, `electric-pair-mode`, `which-key-mode`, `vc-follow-symlinks`, `frame-inhibit-implied-resize`, `compilation-scroll-output`, `completions-detailed`, …) were left untouched — no duplication.
- The four affected `docs/configuration/package-reference.mdx` entries were regenerated **by hand** to match `nix/packages-doc.nix` output: this session could not run the generator offline (`emacs-overlay` is uncached and github tarballs are 403-blocked here). Each rendered entry was verified byte-for-byte against the generator's `@doc` extraction rules, and paren balance was checked on every edited `.el`. `nix flake check` (elisp-lint/compile/test, packages-doc-in-sync) still needs to run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXAJVxN61uRLXfzEeR1ThB

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXAJVxN61uRLXfzEeR1ThB)_