### PR TITLE
Add eglot-booster, rust-analyzer config, dape cargo + Go project markers

### DIFF
--- a/docs/configuration/package-reference.mdx
+++ b/docs/configuration/package-reference.mdx
@@ -787,6 +787,20 @@ auto-starts eglot for ANY project file whose language server is on the
 buffer's (envrc-applied) PATH — so enabling `languages.X.enable' in a
 project's devenv lights up its LSP in Emacs with no per-language config.
 
+### `eglot-booster` *(built-in / Nix)*
+
+Wrap local stdio language servers in emacs-lsp-booster, which
+converts server JSON into Elisp bytecode Emacs reads directly and
+buffers I/O so a busy server can't block the UI. Function-valued
+contacts (the `rass` resolvers above) are boosted at their result, so
+multiplexed sessions are boosted too. The binary rides the distribution
+wrapper PATH (nix/runtime-deps.nix), not a devenv: the mode resolves it
+once at enable time, before any buffer-local exec-path exists. Only
+local stdio servers are boosted — a server over TRAMP needs the binary
+on the remote host, and network-port servers are never boosted.
+Provided by Nix (not on MELPA); `:if' skips the block cleanly in the
+MELPA-fallback launch where the library is absent.
+
 ### `consult-eglot`
 
 Consult-driven workspace symbol search — C-M-. opens an
@@ -1194,7 +1208,9 @@ gap where tree-sitter leaves an empty line at column 0.
 ### `rust-ts-mode` *(built-in / Nix)*
 
 Built-in tree-sitter Rust mode. Eglot wires rust-analyzer in
-init-prog; format-on-save runs rustfmt through apheleia.
+init-prog, with buffer-local workspace configuration (clippy on save,
+build scripts, proc macros) set here in a mode hook; format-on-save
+runs rustfmt through apheleia.
 
 ## `init-lang-python.el` — Python
 

--- a/lisp/init-lang-rust.el
+++ b/lisp/init-lang-rust.el
@@ -8,11 +8,34 @@
 
 ;;; Code:
 
+;; rust-analyzer workspace settings.  Buffer-local in a mode hook rather
+;; than a global `setq-default' so no other language's workspace
+;; configuration is clobbered, and a project .dir-locals.el
+;; `eglot-workspace-configuration' entry still overrides it cleanly.  Same
+;; pattern as `jotain-go--eglot-workspace-config' in init-lang-go.el.
+(defvar eglot-workspace-configuration) ; defined in eglot.el
+
+(defun jotain-rust--eglot-workspace-config ()
+  "Set buffer-local rust-analyzer workspace configuration for Rust buffers.
+`check.command \"clippy\"' runs clippy over the workspace on every save,
+which is noticeably slow on a cold target directory; a project
+.dir-locals.el can override this back to `check' if that matters.
+`cargo (:features \"all\")' is deliberately left out — it is a real cost
+on large workspaces, so it stays a per-project decision."
+  (setq-local eglot-workspace-configuration
+              '(:rust-analyzer
+                (:check (:command "clippy")
+                 :cargo (:buildScripts (:enable t))
+                 :procMacro (:enable t)))))
+
 ;;; @doc Built-in tree-sitter Rust mode. Eglot wires rust-analyzer in
-;;; init-prog; format-on-save runs rustfmt through apheleia.
+;;; init-prog, with buffer-local workspace configuration (clippy on save,
+;;; build scripts, proc macros) set here in a mode hook; format-on-save
+;;; runs rustfmt through apheleia.
 (use-package rust-ts-mode
   :ensure nil
   :mode "\\.rs\\'"
+  :hook (rust-ts-mode . jotain-rust--eglot-workspace-config)
   :custom
   (rust-ts-mode-indent-offset 4))
 

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -419,6 +419,23 @@ connect time, so it sees the project's devenv env — not Jotain's own shell."
   (add-to-list 'eglot-server-programs
                (cons '(likec4-mode) #'jotain-prog--likec4-server)))
 
+;;; @doc Wrap local stdio language servers in emacs-lsp-booster, which
+;;; converts server JSON into Elisp bytecode Emacs reads directly and
+;;; buffers I/O so a busy server can't block the UI. Function-valued
+;;; contacts (the `rass` resolvers above) are boosted at their result, so
+;;; multiplexed sessions are boosted too. The binary rides the distribution
+;;; wrapper PATH (nix/runtime-deps.nix), not a devenv: the mode resolves it
+;;; once at enable time, before any buffer-local exec-path exists. Only
+;;; local stdio servers are boosted — a server over TRAMP needs the binary
+;;; on the remote host, and network-port servers are never boosted.
+;;; Provided by Nix (not on MELPA); `:if' skips the block cleanly in the
+;;; MELPA-fallback launch where the library is absent.
+(use-package eglot-booster
+  :ensure nil ; Provided by Nix
+  :if (locate-library "eglot-booster")
+  :after eglot
+  :config (eglot-booster-mode))
+
 ;;; @doc Consult-driven workspace symbol search — C-M-. opens an
 ;;; orderless-filtered list of symbols across the LSP workspace.
 (use-package consult-eglot
@@ -453,7 +470,27 @@ connect time, so it sees the project's devenv env — not Jotain's own shell."
   ;; them at exit. Both run in :config, so a session that never loads
   ;; dape never touches the breakpoints file.
   (dape-breakpoint-load)
-  (add-hook 'kill-emacs-hook #'dape-breakpoint-save))
+  (add-hook 'kill-emacs-hook #'dape-breakpoint-save)
+
+  ;; Cargo-shaped Rust launch config.  dape's shipped `lldb-dap' config
+  ;; defaults to `:program "a.out"' / `:cwd "."', unusable on a cargo
+  ;; layout without hand-editing every time; this one compiles with cargo
+  ;; and prompts for the built binary under target/debug/.  `lldb-dap'
+  ;; comes from `lldb' on the project/host PATH — same convention as
+  ;; `dlv' for Go, not bundled on the wrapper.
+  (add-to-list 'dape-configs
+               `(cargo-lldb
+                 modes (rust-ts-mode rust-mode)
+                 ensure dape-ensure-command
+                 command "lldb-dap"
+                 command-cwd dape-command-cwd
+                 compile "cargo build"
+                 :type "lldb-dap"
+                 :request "launch"
+                 :cwd "."
+                 :program (lambda ()
+                            (read-file-name "Binary: " (dape-cwd) nil t
+                                            "target/debug/")))))
 
 ;;;; SonarLint (SonarCloud connected mode)
 

--- a/lisp/init-project.el
+++ b/lisp/init-project.el
@@ -67,9 +67,12 @@ projects sharing a basename across different roots stay distinct."
   :custom
   (project-list-file (jotain-var-file "projects.el"))
   (project-buffers-viewer 'project-list-buffers-ibuffer)
+  ;; go.mod/go.work so a Go module under a larger git root is recognised as
+  ;; its own project — otherwise gopls, `project-find-file' and
+  ;; `consult-ripgrep' scope to the git root rather than the module.
   (project-vc-extra-root-markers
    '(".project" "package.json" "Cargo.toml" "pyproject.toml" "flake.nix"
-     "devenv.nix")))
+     "devenv.nix" "go.mod" "go.work")))
 
 ;;;; projection — per-project commands keyed off .dir-locals.el
 

--- a/nix/extra-packages.nix
+++ b/nix/extra-packages.nix
@@ -66,6 +66,22 @@ efinal: eprev: {
     ];
   };
 
+  # Boosts eglot by wrapping local stdio language servers in the
+  # emacs-lsp-booster binary (nix/runtime-deps.nix), which converts server
+  # JSON into Elisp bytecode Emacs reads directly and buffers I/O.  Wired in
+  # lisp/init-prog.el.  Not on MELPA/ELPA; requires only Emacs built-ins
+  # (eglot, jsonrpc, seq), so no packageRequires.
+  eglot-booster = efinal.trivialBuild {
+    pname = "eglot-booster";
+    version = "0.1.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "jdtsmith";
+      repo = "eglot-booster";
+      rev = "510f579409627c333ef0e9157db713b1004da842";
+      sha256 = "0g9ld3dbhj7g5wbrbq21pp274givxpavc44zmql5fn7z93ir258y";
+    };
+  };
+
   combobulate = efinal.trivialBuild {
     pname = "combobulate";
     version = "0-unstable-2026-01-26";

--- a/nix/nix-provided-packages.nix
+++ b/nix/nix-provided-packages.nix
@@ -21,6 +21,7 @@
 [
   "claude-code-ide"
   "combobulate"
+  "eglot-booster"
   "jylhis-emacs-themes"
   "majutsu"
   "nix-ts-mode"

--- a/nix/runtime-deps.nix
+++ b/nix/runtime-deps.nix
@@ -23,6 +23,10 @@ with pkgs;
   rsync # dired-rsync (C-c C-r)
   nixd # shipped Nix LSP fallback (devenv--nix-lsp-program) when a devenv
   # project's own env provides no nixd/nil for eglot
+  emacs-lsp-booster # eglot-booster (init-prog.el): `eglot-booster-mode'
+  # resolves this binary via `executable-find' ONCE at enable time, before
+  # any buffer-local exec-path exists, and disables itself if it is missing
+  # — so it must ride the wrapper PATH, never a per-project devenv.
   qt6.qtdeclarative # qmlls (LSP) + qmlformat (apheleia) for qml-ts-mode
   # (init-lang-qml). Large Qt closure, accepted so QML support is
   # launch-context-independent; a project/devenv qmlls still wins.


### PR DESCRIPTION
Implements the three actionable recommendations from the code-intelligence research review, each mirroring an existing in-tree pattern.

## 1. Wire in `emacs-lsp-booster` + `eglot-booster`

The booster converts LSP server JSON into Elisp bytecode Emacs reads directly and buffers I/O so a busy server can't block the UI. Function-valued contacts (the `rass` resolvers) are boosted at their *result*, so the multiplexed TS/Python sessions are boosted too — no change needed there.

Four touchpoints, matching the existing Nix-provided-package pattern (combobulate/tagref):

- `nix/extra-packages.nix` — `eglot-booster` `trivialBuild` (upstream `jdtsmith/eglot-booster`; requires only Emacs built-ins, so no `packageRequires`). Source hash verified against a real clone.
- `nix/nix-provided-packages.nix` — add `"eglot-booster"` (force-inject + document).
- `nix/runtime-deps.nix` — add `emacs-lsp-booster` on the **wrapper PATH, not a devenv**: `eglot-booster-mode` resolves the binary once at enable time, before any buffer-local `exec-path` exists, and disables itself if it's missing.
- `lisp/init-prog.el` — a `use-package eglot-booster` block guarded with `:if (locate-library "eglot-booster")` so the MELPA-fallback launch (no Nix) skips it cleanly.

Only local stdio servers are boosted — a server over TRAMP needs the binary on the remote host, and network-port servers are never boosted (noted in the `@doc`).

## 2. rust-analyzer workspace configuration

`lisp/init-lang-rust.el` gains a buffer-local `jotain-rust--eglot-workspace-config` (clippy on save, build scripts, proc macros), following the gopls pattern in `init-lang-go.el` so it never clobbers other languages and a project `.dir-locals.el` still overrides it. `cargo (:features "all")` is deliberately left out as a per-project decision.

## 3. dape cargo config + Go project root markers

- `lisp/init-prog.el` — a `cargo-lldb` `dape-configs` entry (compile with `cargo build`, prompt for the built binary under `target/debug/`) so `C-x C-a d` is usable on a cargo project without hand-editing. Verified against dape 0.27.1's shipped `lldb-dap` config. The `lldb-dap` binary comes from the project/host PATH, same convention as `dlv`.
- `lisp/init-project.el` — add `go.mod`/`go.work` to `project-vc-extra-root-markers` so a Go module under a larger git root is recognised as its own project (otherwise gopls, `project-find-file` and `consult-ripgrep` scope to the git root).

`docs/configuration/package-reference.mdx` regenerated for the new/updated `@doc` markers (`just docs-refresh-packages`); the diff is exactly the two expected deltas.

## Verification

- `statix`, `deadnix` — pass.
- `packages-doc` regenerated; tracked `.mdx` is byte-identical to the generator output (`packages-doc-in-sync` will pass).
- `emacs-lsp-booster` 0.2.1 confirmed present in the pinned nixpkgs; `eglot-booster` source hash verified against a fresh clone.
- Note: the full-distribution `elisp-compile`/`packages-default` checks weren't run in the authoring sandbox (adding a package changes the distribution hash, forcing a wrapper rebuild that fetches an unrelated MELPA recipe's source from a blocked host). They run on CI against the cached closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KXpK12Upon1ahvo8FsLmP

---
_Generated by [Claude Code](https://claude.ai/code/session_018KXpK12Upon1ahvo8FsLmP)_