### PR TITLE
completion: make TAB indent and complete; wire HTML LSP

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -482,30 +482,36 @@ matches first.
 
 ### `emacs` *(built-in / Nix)*
 
-`tab-always-indent' = t is the stock Emacs default, restored here
-deliberately: TAB indents the line and does nothing else.
-`indent-for-tab-command's only call to `completion-at-point' is
-guarded by (eq tab-always-indent 'complete), so with t that branch is
-unreachable and TAB provably cannot summon a capf. Completion lives on
-`C-M-i' instead (`jotain-completion-key'). `tab-first-completion' is
-inert unless `tab-always-indent' is `complete', so it is irrelevant
-here and is never set.
+TAB indents and completes. `tab-always-indent' is `complete'
+(unless `jotain-completion-free-tab' is set, which restores the stock
+`t' -- indent only): TAB first indents the line, and once the line is
+already indented `indent-for-tab-command' runs `completion-at-point',
+opening the corfu popup. Inside the popup TAB is repointed to
+`corfu-insert' (see the corfu block below), so a second TAB accepts the
+candidate -- the same open-then-accept gesture as `C-M-i'
+(`jotain-completion-key'), which stays bound as a GUI-safe alternative.
+`tab-first-completion' stays at its default nil (complete right after
+indenting); set it to e.g. `word' if you want TAB not to complete
+immediately after typing a word.
 
 ### `corfu`
 
 In-buffer completion popup — the corfu equivalent of company.
 The popup appears on its own only in the modes listed by
 `jotain-completion-auto-modes' (default: programming modes), so prose
-stays quiet. `C-M-i' is the whole gesture, used twice: with no popup it
-runs the global `completion-at-point' and opens the popup; with the popup
-showing the same key inserts the selected candidate. RET and TAB are
-unbound in `corfu-map', so Enter always inserts a newline and TAB
-always indents, even while the popup is showing. The top candidate is
+stays quiet. Two keys open-and-accept, used twice each: with no popup
+they run `completion-at-point' and open the popup; with the popup
+showing they insert the selected candidate. TAB is one of them (via
+`tab-always-indent' `complete' to open, and `corfu-map's TAB rebound to
+`corfu-insert' to accept), and `C-M-i' (`jotain-completion-key') is the
+GUI-safe alternative. RET stays unbound in `corfu-map', so Enter always
+inserts a newline even while the popup is showing. The top candidate is
 always preselected (`corfu-preselect' `first'), so it is highlighted and
-ready the instant the popup opens; the second `C-M-i' commits it (the
-map's `<remap> <completion-at-point>' is repointed from `corfu-complete'
-to `corfu-insert', which finishes the completion and expands a snippet).
-`M-n'/`M-p' move, `C-g' dismisses.
+ready the instant the popup opens; the accept key commits it (the map's
+`<remap> <completion-at-point>' is repointed from `corfu-complete' to
+`corfu-insert', which finishes the completion and expands a snippet).
+`M-n'/`M-p' move, `C-g' dismisses. Set `jotain-completion-free-tab' to
+restore the stricter "TAB indents only" behaviour.
 
 ### `corfu-history` *(built-in / Nix)*
 
@@ -543,13 +549,15 @@ after point as you type, the way a modern editor does, drawing its
 candidate from the same `completion-at-point-functions' the corfu
 popup uses. Enabled only in `jotain-completion-auto-modes' buffers (so
 prose stays quiet), and only when `jotain-completion-inline-preview'
-is non-nil. Two things keep it inside this config's rules: it binds
-`C-i' — which is the TAB event — to accept the preview, so that entry
-is removed and TAB still only indents; and it never binds RET, so
-Enter stays a newline. Accept the whole preview with `M-RET', or just
-the common prefix with `M-i'. The preview is suppressed inside
-comments and strings, and its sort is paired with corfu's so the ghost
-text matches the popup's top row.
+is non-nil. RET is never bound by the mode, so Enter always stays a
+newline. TAB tracks `jotain-completion-free-tab': by default the mode's
+shipped `C-i' (which IS the TAB event) → `completion-preview-insert'
+binding is kept, so when only the ghost text shows (no popup yet) TAB
+accepts it -- the modern-editor feel; with the strict "TAB indents only"
+opt-in that binding is removed so TAB still only indents. `M-RET' also
+accepts the whole preview, and `M-i' just the common prefix. The preview
+is suppressed inside comments and strings, and its sort is paired with
+corfu's so the ghost text matches the popup's top row.
 
 ## `init-navigation.el` — dired, project, windows
 
@@ -871,10 +879,11 @@ Lightweight template/snippet engine from the corfu/cape author.
 Templates are read from `templates/*.eld' (keyed by major mode);
 `M-+' completes a snippet by name, `M-*' inserts one interactively,
 and once fields are active `M-}'/`M-{' or `C-M-n'/`C-M-p' move
-between them, with `M-RET' to finish. TAB is deliberately not
-involved: in this configuration TAB indents and nothing else. Set
-`jotain-completion-snippets' to nil to keep snippet names out of the
-completion popup; `M-+' and `M-*' still work.
+between them, with `M-RET' to finish. TAB is deliberately not a
+field-navigation key -- it indents and drives completion instead, so it
+never fights the snippet fields. Set `jotain-completion-snippets' to nil
+to keep snippet names out of the completion popup; `M-+' and `M-*' still
+work.
 
 ### `eglot-tempel`
 

--- a/docs/design/completion.md
+++ b/docs/design/completion.md
@@ -21,7 +21,7 @@ These are the owner's stated requirements. They are inputs, not conclusions.
 | # | Requirement |
 | --- | --- |
 | R1 | Completion pops up **automatically in code**, and **only on request in prose** (text/org/markdown/commit buffers). |
-| R2 | **TAB indents. Only.** TAB never triggers completion. |
+| R2 | **TAB indents. Only.** TAB never triggers completion. *(Superseded 2026-09-04 — TAB now indents **and** completes; see §7. Restore with `jotain-completion-free-tab`.)* |
 | R3 | A **separate, explicit key** drives the snippet + completion chain. |
 | R4 | **RET never accepts a completion.** Enter inserts a newline, always. |
 | R5 | Sources that matter: **eglot (LSP)**, **dabbrev/file**, **tempel snippets**, **history/abbrev/spelling**. AI inline suggestions are **surveyed only** — no adoption decision. |
@@ -497,3 +497,53 @@ once auto-insert is gone), a buffer-local `orderless-literal-only`/`basic` style
 for the corfu popup (a real predictability lever, but it changes matching
 semantics and is orthogonal to "annoying popup" — deferred as its own decision),
 and cosmetic width-pinning. See research §6.
+
+---
+
+## 7. Addendum — TAB drives completion (2026-09-04)
+
+**R2 is superseded on the owner's instruction.** The original R2 ("TAB indents.
+Only.") put the whole completion gesture on `C-M-i`. In practice `C-M-i` is
+unreliable: it is the same event as `M-TAB` / `ESC TAB` (§2.3 already recorded
+this), which window managers grab for Alt+Tab and which a TTY cannot tell apart —
+so on the affected setups the chain key never reached Emacs and completion
+"did not work." The owner authorised using TAB for both indent and completion.
+This addendum records that reversal; it does not revisit the trigger model (§2.1),
+the freed **RET** (R4 — see below), the capf chain (§2.4), or the 2026-08 UX round
+(§6), all of which stand. Validated in `test/completion-test.el`.
+
+**7.1 What R2 becomes.** `tab-always-indent` moves from `t` back to `complete`
+(the value §2.2 had reverted): TAB first indents the line, and once the line is
+already indented `indent-for-tab-command` runs `completion-at-point`, opening the
+popup. This is the standard Emacs idiom, not a fight with core.
+
+**7.2 TAB accepts inside the popup.** With the popup open, `corfu-map`'s `TAB` and
+`<tab>` are repointed from corfu's default `corfu-complete` to **`corfu-insert`**
+— the same "finish the completion, run the `:exit-function`, expand a snippet"
+command the `<remap> <completion-at-point>` already used for `C-M-i` (§2.3). So
+TAB is now the open-then-accept gesture, used twice exactly as `C-M-i` was, and
+`C-M-i` stays bound as the GUI-safe alternative. corfu installs `corfu-map`
+through `overriding-terminal-local-map` while the popup is shown, so this TAB
+wins over both `indent-for-tab-command` and completion-preview's `C-i`.
+
+**7.3 TAB accepts the inline ghost text.** `completion-preview-active-mode-map`
+ships `C-i` (the TAB event) → `completion-preview-insert`. §6.4 removed it to
+protect R2; that removal is reversed here (rebound explicitly, not left implicit),
+so when only the preview shows — before the popup opens — TAB accepts the ghost
+text. `M-RET` and `M-i` stay as §6.4 left them.
+
+**7.4 RET is untouched — R4 stands.** RET remains newline-only (`corfu-map` RET
+unbound, the preview map binds no RET). The owner kept R4 explicitly. Only TAB and
+`C-M-i` accept.
+
+**7.5 One knob, one meaning, `nil` = stricter core.** `jotain-completion-free-tab`
+flips default `t` → `nil`. Its meaning is unchanged ("non-nil ⇒ TAB never
+completes"); only the default moved, so setting it restores the whole §2.2 /
+2026-08 "TAB indents only" behaviour — `tab-always-indent` `t`, corfu's TAB
+deleted, the preview's `C-i` deleted — in one place. The knob remains load-time
+(§3.3): changing it needs a restart.
+
+**7.6 Prose.** `tab-always-indent complete` is global, so TAB also completes in
+prose buffers — but only as a *manual* trigger (you pressed TAB, after the line is
+indented), which §2.5 already licenses alongside `C-M-i`. R1's rule is about the
+*auto*-popup, which stays prog-only; nothing here makes prose pop up on its own.

--- a/docs/reference/language-support.mdx
+++ b/docs/reference/language-support.mdx
@@ -57,7 +57,7 @@ The table lists the language-specific wiring on top of that baseline. It is the
 | Meson | `meson-mode` | — | — | `meson` | — | — | — | — |
 | QML | `qml-ts-mode` | ✓ | `qmlls` ᵉ | `qmlformat` | — | — | — | — |
 | LikeC4 | `likec4-mode` | — | `likec4-lsp` / `likec4` ᵉ | — | — | — | — | — |
-| HTML | `mhtml-ts-mode` | ✓ | — | — | — | — | — | — |
+| HTML | `mhtml-ts-mode` | ✓ | `vscode-html-language-server` / `html-languageserver` ᵉ | — | — | — | — | — |
 | CSV | `csv-mode` | — | — | — | — | — | — | — |
 | SQL | `sql-mode` | — | — | — | — | — | — | — |
 | Dune | `dune-mode` | — | — | — | — | — | — | — |

--- a/etc/lang-eval/jotain-lang-registry.el
+++ b/etc/lang-eval/jotain-lang-registry.el
@@ -164,7 +164,8 @@
      :servers ("likec4-lsp" "likec4") :override t)
 
     (:id html       :name "HTML"           :file "init-lang-web.el"
-     :sample "eval.html"           :mode mhtml-ts-mode :classic web-mode :grammar html)
+     :sample "eval.html"           :mode mhtml-ts-mode :classic web-mode :grammar html
+     :servers ("vscode-html-language-server" "html-languageserver") :override t)
 
     (:id csv        :name "CSV"            :file "init-lang-data.el"
      :sample "eval.csv"            :mode csv-mode :grammar nil)

--- a/lisp/init-completion.el
+++ b/lisp/init-completion.el
@@ -86,12 +86,24 @@ Set to nil to restore corfu's default."
   :type 'boolean
   :group 'jotain-completion)
 
-(defcustom jotain-completion-free-tab t
+(defcustom jotain-completion-free-tab nil
   "When non-nil, TAB never completes -- it only indents.
-Two things are needed for that: `tab-always-indent' set to t (the stock
-Emacs default), and corfu's own TAB binding removed, since the popup's
-keymap would otherwise take precedence while it is open.  This option
-covers the second.  Set to nil to restore corfu's default."
+Non-nil is the stricter \"TAB indents, only\" mode: `tab-always-indent'
+is set to t (the stock Emacs default) and corfu's own TAB binding is
+removed, so the popup's keymap cannot make TAB complete while it is open.
+
+The default is nil: TAB both indents and completes, the way most editors
+behave.  Concretely, with nil:
+  - `tab-always-indent' is `complete', so TAB indents the line and, once
+    the line is already indented, runs `completion-at-point' (opening the
+    corfu popup);
+  - inside the popup TAB is bound to `corfu-insert', so a second TAB
+    accepts the highlighted candidate (and expands a snippet), mirroring
+    the `jotain-completion-key' gesture;
+  - when only the inline preview shows (no popup yet), TAB keeps
+    completion-preview's own `C-i' binding, so it accepts the ghost text.
+RET is governed separately by `jotain-completion-free-return' and stays a
+newline regardless of this option."
   :type 'boolean
   :group 'jotain-completion)
 
@@ -439,18 +451,21 @@ ignoring sentinel to just that process."
 
 ;;;; In-buffer completion
 
-;;; @doc `tab-always-indent' = t is the stock Emacs default, restored here
-;;; deliberately: TAB indents the line and does nothing else.
-;;; `indent-for-tab-command's only call to `completion-at-point' is
-;;; guarded by (eq tab-always-indent 'complete), so with t that branch is
-;;; unreachable and TAB provably cannot summon a capf. Completion lives on
-;;; `C-M-i' instead (`jotain-completion-key'). `tab-first-completion' is
-;;; inert unless `tab-always-indent' is `complete', so it is irrelevant
-;;; here and is never set.
+;;; @doc TAB indents and completes. `tab-always-indent' is `complete'
+;;; (unless `jotain-completion-free-tab' is set, which restores the stock
+;;; `t' -- indent only): TAB first indents the line, and once the line is
+;;; already indented `indent-for-tab-command' runs `completion-at-point',
+;;; opening the corfu popup. Inside the popup TAB is repointed to
+;;; `corfu-insert' (see the corfu block below), so a second TAB accepts the
+;;; candidate -- the same open-then-accept gesture as `C-M-i'
+;;; (`jotain-completion-key'), which stays bound as a GUI-safe alternative.
+;;; `tab-first-completion' stays at its default nil (complete right after
+;;; indenting); set it to e.g. `word' if you want TAB not to complete
+;;; immediately after typing a word.
 (use-package emacs
   :ensure nil
   :custom
-  (tab-always-indent t))
+  (tab-always-indent (if jotain-completion-free-tab t 'complete)))
 
 ;; The one completion gesture.  `completion-at-point' rather than the stock
 ;; `complete-symbol' is load-bearing: `corfu-map' contains a
@@ -465,16 +480,19 @@ ignoring sentinel to just that process."
 ;;; @doc In-buffer completion popup — the corfu equivalent of company.
 ;;; The popup appears on its own only in the modes listed by
 ;;; `jotain-completion-auto-modes' (default: programming modes), so prose
-;;; stays quiet. `C-M-i' is the whole gesture, used twice: with no popup it
-;;; runs the global `completion-at-point' and opens the popup; with the popup
-;;; showing the same key inserts the selected candidate. RET and TAB are
-;;; unbound in `corfu-map', so Enter always inserts a newline and TAB
-;;; always indents, even while the popup is showing. The top candidate is
+;;; stays quiet. Two keys open-and-accept, used twice each: with no popup
+;;; they run `completion-at-point' and open the popup; with the popup
+;;; showing they insert the selected candidate. TAB is one of them (via
+;;; `tab-always-indent' `complete' to open, and `corfu-map's TAB rebound to
+;;; `corfu-insert' to accept), and `C-M-i' (`jotain-completion-key') is the
+;;; GUI-safe alternative. RET stays unbound in `corfu-map', so Enter always
+;;; inserts a newline even while the popup is showing. The top candidate is
 ;;; always preselected (`corfu-preselect' `first'), so it is highlighted and
-;;; ready the instant the popup opens; the second `C-M-i' commits it (the
-;;; map's `<remap> <completion-at-point>' is repointed from `corfu-complete'
-;;; to `corfu-insert', which finishes the completion and expands a snippet).
-;;; `M-n'/`M-p' move, `C-g' dismisses.
+;;; ready the instant the popup opens; the accept key commits it (the map's
+;;; `<remap> <completion-at-point>' is repointed from `corfu-complete' to
+;;; `corfu-insert', which finishes the completion and expands a snippet).
+;;; `M-n'/`M-p' move, `C-g' dismisses. Set `jotain-completion-free-tab' to
+;;; restore the stricter "TAB indents only" behaviour.
 (use-package corfu
   :hook (after-init . global-corfu-mode)
   :preface
@@ -503,24 +521,39 @@ Setting `corfu-auto' from `corfu-mode-hook' would be too late, since
   ;; inline AND commits it on further input -- so typing past an open popup
   ;; can silently accept a candidate you never chose.  `nil' shows the
   ;; menu with no inline text and inserts nothing until an explicit
-  ;; `corfu-complete' (`C-M-i'), which is the "never accept unless I ask"
-  ;; behaviour the freed RET/TAB already aim for -- and it leaves the one
-  ;; inline surface to `completion-preview-mode's ghost text.
+  ;; `corfu-complete' -- the "never accept unless I ask" behaviour the freed
+  ;; RET and the explicit TAB/`C-M-i' accept gestures already aim for -- and
+  ;; it leaves the one inline surface to `completion-preview-mode's ghost text.
   (corfu-preview-current nil)
   ;; Always preselect (and highlight, via the `corfu-current' face) the top
-  ;; candidate, so `C-M-i' has something to insert and the user sees what it
-  ;; will insert.  Safe here because RET/TAB are freed -- only the explicit
-  ;; `C-M-i' commits, so `first' cannot cause the accidental accept it can
-  ;; when RET/TAB accept.
+  ;; candidate, so the accept key has something to insert and the user sees
+  ;; what it will insert.  Safe here because nothing commits on continued
+  ;; typing (`corfu-preview-current' nil) and RET is freed: only the explicit
+  ;; TAB / `C-M-i' commits, so `first' cannot cause the accidental accept it
+  ;; risks when a key accepts on its own.
   (corfu-preselect 'first)
   :config
   ;; REMOVE = t genuinely deletes the entry rather than binding it to nil,
   ;; so the key falls through to the buffer and global maps.
   (when jotain-completion-free-return
     (keymap-unset corfu-map "RET" t))
-  (when jotain-completion-free-tab
-    (keymap-unset corfu-map "TAB" t)
-    (keymap-unset corfu-map "<tab>" t))
+  ;; TAB inside the popup.  With the strict "TAB indents only" opt-in we
+  ;; delete corfu's TAB binding so it falls through to
+  ;; `indent-for-tab-command'.  Otherwise (the default) we repoint TAB from
+  ;; corfu's own `corfu-complete' (extends the common prefix, does not run a
+  ;; capf `:exit-function', so snippets would not expand) to `corfu-insert',
+  ;; the same "finish the completion" command the `<remap>' below uses -- so
+  ;; a second TAB accepts the highlighted candidate, matching `C-M-i'.  Both
+  ;; "TAB" and "<tab>" are covered so the GUI function key and the terminal
+  ;; ASCII event behave alike.  corfu binds its map through
+  ;; `overriding-terminal-local-map' while the popup is open, so this wins
+  ;; over both `indent-for-tab-command' and completion-preview's `C-i'.
+  (if jotain-completion-free-tab
+      (progn
+        (keymap-unset corfu-map "TAB" t)
+        (keymap-unset corfu-map "<tab>" t))
+    (keymap-set corfu-map "TAB" #'corfu-insert)
+    (keymap-set corfu-map "<tab>" #'corfu-insert))
   ;; `C-M-i' reaches the popup via corfu-map's `<remap> <completion-at-point>'.
   ;; corfu's default target, `corfu-complete', only extends the common prefix
   ;; (status `exact'), so it neither commits the highlighted candidate nor runs
@@ -592,13 +625,15 @@ comments and docstrings."
 ;;; candidate from the same `completion-at-point-functions' the corfu
 ;;; popup uses. Enabled only in `jotain-completion-auto-modes' buffers (so
 ;;; prose stays quiet), and only when `jotain-completion-inline-preview'
-;;; is non-nil. Two things keep it inside this config's rules: it binds
-;;; `C-i' — which is the TAB event — to accept the preview, so that entry
-;;; is removed and TAB still only indents; and it never binds RET, so
-;;; Enter stays a newline. Accept the whole preview with `M-RET', or just
-;;; the common prefix with `M-i'. The preview is suppressed inside
-;;; comments and strings, and its sort is paired with corfu's so the ghost
-;;; text matches the popup's top row.
+;;; is non-nil. RET is never bound by the mode, so Enter always stays a
+;;; newline. TAB tracks `jotain-completion-free-tab': by default the mode's
+;;; shipped `C-i' (which IS the TAB event) → `completion-preview-insert'
+;;; binding is kept, so when only the ghost text shows (no popup yet) TAB
+;;; accepts it -- the modern-editor feel; with the strict "TAB indents only"
+;;; opt-in that binding is removed so TAB still only indents. `M-RET' also
+;;; accepts the whole preview, and `M-i' just the common prefix. The preview
+;;; is suppressed inside comments and strings, and its sort is paired with
+;;; corfu's so the ghost text matches the popup's top row.
 (use-package completion-preview
   :ensure nil
   :when jotain-completion-inline-preview
@@ -627,10 +662,18 @@ text does not appear where symbol completion is meaningless."
   ;; (after load) rather than `:custom' so touching this deferred built-in
   ;; never forces it to load at startup.
   (setopt completion-preview-idle-delay jotain-completion-auto-delay)
-  ;; R2: `C-i' is the TAB event, and the active-mode map binds it to
-  ;; `completion-preview-insert'.  REMOVE = t drops it so TAB falls
-  ;; through to `indent-for-tab-command' while a preview shows.
-  (keymap-unset completion-preview-active-mode-map "C-i" t)
+  ;; `C-i' is the TAB event, and the active-mode map ships it bound to
+  ;; `completion-preview-insert'.  With the strict "TAB indents only" opt-in
+  ;; we drop it so TAB falls through to `indent-for-tab-command' while a
+  ;; preview shows; by default we keep it (rebinding explicitly so the
+  ;; behaviour does not silently depend on the shipped default), so TAB
+  ;; accepts the ghost text when no popup is open yet.  A visible popup wins
+  ;; regardless: corfu installs `corfu-map' via `overriding-terminal-local-map'
+  ;; and its own TAB → `corfu-insert' takes precedence over this minor-mode map.
+  (if jotain-completion-free-tab
+      (keymap-unset completion-preview-active-mode-map "C-i" t)
+    (keymap-set completion-preview-active-mode-map "C-i"
+                #'completion-preview-insert))
   ;; A non-TAB, non-RET accept gesture for the whole candidate; `M-i'
   ;; (common-prefix complete) is left as upstream ships it.
   (keymap-set completion-preview-active-mode-map "M-RET"

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -210,6 +210,7 @@ These servers may evaluate project JavaScript configuration files."
   ;; eglot itself is not loaded at compile time.
   (declare-function eglot-ensure "eglot")
   (declare-function eglot--guess-contact "eglot")
+  (declare-function eglot-alternatives "eglot")
   (defvar eglot--managed-mode)
 
   (defun jotain-prog--eglot-guess-program ()
@@ -381,6 +382,20 @@ connect time, so it sees the project's devenv env — not Jotain's own shell."
   ;; project/devenv-provided qmlls still wins via the `--suffix' ordering.
   (add-to-list 'eglot-server-programs
                '((qml-ts-mode) . ("qmlls" "-E")))
+
+  ;; HTML (init-lang-web).  `.html' opens in `mhtml-ts-mode' (Emacs 31),
+  ;; which does NOT derive from `html-mode'/`mhtml-mode' — so eglot's own
+  ;; default HTML entry (keyed on those classic modes) never matches it, and
+  ;; HTML buffers get no language server.  Key the tree-sitter modes on the
+  ;; same server, using `eglot-alternatives' exactly as eglot's default does
+  ;; so either vscode's server or the older `html-languageserver' resolves.
+  ;; The binary comes from the project/host PATH, like the other servers; a
+  ;; project without it just falls back to the cape capfs.
+  (add-to-list 'eglot-server-programs
+               (cons '(mhtml-ts-mode html-ts-mode)
+                     (eglot-alternatives
+                      '(("vscode-html-language-server" "--stdio")
+                        ("html-languageserver" "--stdio")))))
 
   ;; C/C++/CUDA (init-lang-systems).  clangd serves all three — it treats a
   ;; `.cu' buffer as CUDA by extension.  Keyed on the tree-sitter modes with

--- a/lisp/init-snippets.el
+++ b/lisp/init-snippets.el
@@ -9,8 +9,9 @@
 ;; straight into `completion-at-point-functions' (snippet names surface
 ;; in the corfu popup) and adds tab-stop field navigation that the
 ;; built-ins lack.  Those fields move on `M-}'/`M-{' (tempel's own keys)
-;; or `C-M-n'/`C-M-p'; TAB is not involved anywhere, because in this
-;; configuration TAB indents and nothing else.
+;; or `C-M-n'/`C-M-p'; TAB is deliberately not a field-navigation key --
+;; here TAB indents and drives completion (`jotain-completion-free-tab'),
+;; never snippet fields, so the two never fight over it.
 ;;
 ;; The curated templates themselves live in `templates/jotain.eld', keyed
 ;; by major mode -- not in this file -- so adding a snippet never means
@@ -37,10 +38,11 @@
 ;;; Templates are read from `templates/*.eld' (keyed by major mode);
 ;;; `M-+' completes a snippet by name, `M-*' inserts one interactively,
 ;;; and once fields are active `M-}'/`M-{' or `C-M-n'/`C-M-p' move
-;;; between them, with `M-RET' to finish. TAB is deliberately not
-;;; involved: in this configuration TAB indents and nothing else. Set
-;;; `jotain-completion-snippets' to nil to keep snippet names out of the
-;;; completion popup; `M-+' and `M-*' still work.
+;;; between them, with `M-RET' to finish. TAB is deliberately not a
+;;; field-navigation key -- it indents and drives completion instead, so it
+;;; never fights the snippet fields. Set `jotain-completion-snippets' to nil
+;;; to keep snippet names out of the completion popup; `M-+' and `M-*' still
+;;; work.
 (use-package tempel
   :functions (tempel-complete cape-capf-super cape-capf-buster
               cape-capf-nonexclusive eglot-completion-at-point eglot-managed-p)
@@ -50,7 +52,8 @@
   (("M-+" . tempel-complete)
    ("M-*" . tempel-insert)
    :map tempel-map
-   ;; TAB is deliberately absent: it indents, always.  Upstream `tempel-map'
+   ;; TAB is deliberately absent here: snippet fields never use it (it
+   ;; indents and drives completion instead).  Upstream `tempel-map'
    ;; never bound it either -- the TAB/S-TAB pair that used to live here was
    ;; this config's own addition.  Removing it restores tempel's own
    ;; `M-}'/`M-{' (plus `M-RET' to finish and `M-<up>'/`M-<down>'), and the

--- a/test/completion-test.el
+++ b/test/completion-test.el
@@ -205,7 +205,7 @@ This is why `init-snippets.el' wraps its eglot merge."
   (should (equal jotain-completion-auto-prefix 3))
   (should (equal jotain-completion-key "C-M-i"))
   (should (eq jotain-completion-free-return t))
-  (should (eq jotain-completion-free-tab t))
+  (should (eq jotain-completion-free-tab nil))
   (should (eq jotain-completion-fallbacks t))
   (should (eq jotain-completion-snippets t))
   (should (eq jotain-completion-eglot-nonexclusive t))
@@ -219,9 +219,13 @@ corfu's own default is `insert', which commits the selected candidate on
 further input -- exactly the accidental-accept this config avoids."
   (should (eq corfu-preview-current nil)))
 
-(ert-deftest completion-test-tab-indents-only ()
-  "TAB is on the stock default, so `indent-for-tab-command' cannot complete."
-  (should (eq tab-always-indent t)))
+(ert-deftest completion-test-tab-indents-and-completes ()
+  "TAB indents and completes: `tab-always-indent' is `complete'.
+With the default `jotain-completion-free-tab' nil, `indent-for-tab-command'
+indents the line and then runs `completion-at-point' once it is already
+indented.  Setting the knob restores the stock `t' (indent only)."
+  (should (eq jotain-completion-free-tab nil))
+  (should (eq tab-always-indent 'complete)))
 
 (ert-deftest completion-test-auto-popup-is-opt-in-per-mode ()
   "Auto-popup is off globally and opted into per mode hook, buffer-locally."
@@ -235,24 +239,28 @@ further input -- exactly the accidental-accept this config avoids."
   ;; The opt-in never touches the global value.
   (should (eq (default-value 'corfu-auto) nil)))
 
-(ert-deftest completion-test-corfu-map-frees-return-and-tab ()
-  "RET and TAB are removed from `corfu-map', and navigation still works."
+(ert-deftest completion-test-corfu-map-frees-return-and-accepts-on-tab ()
+  "RET is removed from `corfu-map'; TAB accepts the selected candidate.
+RET stays freed (newline only) via `jotain-completion-free-return'.  With
+`jotain-completion-free-tab' nil, TAB and `<tab>' are repointed to
+`corfu-insert' so a second TAB commits the highlighted candidate (and runs
+its `:exit-function', expanding snippets), the same command the
+`<remap> <completion-at-point>' below uses.  Navigation still works."
   (should-not (lookup-key corfu-map (kbd "RET")))
-  (should-not (lookup-key corfu-map (kbd "TAB")))
-  (should-not (lookup-key corfu-map [tab]))
+  (should (eq (lookup-key corfu-map (kbd "TAB")) #'corfu-insert))
+  (should (eq (lookup-key corfu-map [tab]) #'corfu-insert))
   (should (eq (lookup-key corfu-map (kbd "M-n")) #'corfu-next))
   (should (eq (lookup-key corfu-map (kbd "M-p")) #'corfu-previous)))
 
-(ert-deftest completion-test-inline-preview-tab-is-freed ()
-  "The inline preview never lets TAB (or RET) accept a candidate.
+(ert-deftest completion-test-inline-preview-tab-accepts-ghost-text ()
+  "TAB accepts the inline preview; RET is never bound, so Enter stays a newline.
 `completion-preview-active-mode-map' ships `C-i' -> `completion-preview-insert',
-and `C-i' IS the TAB event, so leaving it bound would let TAB accept the
-preview -- violating the TAB-indents-only rule.  This config removes it and
-puts the whole-candidate accept on `M-RET' instead; RET is never bound by
-the mode, so Enter stays a newline."
-  (should-not (lookup-key completion-preview-active-mode-map (kbd "C-i")))
-  (should-not (lookup-key completion-preview-active-mode-map (kbd "TAB")))
-  (should-not (lookup-key completion-preview-active-mode-map [tab]))
+and `C-i' IS the TAB event.  With `jotain-completion-free-tab' nil that
+binding is kept (set explicitly), so when only the ghost text shows TAB
+accepts it; the whole-candidate accept is also on `M-RET'.  RET is never
+bound by the mode, so Enter stays a newline regardless."
+  (should (eq (lookup-key completion-preview-active-mode-map (kbd "C-i"))
+              #'completion-preview-insert))
   (should-not (lookup-key completion-preview-active-mode-map (kbd "RET")))
   (should-not (lookup-key completion-preview-active-mode-map [return]))
   (should (eq (lookup-key completion-preview-active-mode-map (kbd "M-RET"))


### PR DESCRIPTION
## Why

The in-buffer completion gesture lived on `C-M-i` (design requirement **R2**, "TAB indents. Only."). `C-M-i` is the *same event* as `M-TAB` / `ESC TAB`, which window managers grab for Alt+Tab and a TTY cannot distinguish — so on those setups the key never reached Emacs and completion appeared broken. The owner authorised using TAB for both indent and completion.

## What changed — TAB now indents **and** completes

- `tab-always-indent` → `complete`: TAB indents the line, then runs `completion-at-point` (opening the corfu popup) once the line is already indented.
- `corfu-map` `TAB`/`<tab>` → `corfu-insert`: with the popup open, a second TAB accepts the selected candidate and expands snippets — mirroring the `C-M-i` open-then-accept gesture. corfu installs `corfu-map` through `overriding-terminal-local-map`, so this TAB wins over both `indent-for-tab-command` and completion-preview's `C-i`.
- `completion-preview` keeps its shipped `C-i` → `completion-preview-insert` (rebound explicitly), so TAB accepts the inline ghost text when no popup is open yet.
- **RET stays newline-only (R4 kept)**; `C-M-i` stays bound as a GUI-safe alternative.

All gated by `jotain-completion-free-tab`, whose default flips `t` → `nil`. Its meaning is unchanged ("non-nil ⇒ TAB never completes"); setting it restores the strict "TAB indents only" behaviour (`tab-always-indent` `t`, corfu's TAB deleted, the preview's `C-i` deleted) in one place.

## Also: HTML code-intelligence gap

While auditing completion sources per language, found that `.html` opens in `mhtml-ts-mode` (new in Emacs 31), which does **not** derive from `html-mode`/`mhtml-mode` — so eglot's default HTML entry never matched and HTML buffers got no language server. Added an explicit `eglot-server-programs` entry (`vscode-html-language-server` / `html-languageserver` via `eglot-alternatives`; server resolved from the project PATH like the others) and updated the language-support registry + matrix.

## Docs & tests

- `test/completion-test.el`: updated the TAB / corfu-map / completion-preview assertions.
- `docs/design/completion.md`: new **§7** addendum recording the R2 reversal (per the doc's record-departures-in-place ethos); R2 row flagged as superseded.
- `docs/configuration/package-reference.mdx`: re-synced the four changed `@doc` blocks.
- `docs/reference/language-support.mdx` + `etc/lang-eval/jotain-lang-registry.el`: HTML server row.

## Validation

Local nix flake checks can't run in this environment (the `emacs-overlay` input isn't cached and the proxy blocks the GitHub tarball fetch). Validated as far as possible offline: `check-parens` passes on all four edited elisp files with a cache-fetched Emacs 31.1; the generated docs were hand-synced byte-for-byte against the pure-Nix generators (`nix/packages-doc.nix`, `etc/lang-eval/jotain-lang-doc.el`). Full `elisp-compile` / `elisp-test` / `packages-doc-in-sync` run in CI.

## Follow-ups surfaced by the source audit (not in this PR)

Reported for a separate decision rather than changed here:
- **Nix LSP** is gated on the `devenv` CLI being present (`init-devenv.el`); without it, the bundled `nixd` is never wired — a deliberate, documented gating worth revisiting.
- **YAML** eglot only starts because a `text-mode` shim re-runs `prog-mode-hook` — fragile coupling.
- **JavaScript** bypasses the `rass` multiplexer that TS uses.
- `@doc`/comment drift: Rust and Zig claim eglot is "wired in init-prog" but rely on eglot's built-in defaults.
- Several devops modes (`just`, `docker-compose`, `sql`, `ansible`, `bazel`) fall back to cape-only where an upstream server exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWwV8A39ag7PPsA4PkkXoB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWwV8A39ag7PPsA4PkkXoB)_