### PR TITLE
perf(startup): defer eager on-demand built-ins (ffap, shr, bookmark, apropos, re-builder)

### DIFF
--- a/lisp/init-core.el
+++ b/lisp/init-core.el
@@ -229,6 +229,13 @@ immediately for writes."
 ;;; the editor on a DNS lookup — reject means "treat as not a host".
 (use-package ffap
   :ensure nil
+  ;; Purely on-demand (find-file-at-point and friends), yet its ~2k-line
+  ;; body pulled in the largest built-in load on the eager startup path
+  ;; (~67ms in an isolated Emacs 31 measurement). Defer it: the built-in
+  ;; autoloads still trigger the load when a ffap command runs, and the
+  ;; `:custom' value below is recorded now and applied by the deferred
+  ;; `defcustom' when ffap finally loads.
+  :defer t
   :custom
   (ffap-machine-p-known 'reject))
 
@@ -361,6 +368,9 @@ freezes — start, reproduce, stop."
 ;;; glyph is suppressed because it adds visual noise without info.
 (use-package bookmark
   :ensure nil
+  ;; On-demand: nothing on the startup path uses bookmarks. Autoloaded via
+  ;; `bookmark-jump'/`consult-bookmark'; the customs apply on that load.
+  :defer t
   :custom
   (bookmark-default-file (jotain-var-file "bookmarks.el"))
   (bookmark-fringe-mark nil)
@@ -387,6 +397,11 @@ freezes — start, reproduce, stop."
 ;;; predictable layout.
 (use-package shr
   :ensure nil
+  ;; The HTML renderer, only reached on demand (eww, rendered mail, etc.),
+  ;; but the heaviest built-in on the eager startup path (~74ms, ~41 deps
+  ;; in an isolated Emacs 31 measurement). Defer it; callers that need it
+  ;; require it themselves, and the customs below apply on that load.
+  :defer t
   :custom
   (shr-use-colors nil)
   (shr-use-fonts nil))

--- a/lisp/init-editing.el
+++ b/lisp/init-editing.el
@@ -142,6 +142,8 @@
 ;;; syntax that requires escaping every backslash twice.
 (use-package re-builder
   :ensure nil
+  ;; On-demand (M-x re-builder); autoloaded, so keep it off the startup path.
+  :defer t
   :custom (reb-re-syntax 'string))
 
 ;;; @doc Counts command invocations to disk; `M-x keyfreq-show` ranks

--- a/lisp/init-help.el
+++ b/lisp/init-help.el
@@ -34,6 +34,8 @@
 ;;; faces, classes, and customs alongside functions and variables.
 (use-package apropos
   :ensure nil
+  ;; On-demand (M-x apropos*); autoloaded, so keep it off the startup path.
+  :defer t
   :custom
   (apropos-do-all t))
 


### PR DESCRIPTION
## What & why

Prompted by James Cherti's ["Optimizing Emacs Startup: deferred package loading with use-package"](https://www.jamescherti.com/emacs-startup-defer-use-package-performance/). The config already follows the article's core recommendation — `use-package-always-defer` is left **nil** and packages are deferred explicitly, with `:demand t` reserved for the few that must load eagerly (only `vertico`/`orderless` among third-party packages). This PR closes the last real gap that approach leaves: a handful of **built-ins** that carried only plain-value `:custom` settings with no deferral trigger, so use-package `require`d them while `init.el` ran even though nothing on the startup path uses them.

Five blocks now get `:defer t`:

| package | why eager was wasteful | isolated load cost¹ |
|---|---|---|
| `shr` | HTML renderer, only reached via eww / rendered mail | **~74 ms**, ~41 deps |
| `ffap` | `find-file-at-point` and friends, on-demand only | **~67 ms**, ~20 deps |
| `bookmark` | nothing on the startup path uses bookmarks | ~21 ms |
| `re-builder` | `M-x re-builder` only | ~20 ms |
| `apropos` | `M-x apropos*` only | ~16 ms |

¹ `(benchmark-run (require …))` in a stock **Emacs 31.1** (nixpkgs `emacs-nox`, same major version as the `unstable`/`igc` variants). There's a ~15 ms fixed first-`require` floor, so `shr` and `ffap` are the meaningful wins; the rest are near-floor but equally on-demand.

## Why this is safe (empirically verified against Emacs 31)

- **`:defer t` genuinely avoids the load.** Confirmed the current `:custom`-only form loads the package at init (`featurep` = t), while `:defer t` + `:custom` does not.
- **Customs still apply.** use-package records each `:custom` via `custom-theme-set-variables` at init; the value is void until load, then the deferred `defcustom` picks it up (verified: `ffap-machine-p-known`, `bookmark-save-flag`, `shr-use-colors`, `apropos-do-all`, `reb-re-syntax` all correct after load). Each of these customs is only read by its own package, so nothing on the startup path observes the void window.
- **Entry points preserved.** Built-ins keep their own autoloads (`find-file-at-point`, `bookmark-jump`, `M-x apropos`/`re-builder`, shr's callers), so behaviour is unchanged.
- **Not pulled in transitively.** After loading every built-in that must stay eager (recentf/savehist/autorevert/… global-mode enablers), none of the five candidates was already loaded — so deferral is a real net win, not a no-op.

## Deliberately unchanged

- `use-package-always-defer` stays **nil** — explicit per-package deferral, per the article's advice against blanket deferral.
- Built-ins that enable a **global mode** in `:config` (`winner`, `repeat`, `autorevert`, `which-key`, `pixel-scroll`, …) or run a **`:set` side-effect** (`help-at-pt`'s idle timer) stay eager — deferring them would break the behaviour.
- `xref`, `compile`, `comint` left eager: pure-custom and technically deferrable, but they're pulled in by the eglot / project / `devenv.el` stack, so deferral would likely be a no-op; left out to keep this change unambiguous.

## Validation

- `check-parens` clean on all three edited files.
- Macroexpansion + defer/apply behaviour validated against real Emacs 31 (above). A live `just bench-built` run (build + display) couldn't execute in the cloud session — the Nix caches carrying the full distribution are blocked by egress policy — so the numbers here come from isolated built-in `require` timings against stock Emacs 31, not a full-config startup profile.

## Diff

`+19` lines across `lisp/init-core.el`, `lisp/init-help.el`, `lisp/init-editing.el` — one `:defer t` (plus a short rationale comment) per block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mx1BXg7XLAfjKkt2DVPFbd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mx1BXg7XLAfjKkt2DVPFbd)_